### PR TITLE
ci: add Codecov test analytics

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,11 +55,15 @@ jobs:
           fetch-depth: 2
       - uses: astral-sh/setup-uv@v4
       - run: uv sync --group dev
-      - run: uv run pytest tests/ -v --cov=ontokit --cov-branch --cov-report=xml
+      - run: uv run pytest tests/ -v --cov=ontokit --cov-branch --cov-report=xml --junitxml=junit.xml
       - uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
+      - uses: codecov/test-results-action@v1
+        if: ${{ !cancelled() }}
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   build:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![PyPI](https://img.shields.io/pypi/v/ontokit)](https://pypi.org/project/ontokit/)
 [![Python](https://img.shields.io/python/required-version-toml?tomlFilePath=https%3A%2F%2Fraw.githubusercontent.com%2FCatholicOS%2Fontokit-api%2Fmain%2Fpyproject.toml)](https://github.com/CatholicOS/ontokit-api)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
+[![codecov](https://codecov.io/gh/CatholicOS/ontokit-api/graph/badge.svg?token=MUF88DIN0X)](https://codecov.io/gh/CatholicOS/ontokit-api)
 
 Collaborative OWL ontology curation API built with FastAPI.
 


### PR DESCRIPTION
## Summary
- Adds `--junitxml=junit.xml` to pytest to generate JUnit XML test results
- Uploads test results to Codecov via `codecov/test-results-action@v1`
- Uses `if: ${{ !cancelled() }}` so results are uploaded even on test failures

## Test plan
- [ ] CI passes and test results appear on Codecov dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Codecov coverage badge to the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->