### PR TITLE
fix: register NormalizationRun model in package exports and Alembic

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -27,6 +27,7 @@ from ontokit.models import (  # noqa: E402, F401
     IndexedHierarchy,
     IndexedLabel,
     JoinRequest,
+    NormalizationRun,
     OntologyIndexStatus,
     Project,
     ProjectMember,

--- a/ontokit/models/__init__.py
+++ b/ontokit/models/__init__.py
@@ -10,6 +10,7 @@ from ontokit.models.lint import (
     LintRun,
     LintRunStatus,
 )
+from ontokit.models.normalization import NormalizationRun
 from ontokit.models.notification import Notification
 from ontokit.models.ontology_index import (
     IndexedAnnotation,
@@ -50,6 +51,7 @@ __all__ = [
     "LintIssueType",
     "LintRun",
     "LintRunStatus",
+    "NormalizationRun",
     "Notification",
     "OntologyIndexStatus",
     "PRStatus",


### PR DESCRIPTION
## Summary
- **Add `NormalizationRun`** to `ontokit/models/__init__.py` import and `__all__`
- **Add `NormalizationRun`** to `alembic/env.py` model imports for autogenerate

Fixes #12 — the model was referenced by `Project.normalization_runs` but never registered, causing lazy-load name resolution failures in standalone scripts and invisible migration drift in Alembic autogenerate.

## Test plan
- [ ] Run a standalone script that imports `Project` (e.g., benchmark) — should no longer fail with `expression 'NormalizationRun' failed to locate a name`
- [ ] Run `alembic revision --autogenerate` — should detect `normalization_runs` table

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new NormalizationRun model to the public API, making it available for use throughout the application.
  * Integrated NormalizationRun with the database schema generation so it will be considered during migration autogeneration and schema alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->