### PR TITLE
feat: add search parameter to project list endpoint

### DIFF
--- a/ontokit/api/routes/projects.py
+++ b/ontokit/api/routes/projects.py
@@ -108,7 +108,8 @@ async def list_projects(
     skip: int = Query(default=0, ge=0),
     limit: int = Query(default=20, ge=1, le=100),
     filter: str | None = Query(
-        default=None, description="Filter: 'public', 'mine', or null for all accessible"
+        default=None,
+        description="Filter: 'public', 'private', 'mine', or null for all accessible",
     ),
     search: str | None = Query(
         default=None, max_length=200, description="Search by project name or description"
@@ -120,8 +121,9 @@ async def list_projects(
     For anonymous users, only public projects are returned.
     For authenticated users:
     - filter=public: Only public projects
-    - filter=mine: Projects where user is a member
-    - filter=null: All accessible (public + user's projects)
+    - filter=private: Private projects where user is a member
+    - filter=mine: All projects where user is a member (public + private)
+    - filter=null: All accessible (public + user's private projects)
     """
     return await service.list_accessible(
         user, skip=skip, limit=limit, filter_type=filter, search=search

--- a/ontokit/services/project_service.py
+++ b/ontokit/services/project_service.py
@@ -465,8 +465,15 @@ class ProjectService:
             # Authenticated user
             if filter_type == "public":
                 query = query.where(Project.is_public == True)  # noqa: E712
+            elif filter_type == "private":
+                # Private projects where user is a member
+                subquery = select(ProjectMember.project_id).where(ProjectMember.user_id == user.id)
+                query = query.where(
+                    Project.is_public == False,  # noqa: E712
+                    Project.id.in_(subquery),
+                )
             elif filter_type == "mine":
-                # Projects where user is a member
+                # All projects where user is a member (public + private)
                 subquery = select(ProjectMember.project_id).where(ProjectMember.user_id == user.id)
                 query = query.where(Project.id.in_(subquery))
             else:


### PR DESCRIPTION
## Summary

- Add optional `search` query parameter to `GET /api/v1/projects`
- Performs case-insensitive ILIKE search on project name and description
- Max length 200 characters

## Related

- CatholicOS/ontokit-web#52 — frontend pagination and search improvements

## Test plan

- [ ] `GET /api/v1/projects?search=Catholic` returns matching projects
- [ ] `GET /api/v1/projects?search=nonexistent` returns empty results with total=0
- [ ] Search combines correctly with filter parameter
- [ ] Empty/null search returns all projects (existing behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added search to project listing to filter by name or description (case-insensitive, respects literal %, _, \) and updates pagination counts.
* **Bug Fixes / Behavior Changes**
  * Clarified project filter semantics: new "private" option returns private projects where you're a member; "mine" includes both public and private member projects; null now returns accessible public plus your private projects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->