### PR TITLE
docs: add 'private' to filter_type docstring

### DIFF
--- a/ontokit/services/project_service.py
+++ b/ontokit/services/project_service.py
@@ -450,7 +450,7 @@ class ProjectService:
             user: Current user (None for anonymous)
             skip: Pagination offset
             limit: Maximum results to return
-            filter_type: Filter by 'public', 'mine', or None for all accessible
+            filter_type: Filter by 'public', 'private', 'mine', or None for all accessible
             search: Case-insensitive search on name and description
         """
         # Build base query


### PR DESCRIPTION
## Summary
- Updates the `list_accessible` method's Args docstring in `project_service.py` to include the `'private'` filter option
- The `'private'` filter was added in PR #28 but the docstring was not updated

Closes #36

## Test plan
- [x] `ruff check` passes
- [x] `ruff format` reports no changes
- [x] `mypy` passes (via pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)