### PR TITLE
fix: wrap webhook handler's arq enqueue in try/except

### DIFF
--- a/ontokit/api/routes/pull_requests.py
+++ b/ontokit/api/routes/pull_requests.py
@@ -679,20 +679,26 @@ async def github_webhook(
                     touched_files.update(commit.get("modified", []))
 
                 if sync_config.file_path in touched_files:
+                    previous_status = sync_config.status
+                    sync_config.status = "checking"
+                    await service.db.commit()
+
                     try:
                         pool = await get_arq_pool()
                         if pool is not None:
                             await pool.enqueue_job("run_remote_check_task", str(project_id))
-                            sync_config.status = "checking"
-                            await service.db.commit()
                         else:
                             logger.warning(
                                 "ARQ pool is None; skipping remote sync check after webhook push"
                             )
+                            sync_config.status = previous_status
+                            await service.db.commit()
                     except Exception:
                         logger.warning(
                             "Failed to queue remote sync check after webhook push",
                             exc_info=True,
                         )
+                        sync_config.status = previous_status
+                        await service.db.commit()
 
     return {"status": "ok"}


### PR DESCRIPTION
## Summary

- Wraps the `get_arq_pool()` and `pool.enqueue_job()` calls in the GitHub webhook push handler with try/except error handling
- Adds a `pool is not None` guard before enqueueing, matching the defensive pattern used elsewhere
- Matches the existing error-handling pattern from the merge endpoint (lines 203-213)
- Prevents Redis/ARQ failures from returning 500 to GitHub, which would cause delivery failures and webhook retries

Closes #24

## Test plan

- [ ] Verify the webhook endpoint returns `{"status": "ok"}` even when Redis is unavailable
- [ ] Verify that when Redis is available, the `run_remote_check_task` job is still enqueued correctly
- [ ] Confirm the warning is logged when the arq pool fails
- [ ] Review that the fix matches the pattern in the merge endpoint (lines 203-213)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Webhook-driven remote sync checks now verify background job queue availability before starting. If the queue is unavailable or enqueueing fails, the failure is logged and suppressed, and the sync status is restored to its prior state instead of remaining stuck in "checking". This prevents propagated errors and improves sync status accuracy and webhook reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->