### PR TITLE
feat: add filter=private to project list endpoint

### DIFF
--- a/ontokit/services/project_service.py
+++ b/ontokit/services/project_service.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from uuid import UUID
 
 from fastapi import HTTPException, status
-from sqlalchemy import func, or_, select
+from sqlalchemy import func, literal, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -459,8 +459,11 @@ class ProjectService:
         )
 
         if user is None:
-            # Anonymous: only public projects
-            query = query.where(Project.is_public == True)  # noqa: E712
+            # Anonymous: mine/private require membership, so return no rows
+            if filter_type in ("mine", "private"):
+                query = query.where(literal(False))
+            else:
+                query = query.where(Project.is_public == True)  # noqa: E712
         else:
             # Authenticated user
             if filter_type == "public":


### PR DESCRIPTION
## Summary

Closes #32

- Add `filter=private` option to `GET /api/v1/projects` which returns only private projects where the authenticated user is a member (`is_public = false` AND user is in the members list)
- Complements existing `filter=public` (public projects only) and `filter=mine` (all projects where user is a member)

| Filter | Returns |
|--------|---------|
| `public` | All public projects |
| `mine` | All projects where user is a member (public + private) |
| `private` | **Private** projects where user is a member |
| `null` | All accessible (public + user's projects) |

## Test plan

- [ ] `GET /api/v1/projects?filter=private` with auth returns only private projects the user belongs to
- [ ] `GET /api/v1/projects?filter=private` without auth returns empty (anonymous users have no memberships)
- [ ] Existing filters (`public`, `mine`, `null`) still work as before
- [ ] Pagination and total count are correct for the private filter

## Related

- CatholicOS/ontokit-web#55 — frontend: separate My Projects and Private tabs (depends on this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for filtering projects by "private" status. Users can now use `filter=private` to view private projects where they are members.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->