### PR TITLE
docs: add Field descriptions for nullable OWLClassResponse fields

### DIFF
--- a/ontokit/schemas/owl_class.py
+++ b/ontokit/schemas/owl_class.py
@@ -60,10 +60,19 @@ class OWLClassResponse(OWLClassBase):
         default_factory=dict,
         description="Map of parent IRI to resolved label",
     )
-    equivalent_iris: list[str] | None = Field(default=None)
-    disjoint_iris: list[str] | None = Field(default=None)
+    equivalent_iris: list[str] | None = Field(
+        default=None,
+        description="owl:equivalentClass IRIs. None when served from the PostgreSQL index (not indexed); populated list from the RDFLib fallback path.",
+    )
+    disjoint_iris: list[str] | None = Field(
+        default=None,
+        description="owl:disjointWith IRIs. None when served from the PostgreSQL index (not indexed); populated list from the RDFLib fallback path.",
+    )
     child_count: int = 0
-    instance_count: int | None = None
+    instance_count: int | None = Field(
+        default=None,
+        description="Number of rdf:type instances. None when served from the PostgreSQL index (rdf:type not indexed); computed int from the RDFLib fallback path.",
+    )
     is_defined: bool = True  # vs just declared
     source_ontology: str | None = None  # If imported
     annotations: list[AnnotationProperty] = Field(


### PR DESCRIPTION
## Summary
- Adds `description` parameters to the `equivalent_iris`, `disjoint_iris`, and `instance_count` fields on `OWLClassResponse`
- Documents when each field is `None` (PostgreSQL index path, where these fields are not indexed) vs populated (RDFLib fallback path)
- Improves the auto-generated OpenAPI/Swagger docs for API consumers

Closes #25

## Test plan
- [ ] Verify `ruff check` and `ruff format` pass (confirmed in CI)
- [ ] Confirm OpenAPI schema at `/docs` now shows field descriptions for the three updated fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)