### PR TITLE
chore: add CI, PyPI, Python, and Ruff badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # OntoKit API
 
+[![CI](https://github.com/CatholicOS/ontokit-api/actions/workflows/release.yml/badge.svg)](https://github.com/CatholicOS/ontokit-api/actions/workflows/release.yml)
+[![PyPI](https://img.shields.io/pypi/v/ontokit)](https://pypi.org/project/ontokit/)
+[![Python](https://img.shields.io/python/required-version-toml?tomlFilePath=https%3A%2F%2Fraw.githubusercontent.com%2FCatholicOS%2Fontokit-api%2Fmain%2Fpyproject.toml)](https://github.com/CatholicOS/ontokit-api)
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
+
 Collaborative OWL ontology curation API built with FastAPI.
 
 ## Features


### PR DESCRIPTION
## Summary
- Add CI workflow status badge
- Add PyPI version badge (activates once published)
- Add Python version badge (reads from pyproject.toml)
- Add Ruff code style badge

## Test plan
- [ ] Verify badges render correctly on the PR diff
- [ ] Merge and confirm they display on the main README

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added CI, PyPI, Python version, and Ruff status badges to the README with corresponding links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->