### PR TITLE
feat: add GET /projects/{id}/ontology/index-status endpoint

### DIFF
--- a/ontokit/api/routes/analytics.py
+++ b/ontokit/api/routes/analytics.py
@@ -34,6 +34,13 @@ async def _verify_access(project_id: UUID, db: AsyncSession, user: CurrentUser |
         raise
 
 
+def get_change_events(
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> ChangeEventService:
+    """Dependency to get change event service with database session."""
+    return ChangeEventService(db)
+
+
 @router.get(
     "/{project_id}/analytics/activity",
     response_model=ProjectActivity,
@@ -41,12 +48,12 @@ async def _verify_access(project_id: UUID, db: AsyncSession, user: CurrentUser |
 async def get_project_activity(
     project_id: UUID,
     db: Annotated[AsyncSession, Depends(get_db)],
+    service: Annotated[ChangeEventService, Depends(get_change_events)],
     user: OptionalUser,
     days: int = Query(default=30, ge=1, le=365),
 ) -> ProjectActivity:
     """Get project activity over time."""
     await _verify_access(project_id, db, user)
-    service = ChangeEventService(db)
     return await service.get_activity(project_id, days)
 
 
@@ -58,6 +65,7 @@ async def get_entity_history(
     project_id: UUID,
     iri: str,
     db: Annotated[AsyncSession, Depends(get_db)],
+    service: Annotated[ChangeEventService, Depends(get_change_events)],
     user: OptionalUser,
     branch: str | None = Query(default=None),
     limit: int = Query(default=50, ge=1, le=200),
@@ -65,7 +73,6 @@ async def get_entity_history(
     """Get change history for a specific entity."""
     await _verify_access(project_id, db, user)
     decoded_iri = unquote(iri)
-    service = ChangeEventService(db)
     return await service.get_entity_history(project_id, decoded_iri, branch, limit)
 
 
@@ -76,12 +83,12 @@ async def get_entity_history(
 async def get_hot_entities(
     project_id: UUID,
     db: Annotated[AsyncSession, Depends(get_db)],
+    service: Annotated[ChangeEventService, Depends(get_change_events)],
     user: OptionalUser,
     limit: int = Query(default=20, ge=1, le=100),
 ) -> list[HotEntity]:
     """Get most frequently edited entities in the last 30 days."""
     await _verify_access(project_id, db, user)
-    service = ChangeEventService(db)
     return await service.get_hot_entities(project_id, limit)
 
 
@@ -92,10 +99,10 @@ async def get_hot_entities(
 async def get_contributors(
     project_id: UUID,
     db: Annotated[AsyncSession, Depends(get_db)],
+    service: Annotated[ChangeEventService, Depends(get_change_events)],
     user: OptionalUser,
     days: int = Query(default=30, ge=1, le=365),
 ) -> list[ContributorStats]:
     """Get contributor statistics."""
     await _verify_access(project_id, db, user)
-    service = ChangeEventService(db)
     return await service.get_contributors(project_id, days)

--- a/ontokit/api/routes/embeddings.py
+++ b/ontokit/api/routes/embeddings.py
@@ -29,6 +29,13 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
+def get_embeddings(
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> EmbeddingService:
+    """Dependency to get embedding service with database session."""
+    return EmbeddingService(db)
+
+
 async def _verify_write_access(project_id: UUID, db: AsyncSession, user: CurrentUser) -> None:
     service = get_project_service(db)
     project_response = await service.get(project_id, user)
@@ -43,13 +50,12 @@ async def _verify_write_access(project_id: UUID, db: AsyncSession, user: Current
 async def get_embedding_config(
     project_id: UUID,
     db: Annotated[AsyncSession, Depends(get_db)],
+    embed_service: Annotated[EmbeddingService, Depends(get_embeddings)],
     user: RequiredUser,
 ) -> EmbeddingConfig:
     """Get embedding configuration for a project."""
     service = get_project_service(db)
     await service.get(project_id, user)
-
-    embed_service = EmbeddingService(db)
     config = await embed_service.get_config(project_id)
     if not config:
         return EmbeddingConfig(
@@ -67,11 +73,11 @@ async def update_embedding_config(
     project_id: UUID,
     data: EmbeddingConfigUpdate,
     db: Annotated[AsyncSession, Depends(get_db)],
+    embed_service: Annotated[EmbeddingService, Depends(get_embeddings)],
     user: RequiredUser,
 ) -> EmbeddingConfig:
     """Update embedding configuration."""
     await _verify_write_access(project_id, db, user)
-    embed_service = EmbeddingService(db)
     return await embed_service.update_config(project_id, data)
 
 
@@ -148,6 +154,7 @@ async def generate_embeddings(
 async def get_embedding_status(
     project_id: UUID,
     db: Annotated[AsyncSession, Depends(get_db)],
+    embed_service: Annotated[EmbeddingService, Depends(get_embeddings)],
     user: RequiredUser,
     branch: str | None = Query(default=None),
 ) -> EmbeddingStatus:
@@ -158,7 +165,6 @@ async def get_embedding_status(
     git = get_git_service()
     resolved_branch = branch or git.get_default_branch(project_id)
 
-    embed_service = EmbeddingService(db)
     return await embed_service.get_status(project_id, resolved_branch)
 
 
@@ -169,9 +175,9 @@ async def get_embedding_status(
 async def clear_embeddings(
     project_id: UUID,
     db: Annotated[AsyncSession, Depends(get_db)],
+    embed_service: Annotated[EmbeddingService, Depends(get_embeddings)],
     user: RequiredUser,
 ) -> None:
     """Clear all embeddings for a project."""
     await _verify_write_access(project_id, db, user)
-    embed_service = EmbeddingService(db)
     await embed_service.clear_embeddings(project_id)

--- a/ontokit/api/routes/lint.py
+++ b/ontokit/api/routes/lint.py
@@ -588,6 +588,8 @@ async def lint_websocket(
         pass
     except Exception as e:
         logger.exception(f"WebSocket error for project {project_id_str}: {e}")
+        with contextlib.suppress(Exception):
+            await websocket.close(code=1011, reason="Internal server error")
     finally:
         manager.disconnect(websocket, project_id_str)
         if pubsub:

--- a/ontokit/api/routes/lint.py
+++ b/ontokit/api/routes/lint.py
@@ -534,6 +534,7 @@ manager = LintConnectionManager()
 async def lint_websocket(
     websocket: WebSocket,
     project_id: UUID,
+    token: str | None = Query(default=None, description="Bearer token for authentication"),
 ) -> None:
     """
     WebSocket endpoint for real-time lint updates.
@@ -544,17 +545,44 @@ async def lint_websocket(
     - Lint run fails
 
     Messages are JSON objects with a "type" field indicating the event type.
+    Pass ``token`` as a query parameter for authentication.
     """
+    from ontokit.core.auth import CurrentUser, fetch_userinfo, validate_token
+    from ontokit.services.project_service import ProjectService
+
     project_id_str = str(project_id)
 
-    # Verify project exists (basic access check) using manual session
-    async with async_session_maker() as db:
-        result = await db.execute(select(Project).where(Project.id == project_id))
-        project = result.scalar_one_or_none()
-
-    if not project:
-        await websocket.close(code=4004, reason="Project not found")
+    # Authenticate
+    if not token:
+        await websocket.close(code=4001, reason="Authentication required")
         return
+
+    try:
+        payload = await validate_token(token)
+        name = payload.name
+        email = payload.email
+        username = payload.preferred_username
+        if not name or not email:
+            userinfo = await fetch_userinfo(token)
+            if userinfo:
+                name = name or userinfo.get("name") or userinfo.get("preferred_username")
+                email = email or userinfo.get("email")
+                username = username or userinfo.get("preferred_username")
+        user = CurrentUser(
+            id=payload.sub, email=email, name=name, username=username, roles=payload.roles
+        )
+    except Exception:
+        await websocket.close(code=4001, reason="Invalid or expired token")
+        return
+
+    # Verify project access
+    async with async_session_maker() as db:
+        svc = ProjectService(db)
+        try:
+            await svc.get(project_id, user)
+        except Exception:
+            await websocket.close(code=4004, reason="Project not found or access denied")
+            return
 
     await manager.connect(websocket, project_id_str)
 

--- a/ontokit/api/routes/lint.py
+++ b/ontokit/api/routes/lint.py
@@ -14,7 +14,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from ontokit.api.utils.redis import get_arq_pool
 from ontokit.core.auth import CurrentUser, OptionalUser, RequiredUser
-from ontokit.core.database import async_session_maker, get_db
+from ontokit.core.constants import LINT_UPDATES_CHANNEL
+from ontokit.core.database import get_db
 from ontokit.models.lint import LintIssue, LintRun, LintRunStatus
 from ontokit.models.project import Project
 from ontokit.schemas.lint import (
@@ -32,7 +33,6 @@ from ontokit.schemas.lint import (
 )
 from ontokit.services.linter import get_available_rules
 from ontokit.services.project_service import get_project_service
-from ontokit.worker import LINT_UPDATES_CHANNEL
 
 logger = logging.getLogger(__name__)
 
@@ -547,42 +547,12 @@ async def lint_websocket(
     Messages are JSON objects with a "type" field indicating the event type.
     Pass ``token`` as a query parameter for authentication.
     """
-    from ontokit.core.auth import CurrentUser, fetch_userinfo, validate_token
-    from ontokit.services.project_service import ProjectService
+    from ontokit.api.utils.ws_auth import authenticate_ws
 
     project_id_str = str(project_id)
 
-    # Authenticate
-    if not token:
-        await websocket.close(code=4001, reason="Authentication required")
+    if not await authenticate_ws(websocket, project_id, token):
         return
-
-    try:
-        payload = await validate_token(token)
-        name = payload.name
-        email = payload.email
-        username = payload.preferred_username
-        if not name or not email:
-            userinfo = await fetch_userinfo(token)
-            if userinfo:
-                name = name or userinfo.get("name") or userinfo.get("preferred_username")
-                email = email or userinfo.get("email")
-                username = username or userinfo.get("preferred_username")
-        user = CurrentUser(
-            id=payload.sub, email=email, name=name, username=username, roles=payload.roles
-        )
-    except Exception:
-        await websocket.close(code=4001, reason="Invalid or expired token")
-        return
-
-    # Verify project access
-    async with async_session_maker() as db:
-        svc = ProjectService(db)
-        try:
-            await svc.get(project_id, user)
-        except Exception:
-            await websocket.close(code=4004, reason="Project not found or access denied")
-            return
 
     await manager.connect(websocket, project_id_str)
 

--- a/ontokit/api/routes/lint.py
+++ b/ontokit/api/routes/lint.py
@@ -496,8 +496,7 @@ class LintConnectionManager:
         self.active_connections: dict[str, list[WebSocket]] = {}
 
     async def connect(self, websocket: WebSocket, project_id: str) -> None:
-        """Accept connection and add to project's connection list."""
-        await websocket.accept()
+        """Add connection to project's connection list."""
         if project_id not in self.active_connections:
             self.active_connections[project_id] = []
         self.active_connections[project_id].append(websocket)

--- a/ontokit/api/routes/projects.py
+++ b/ontokit/api/routes/projects.py
@@ -61,6 +61,7 @@ from ontokit.schemas.pull_request import (
     GitHubRepoFilesResponse,
     ProjectCreateFromGitHub,
 )
+from ontokit.services.change_event_service import ChangeEventService
 from ontokit.services.github_service import get_github_service
 from ontokit.services.indexed_ontology import IndexedOntologyService
 from ontokit.services.ontology import OntologyService, get_ontology_service
@@ -101,6 +102,11 @@ def get_git() -> GitRepositoryService:
 def get_index(db: Annotated[AsyncSession, Depends(get_db)]) -> OntologyIndexService:
     """Dependency to get ontology index service with database session."""
     return OntologyIndexService(db)
+
+
+def get_change_events(db: Annotated[AsyncSession, Depends(get_db)]) -> ChangeEventService:
+    """Dependency to get change event service with database session."""
+    return ChangeEventService(db)
 
 
 def get_indexed_ontology(
@@ -1157,6 +1163,7 @@ async def delete_branch(
     service: Annotated[ProjectService, Depends(get_service)],
     git: Annotated[GitRepositoryService, Depends(get_git)],
     db: Annotated[AsyncSession, Depends(get_db)],
+    index_service: Annotated[OntologyIndexService, Depends(get_index)],
     user: RequiredUser,
     force: bool = Query(
         default=False, description="Force delete even if branch has unmerged changes"
@@ -1238,7 +1245,6 @@ async def delete_branch(
 
     # Clean up ontology index for deleted branch
     try:
-        index_service = OntologyIndexService(db)
         await index_service.delete_branch_index(project_id, branch_name, auto_commit=False)
     except Exception:
         logger.warning("Failed to clean up ontology index for deleted branch", exc_info=True)
@@ -1258,6 +1264,7 @@ async def save_source_content(
     ontology: Annotated[OntologyService, Depends(get_ontology)],
     git: Annotated[GitRepositoryService, Depends(get_git)],
     db: Annotated[AsyncSession, Depends(get_db)],
+    change_service: Annotated[ChangeEventService, Depends(get_change_events)],
     user: RequiredUser,
     branch: str | None = Query(default=None, description="Branch to commit to"),
 ) -> SourceContentSaveResponse:
@@ -1360,9 +1367,6 @@ async def save_source_content(
     change_events = []
     try:
         new_graph = await ontology._get_graph(project_id, current_branch)
-        from ontokit.services.change_event_service import ChangeEventService
-
-        change_service = ChangeEventService(db)
         change_events = await change_service.record_events_from_diff(
             project_id,
             current_branch,

--- a/ontokit/api/routes/projects.py
+++ b/ontokit/api/routes/projects.py
@@ -98,6 +98,11 @@ def get_git() -> GitRepositoryService:
     return get_git_service()
 
 
+def get_index(db: Annotated[AsyncSession, Depends(get_db)]) -> OntologyIndexService:
+    """Dependency to get ontology index service with database session."""
+    return OntologyIndexService(db)
+
+
 def get_indexed_ontology(
     db: Annotated[AsyncSession, Depends(get_db)],
 ) -> IndexedOntologyService:
@@ -1426,7 +1431,7 @@ async def get_ontology_index_status(
     project_id: UUID,
     service: Annotated[ProjectService, Depends(get_service)],
     git: Annotated[GitRepositoryService, Depends(get_git)],
-    db: Annotated[AsyncSession, Depends(get_db)],
+    index_service: Annotated[OntologyIndexService, Depends(get_index)],
     user: RequiredUser,
     branch: str | None = Query(default=None, description="Branch to check index status for"),
 ) -> dict[str, str | int | None]:
@@ -1434,7 +1439,6 @@ async def get_ontology_index_status(
     project = await service.get(project_id, user)
     resolved_branch = branch or git.get_default_branch(project_id)
 
-    index_service = OntologyIndexService(db)
     index_status = await index_service.get_index_status(project.id, resolved_branch)
 
     if index_status is None:

--- a/ontokit/api/routes/projects.py
+++ b/ontokit/api/routes/projects.py
@@ -1415,6 +1415,37 @@ async def save_source_content(
     )
 
 
+@router.get("/{project_id}/ontology/index-status")
+async def get_ontology_index_status(
+    project_id: UUID,
+    service: Annotated[ProjectService, Depends(get_service)],
+    git: Annotated[GitRepositoryService, Depends(get_git)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+    user: RequiredUser,
+    branch: str | None = Query(default=None, description="Branch to check index status for"),
+) -> dict[str, str | int | None]:
+    """Get the ontology search index status for a project/branch."""
+    project = await service.get(project_id, user)
+    resolved_branch = branch or git.get_default_branch(project_id)
+
+    index_service = OntologyIndexService(db)
+    index_status = await index_service.get_index_status(project.id, resolved_branch)
+
+    if index_status is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No index status found for this project and branch",
+        )
+
+    return {
+        "status": index_status.status,
+        "entity_count": index_status.entity_count,
+        "indexed_at": index_status.indexed_at.isoformat() if index_status.indexed_at else None,
+        "commit_hash": index_status.commit_hash,
+        "error_message": index_status.error_message,
+    }
+
+
 @router.post("/{project_id}/ontology/reindex", status_code=status.HTTP_202_ACCEPTED)
 async def trigger_ontology_reindex(
     project_id: UUID,

--- a/ontokit/api/routes/projects.py
+++ b/ontokit/api/routes/projects.py
@@ -62,6 +62,7 @@ from ontokit.schemas.pull_request import (
     ProjectCreateFromGitHub,
 )
 from ontokit.services.change_event_service import ChangeEventService
+from ontokit.services.embedding_service import EmbeddingService
 from ontokit.services.github_service import get_github_service
 from ontokit.services.indexed_ontology import IndexedOntologyService
 from ontokit.services.ontology import OntologyService, get_ontology_service
@@ -107,6 +108,11 @@ def get_index(db: Annotated[AsyncSession, Depends(get_db)]) -> OntologyIndexServ
 def get_change_events(db: Annotated[AsyncSession, Depends(get_db)]) -> ChangeEventService:
     """Dependency to get change event service with database session."""
     return ChangeEventService(db)
+
+
+def get_embeddings(db: Annotated[AsyncSession, Depends(get_db)]) -> EmbeddingService:
+    """Dependency to get embedding service with database session."""
+    return EmbeddingService(db)
 
 
 def get_indexed_ontology(
@@ -1263,8 +1269,8 @@ async def save_source_content(
     storage: Annotated[StorageService, Depends(get_storage)],
     ontology: Annotated[OntologyService, Depends(get_ontology)],
     git: Annotated[GitRepositoryService, Depends(get_git)],
-    db: Annotated[AsyncSession, Depends(get_db)],
     change_service: Annotated[ChangeEventService, Depends(get_change_events)],
+    embed_service: Annotated[EmbeddingService, Depends(get_embeddings)],
     user: RequiredUser,
     branch: str | None = Query(default=None, description="Branch to commit to"),
 ) -> SourceContentSaveResponse:
@@ -1383,9 +1389,8 @@ async def save_source_content(
     if change_events:
         try:
             from ontokit.models.change_event import ChangeEventType
-            from ontokit.services.embedding_service import EmbeddingService
 
-            embed_config = await EmbeddingService(db).get_config(project_id)
+            embed_config = await embed_service.get_config(project_id)
             if embed_config and embed_config.auto_embed_on_save:
                 pool = await get_arq_pool()
                 if pool is None:
@@ -1577,6 +1582,8 @@ async def ontology_index_websocket(
         pass
     except Exception as e:
         logger.exception(f"Index WebSocket error for project {project_id_str}: {e}")
+        with contextlib.suppress(Exception):
+            await websocket.close(code=1011, reason="Internal server error")
     finally:
         index_ws_manager.disconnect(websocket, project_id_str)
         if pubsub:

--- a/ontokit/api/routes/projects.py
+++ b/ontokit/api/routes/projects.py
@@ -30,7 +30,6 @@ from ontokit.core.database import async_session_maker, get_db
 from ontokit.core.encryption import decrypt_token
 from ontokit.git import GitRepositoryService, get_git_service
 from ontokit.models.branch_metadata import BranchMetadata
-from ontokit.models.project import Project
 from ontokit.models.pull_request import GitHubIntegration, PRStatus, PullRequest
 from ontokit.models.user_github_token import UserGitHubToken
 from ontokit.schemas.owl_class import EntitySearchResponse, OWLClassResponse, OWLClassTreeResponse
@@ -1534,21 +1533,51 @@ index_ws_manager = IndexConnectionManager()
 async def ontology_index_websocket(
     websocket: WebSocket,
     project_id: UUID,
+    token: str | None = Query(default=None, description="Bearer token for authentication"),
 ) -> None:
     """WebSocket endpoint for real-time ontology index updates.
 
     Forwards index_started, index_complete, and index_failed events
     from the background worker to connected clients.
+
+    Pass ``token`` as a query parameter for authentication (WebSocket
+    connections cannot use HTTP Authorization headers from browsers).
     """
+    from ontokit.core.auth import CurrentUser, fetch_userinfo, validate_token
+
     project_id_str = str(project_id)
 
-    async with async_session_maker() as db:
-        result = await db.execute(select(Project).where(Project.id == project_id))
-        project = result.scalar_one_or_none()
-
-    if not project:
-        await websocket.close(code=4004, reason="Project not found")
+    # Authenticate
+    if not token:
+        await websocket.close(code=4001, reason="Authentication required")
         return
+
+    try:
+        payload = await validate_token(token)
+        name = payload.name
+        email = payload.email
+        username = payload.preferred_username
+        if not name or not email:
+            userinfo = await fetch_userinfo(token)
+            if userinfo:
+                name = name or userinfo.get("name") or userinfo.get("preferred_username")
+                email = email or userinfo.get("email")
+                username = username or userinfo.get("preferred_username")
+        user = CurrentUser(
+            id=payload.sub, email=email, name=name, username=username, roles=payload.roles
+        )
+    except Exception:
+        await websocket.close(code=4001, reason="Invalid or expired token")
+        return
+
+    # Verify project access
+    async with async_session_maker() as db:
+        svc = ProjectService(db)
+        try:
+            await svc.get(project_id, user)
+        except Exception:
+            await websocket.close(code=4004, reason="Project not found or access denied")
+            return
 
     await index_ws_manager.connect(websocket, project_id_str)
 

--- a/ontokit/api/routes/projects.py
+++ b/ontokit/api/routes/projects.py
@@ -1512,7 +1512,6 @@ class IndexConnectionManager:
         self.active_connections: dict[str, list[WebSocket]] = {}
 
     async def connect(self, websocket: WebSocket, project_id: str) -> None:
-        await websocket.accept()
         if project_id not in self.active_connections:
             self.active_connections[project_id] = []
         self.active_connections[project_id].append(websocket)

--- a/ontokit/api/routes/projects.py
+++ b/ontokit/api/routes/projects.py
@@ -26,7 +26,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from ontokit.api.utils.redis import get_arq_pool
 from ontokit.core.auth import OptionalUser, RequiredUser, RequiredUserWithToken
-from ontokit.core.database import async_session_maker, get_db
+from ontokit.core.constants import ONTOLOGY_INDEX_UPDATES_CHANNEL
+from ontokit.core.database import get_db
 from ontokit.core.encryption import decrypt_token
 from ontokit.git import GitRepositoryService, get_git_service
 from ontokit.models.branch_metadata import BranchMetadata
@@ -1435,7 +1436,7 @@ async def get_ontology_index_status(
     service: Annotated[ProjectService, Depends(get_service)],
     git: Annotated[GitRepositoryService, Depends(get_git)],
     index_service: Annotated[OntologyIndexService, Depends(get_index)],
-    user: RequiredUser,
+    user: OptionalUser,
     branch: str | None = Query(default=None, description="Branch to check index status for"),
 ) -> dict[str, str | int | None]:
     """Get the ontology search index status for a project/branch."""
@@ -1503,8 +1504,6 @@ async def trigger_ontology_reindex(
 # WebSocket for real-time ontology index updates
 # ---------------------------------------------------------------------------
 
-ONTOLOGY_INDEX_UPDATES_CHANNEL = "ontology_index:updates"
-
 
 class IndexConnectionManager:
     """Manages WebSocket connections for ontology index update notifications."""
@@ -1543,41 +1542,12 @@ async def ontology_index_websocket(
     Pass ``token`` as a query parameter for authentication (WebSocket
     connections cannot use HTTP Authorization headers from browsers).
     """
-    from ontokit.core.auth import CurrentUser, fetch_userinfo, validate_token
+    from ontokit.api.utils.ws_auth import authenticate_ws
 
     project_id_str = str(project_id)
 
-    # Authenticate
-    if not token:
-        await websocket.close(code=4001, reason="Authentication required")
+    if not await authenticate_ws(websocket, project_id, token):
         return
-
-    try:
-        payload = await validate_token(token)
-        name = payload.name
-        email = payload.email
-        username = payload.preferred_username
-        if not name or not email:
-            userinfo = await fetch_userinfo(token)
-            if userinfo:
-                name = name or userinfo.get("name") or userinfo.get("preferred_username")
-                email = email or userinfo.get("email")
-                username = username or userinfo.get("preferred_username")
-        user = CurrentUser(
-            id=payload.sub, email=email, name=name, username=username, roles=payload.roles
-        )
-    except Exception:
-        await websocket.close(code=4001, reason="Invalid or expired token")
-        return
-
-    # Verify project access
-    async with async_session_maker() as db:
-        svc = ProjectService(db)
-        try:
-            await svc.get(project_id, user)
-        except Exception:
-            await websocket.close(code=4004, reason="Project not found or access denied")
-            return
 
     await index_ws_manager.connect(websocket, project_id_str)
 

--- a/ontokit/api/routes/projects.py
+++ b/ontokit/api/routes/projects.py
@@ -1,5 +1,8 @@
 """Project management endpoints."""
 
+import asyncio
+import contextlib
+import json
 import logging
 from typing import Annotated
 from uuid import UUID
@@ -12,6 +15,8 @@ from fastapi import (
     HTTPException,
     Query,
     UploadFile,
+    WebSocket,
+    WebSocketDisconnect,
     status,
 )
 from sqlalchemy import delete as sa_delete
@@ -21,10 +26,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from ontokit.api.utils.redis import get_arq_pool
 from ontokit.core.auth import OptionalUser, RequiredUser, RequiredUserWithToken
-from ontokit.core.database import get_db
+from ontokit.core.database import async_session_maker, get_db
 from ontokit.core.encryption import decrypt_token
 from ontokit.git import GitRepositoryService, get_git_service
 from ontokit.models.branch_metadata import BranchMetadata
+from ontokit.models.project import Project
 from ontokit.models.pull_request import GitHubIntegration, PRStatus, PullRequest
 from ontokit.models.user_github_token import UserGitHubToken
 from ontokit.schemas.owl_class import EntitySearchResponse, OWLClassResponse, OWLClassTreeResponse
@@ -1484,3 +1490,89 @@ async def trigger_ontology_reindex(
     )
 
     return {"status": "accepted", "branch": resolved_branch}
+
+
+# ---------------------------------------------------------------------------
+# WebSocket for real-time ontology index updates
+# ---------------------------------------------------------------------------
+
+ONTOLOGY_INDEX_UPDATES_CHANNEL = "ontology_index:updates"
+
+
+class IndexConnectionManager:
+    """Manages WebSocket connections for ontology index update notifications."""
+
+    def __init__(self) -> None:
+        self.active_connections: dict[str, list[WebSocket]] = {}
+
+    async def connect(self, websocket: WebSocket, project_id: str) -> None:
+        await websocket.accept()
+        if project_id not in self.active_connections:
+            self.active_connections[project_id] = []
+        self.active_connections[project_id].append(websocket)
+
+    def disconnect(self, websocket: WebSocket, project_id: str) -> None:
+        if project_id in self.active_connections:
+            if websocket in self.active_connections[project_id]:
+                self.active_connections[project_id].remove(websocket)
+            if not self.active_connections[project_id]:
+                del self.active_connections[project_id]
+
+
+index_ws_manager = IndexConnectionManager()
+
+
+@router.websocket("/{project_id}/ontology/index-ws")
+async def ontology_index_websocket(
+    websocket: WebSocket,
+    project_id: UUID,
+) -> None:
+    """WebSocket endpoint for real-time ontology index updates.
+
+    Forwards index_started, index_complete, and index_failed events
+    from the background worker to connected clients.
+    """
+    project_id_str = str(project_id)
+
+    async with async_session_maker() as db:
+        result = await db.execute(select(Project).where(Project.id == project_id))
+        project = result.scalar_one_or_none()
+
+    if not project:
+        await websocket.close(code=4004, reason="Project not found")
+        return
+
+    await index_ws_manager.connect(websocket, project_id_str)
+
+    pubsub = None
+    try:
+        pool = await get_arq_pool()
+        pubsub = pool.pubsub()
+        await pubsub.subscribe(ONTOLOGY_INDEX_UPDATES_CHANNEL)
+
+        while True:
+            message = await pubsub.get_message(ignore_subscribe_messages=True, timeout=0.1)
+            if message and message["type"] == "message":
+                try:
+                    data = json.loads(message["data"])
+                    if data.get("project_id") == project_id_str:
+                        await websocket.send_json(data)
+                except json.JSONDecodeError:
+                    pass
+
+            try:
+                await asyncio.wait_for(websocket.receive_text(), timeout=0.1)
+            except TimeoutError:
+                pass
+            except WebSocketDisconnect:
+                break
+
+    except WebSocketDisconnect:
+        pass
+    except Exception as e:
+        logger.exception(f"Index WebSocket error for project {project_id_str}: {e}")
+    finally:
+        index_ws_manager.disconnect(websocket, project_id_str)
+        if pubsub:
+            with contextlib.suppress(Exception):
+                await pubsub.unsubscribe(ONTOLOGY_INDEX_UPDATES_CHANNEL)

--- a/ontokit/api/routes/semantic_search.py
+++ b/ontokit/api/routes/semantic_search.py
@@ -24,6 +24,13 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
+def get_embeddings(
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> EmbeddingService:
+    """Dependency to get embedding service with database session."""
+    return EmbeddingService(db)
+
+
 async def _verify_access(project_id: UUID, db: AsyncSession, user: CurrentUser | None) -> None:
     from fastapi import HTTPException
 
@@ -41,6 +48,7 @@ async def _verify_access(project_id: UUID, db: AsyncSession, user: CurrentUser |
 async def semantic_search(
     project_id: UUID,
     db: Annotated[AsyncSession, Depends(get_db)],
+    service: Annotated[EmbeddingService, Depends(get_embeddings)],
     user: OptionalUser,
     q: str = Query(..., min_length=1, description="Search query"),
     branch: str | None = Query(default=None),
@@ -54,7 +62,6 @@ async def semantic_search(
         from ontokit.git import get_git_service
 
         resolved_branch = get_git_service().get_default_branch(project_id)
-    service = EmbeddingService(db)
     return await service.semantic_search(project_id, resolved_branch, q, limit, threshold)
 
 
@@ -66,6 +73,7 @@ async def find_similar_entities(
     project_id: UUID,
     iri: str,
     db: Annotated[AsyncSession, Depends(get_db)],
+    service: Annotated[EmbeddingService, Depends(get_embeddings)],
     user: OptionalUser,
     branch: str | None = Query(default=None),
     limit: int = Query(default=10, ge=1, le=50),
@@ -79,7 +87,6 @@ async def find_similar_entities(
 
         resolved_branch = get_git_service().get_default_branch(project_id)
     decoded_iri = unquote(iri)
-    service = EmbeddingService(db)
     return await service.find_similar(project_id, resolved_branch, decoded_iri, limit, threshold)
 
 
@@ -91,6 +98,7 @@ async def rank_suggestions(
     project_id: UUID,
     body: RankSuggestionRequest,
     db: Annotated[AsyncSession, Depends(get_db)],
+    service: Annotated[EmbeddingService, Depends(get_embeddings)],
     user: RequiredUser,
 ) -> list[RankedCandidate]:
     """Rank candidate entities by similarity to a context entity."""
@@ -99,5 +107,4 @@ async def rank_suggestions(
         from ontokit.git import get_git_service
 
         body.branch = get_git_service().get_default_branch(project_id)
-    service = EmbeddingService(db)
     return await service.rank_suggestions(project_id, body)

--- a/ontokit/api/utils/ws_auth.py
+++ b/ontokit/api/utils/ws_auth.py
@@ -1,0 +1,82 @@
+"""Shared WebSocket authentication and project access helper."""
+
+import logging
+from uuid import UUID
+
+from fastapi import HTTPException, WebSocket
+
+from ontokit.core.auth import CurrentUser, fetch_userinfo, validate_token
+from ontokit.core.database import async_session_maker
+from ontokit.services.project_service import ProjectService
+
+logger = logging.getLogger(__name__)
+
+
+async def authenticate_ws(
+    websocket: WebSocket,
+    project_id: UUID,
+    token: str | None,
+) -> bool:
+    """Authenticate a WebSocket connection and verify project access.
+
+    Validates the JWT token, builds a ``CurrentUser``, and checks project
+    access via ``ProjectService.get``.  Returns ``True`` if the caller
+    should proceed (auth + access succeeded).  Returns ``False`` after
+    closing the WebSocket with an appropriate code when auth or access
+    fails.
+
+    HTTP 401/403/404 from the auth/service layer are translated to
+    WebSocket close codes:
+
+    * **4001** – missing or invalid token
+    * **4003** – authenticated but access denied
+    * **4004** – project not found
+
+    Unexpected server errors are closed with **1011** (internal error)
+    and logged.
+    """
+    # --- Token required ---
+    if not token:
+        await websocket.close(code=4001, reason="Authentication required")
+        return False
+
+    # --- Validate JWT ---
+    try:
+        payload = await validate_token(token)
+        name = payload.name
+        email = payload.email
+        username = payload.preferred_username
+        if not name or not email:
+            userinfo = await fetch_userinfo(token)
+            if userinfo:
+                name = name or userinfo.get("name") or userinfo.get("preferred_username")
+                email = email or userinfo.get("email")
+                username = username or userinfo.get("preferred_username")
+        user = CurrentUser(
+            id=payload.sub, email=email, name=name, username=username, roles=payload.roles
+        )
+    except HTTPException:
+        await websocket.close(code=4001, reason="Invalid or expired token")
+        return False
+    except Exception:
+        logger.exception("Unexpected error during WebSocket token validation")
+        await websocket.close(code=1011, reason="Internal server error")
+        return False
+
+    # --- Verify project access ---
+    try:
+        async with async_session_maker() as db:
+            svc = ProjectService(db)
+            await svc.get(project_id, user)
+    except HTTPException as exc:
+        if exc.status_code == 404:
+            await websocket.close(code=4004, reason="Project not found")
+        else:
+            await websocket.close(code=4003, reason="Access denied")
+        return False
+    except Exception:
+        logger.exception("Unexpected error during WebSocket project access check")
+        await websocket.close(code=1011, reason="Internal server error")
+        return False
+
+    return True

--- a/ontokit/api/utils/ws_auth.py
+++ b/ontokit/api/utils/ws_auth.py
@@ -34,7 +34,12 @@ async def authenticate_ws(
 
     Unexpected server errors are closed with **1011** (internal error)
     and logged.
+
+    The WebSocket is accepted before any error close so that the client
+    receives a proper close frame rather than a raw HTTP 403.
     """
+    await websocket.accept()
+
     # --- Token required ---
     if not token:
         await websocket.close(code=4001, reason="Authentication required")

--- a/ontokit/core/constants.py
+++ b/ontokit/core/constants.py
@@ -14,3 +14,9 @@ ONTOKIT_SYNC_COMMITTER_EMAIL = "sync@ontokit.dev"
 ONTOKIT_COMMITTER_EMAILS: frozenset[str] = frozenset(
     {ONTOKIT_COMMITTER_EMAIL, ONTOKIT_SYNC_COMMITTER_EMAIL}
 )
+
+# Redis pubsub channels for real-time updates.
+LINT_UPDATES_CHANNEL = "lint:updates"
+NORMALIZATION_UPDATES_CHANNEL = "normalization:updates"
+ONTOLOGY_INDEX_UPDATES_CHANNEL = "ontology_index:updates"
+REMOTE_SYNC_UPDATES_CHANNEL = "remote_sync:updates"

--- a/ontokit/models/project.py
+++ b/ontokit/models/project.py
@@ -1,5 +1,6 @@
 """Project and ProjectMember database models."""
 
+import os
 import uuid
 from datetime import datetime
 from typing import TYPE_CHECKING
@@ -73,6 +74,24 @@ class Project(Base):
 
     def __repr__(self) -> str:
         return f"<Project(id={self.id}, name={self.name!r}, is_public={self.is_public})>"
+
+
+def get_git_ontology_path(project: Project) -> str:
+    """Get the actual file path within the git repo for a project's ontology.
+
+    Checks the GitHub integration's turtle_file_path / ontology_file_path first,
+    then falls back to basename of source_file_path, and finally "ontology.ttl".
+    """
+    if project.github_integration:
+        path = (
+            project.github_integration.turtle_file_path
+            or project.github_integration.ontology_file_path
+        )
+        if path:
+            return path
+    if project.source_file_path:
+        return os.path.basename(project.source_file_path)
+    return "ontology.ttl"
 
 
 class ProjectMember(Base):

--- a/ontokit/services/embedding_service.py
+++ b/ontokit/services/embedding_service.py
@@ -263,8 +263,10 @@ class EmbeddingService:
                 .where(Project.id == project_id)
             )
             project = proj_result.scalar_one_or_none()
-            if not project or not project.source_file_path:
-                raise ValueError("Project not found or has no ontology file")
+            if not project:
+                raise ValueError("Project not found")
+            if not project.source_file_path and not project.github_integration:
+                raise ValueError("Project has no ontology file")
 
             storage = get_storage_service()
             ontology = get_ontology_service(storage)
@@ -277,6 +279,8 @@ class EmbeddingService:
                 # Only fall back to storage for the default branch; a specific
                 # branch that doesn't exist in git should fail the job rather
                 # than silently embedding the storage snapshot under that branch.
+                if not project.source_file_path:
+                    raise
                 default_branch = git.get_default_branch(project_id)
                 if branch and branch != default_branch:
                     raise

--- a/ontokit/services/embedding_service.py
+++ b/ontokit/services/embedding_service.py
@@ -250,12 +250,18 @@ class EmbeddingService:
 
         try:
             # Load graph
+            from sqlalchemy.orm import selectinload
+
             from ontokit.git.bare_repository import BareGitRepositoryService
-            from ontokit.models.project import Project
+            from ontokit.models.project import Project, get_git_ontology_path
             from ontokit.services.ontology import get_ontology_service
             from ontokit.services.storage import get_storage_service
 
-            proj_result = await self._db.execute(select(Project).where(Project.id == project_id))
+            proj_result = await self._db.execute(
+                select(Project)
+                .options(selectinload(Project.github_integration))
+                .where(Project.id == project_id)
+            )
             project = proj_result.scalar_one_or_none()
             if not project or not project.source_file_path:
                 raise ValueError("Project not found or has no ontology file")
@@ -264,11 +270,7 @@ class EmbeddingService:
             ontology = get_ontology_service(storage)
             git = BareGitRepositoryService()
 
-            import os
-
-            filename = getattr(project, "git_ontology_path", None) or os.path.basename(
-                project.source_file_path
-            )
+            filename = get_git_ontology_path(project)
             try:
                 graph = await ontology.load_from_git(project_id, branch, filename, git)
             except (FileNotFoundError, KeyError, ValueError):

--- a/ontokit/worker.py
+++ b/ontokit/worker.py
@@ -13,6 +13,12 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 from sqlalchemy.orm import selectinload
 
 from ontokit.core.config import settings
+from ontokit.core.constants import (
+    LINT_UPDATES_CHANNEL,
+    NORMALIZATION_UPDATES_CHANNEL,
+    ONTOLOGY_INDEX_UPDATES_CHANNEL,
+    REMOTE_SYNC_UPDATES_CHANNEL,
+)
 from ontokit.core.encryption import decrypt_token
 from ontokit.git.bare_repository import BareGitRepositoryService
 from ontokit.models.lint import LintIssue, LintRun, LintRunStatus
@@ -25,17 +31,7 @@ from ontokit.services.normalization_service import NormalizationService
 from ontokit.services.ontology import get_ontology_service
 from ontokit.services.storage import get_storage_service
 
-# Redis pubsub channels for remote sync updates
-REMOTE_SYNC_UPDATES_CHANNEL = "remote_sync:updates"
-
 logger = logging.getLogger(__name__)
-
-# Redis pubsub channels for updates
-LINT_UPDATES_CHANNEL = "lint:updates"
-NORMALIZATION_UPDATES_CHANNEL = "normalization:updates"
-
-
-ONTOLOGY_INDEX_UPDATES_CHANNEL = "ontology_index:updates"
 
 
 async def run_ontology_index_task(

--- a/ontokit/worker.py
+++ b/ontokit/worker.py
@@ -10,12 +10,13 @@ from arq import ArqRedis, cron
 from arq.connections import RedisSettings
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.orm import selectinload
 
 from ontokit.core.config import settings
 from ontokit.core.encryption import decrypt_token
 from ontokit.git.bare_repository import BareGitRepositoryService
 from ontokit.models.lint import LintIssue, LintRun, LintRunStatus
-from ontokit.models.project import Project
+from ontokit.models.project import Project, get_git_ontology_path
 from ontokit.models.pull_request import GitHubIntegration
 from ontokit.models.user_github_token import UserGitHubToken
 from ontokit.services.github_sync import sync_github_project
@@ -61,8 +62,12 @@ async def run_ontology_index_task(
     project_uuid = UUID(project_id)
 
     try:
-        # Verify project exists
-        result = await db.execute(select(Project).where(Project.id == project_uuid))
+        # Verify project exists (eagerly load github_integration for file path)
+        result = await db.execute(
+            select(Project)
+            .options(selectinload(Project.github_integration))
+            .where(Project.id == project_uuid)
+        )
         project = result.scalar_one_or_none()
 
         if not project:
@@ -80,13 +85,9 @@ async def run_ontology_index_task(
         )
 
         # Load ontology from git or storage
-        import os
-
         storage = get_storage_service()
         ontology_service = get_ontology_service(storage)
-        filename = getattr(project, "git_ontology_path", None) or os.path.basename(
-            project.source_file_path
-        )
+        filename = get_git_ontology_path(project)
 
         git_service = BareGitRepositoryService()
         if git_service.repository_exists(project_uuid):

--- a/ontokit/worker.py
+++ b/ontokit/worker.py
@@ -73,7 +73,9 @@ async def run_ontology_index_task(
         if not project:
             raise ValueError(f"Project {project_id} not found")
 
-        if not project.source_file_path:
+        filename = get_git_ontology_path(project)
+
+        if not project.source_file_path and not project.github_integration:
             raise ValueError(f"Project {project_id} has no ontology file")
 
         logger.info("Starting ontology index for project %s branch %s", project_id, branch)
@@ -87,7 +89,6 @@ async def run_ontology_index_task(
         # Load ontology from git or storage
         storage = get_storage_service()
         ontology_service = get_ontology_service(storage)
-        filename = get_git_ontology_path(project)
 
         git_service = BareGitRepositoryService()
         if git_service.repository_exists(project_uuid):
@@ -101,12 +102,14 @@ async def run_ontology_index_task(
                     commit_hash = repo.get_branch_commit_hash(branch)
                 except Exception:
                     commit_hash = "unknown"
-        else:
+        elif project.source_file_path:
             graph = await ontology_service.load_from_storage(
                 project_uuid, project.source_file_path, branch
             )
             if commit_hash is None:
                 commit_hash = "storage"
+        else:
+            raise ValueError(f"Project {project_id} has no git repository and no storage file")
 
         # Run indexing
         from ontokit.services.ontology_index import OntologyIndexService

--- a/tests/unit/test_di_factories.py
+++ b/tests/unit/test_di_factories.py
@@ -1,0 +1,77 @@
+"""Tests for DI factory functions that create service instances."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from ontokit.api.routes.projects import get_change_events, get_index, get_indexed_ontology
+from ontokit.services.change_event_service import ChangeEventService
+from ontokit.services.ontology_index import OntologyIndexService
+
+
+class TestProjectsDIFactories:
+    """Tests for DI factory functions in projects routes."""
+
+    def test_get_index_returns_ontology_index_service(self) -> None:
+        """get_index() returns an OntologyIndexService with the provided db session."""
+        mock_db = AsyncMock()
+        result = get_index(mock_db)
+        assert isinstance(result, OntologyIndexService)
+
+    def test_get_change_events_returns_change_event_service(self) -> None:
+        """get_change_events() returns a ChangeEventService with the provided db session."""
+        mock_db = AsyncMock()
+        result = get_change_events(mock_db)
+        assert isinstance(result, ChangeEventService)
+
+    @patch("ontokit.api.routes.projects.get_ontology_service")
+    @patch("ontokit.api.routes.projects.get_storage_service")
+    def test_get_indexed_ontology_returns_indexed_ontology_service(
+        self,
+        mock_storage: MagicMock,  # noqa: ARG002
+        mock_ontology: MagicMock,  # noqa: ARG002
+    ) -> None:
+        """get_indexed_ontology() returns an IndexedOntologyService."""
+        from ontokit.services.indexed_ontology import IndexedOntologyService
+
+        mock_db = AsyncMock()
+        result = get_indexed_ontology(mock_db)
+        assert isinstance(result, IndexedOntologyService)
+
+
+class TestEmbeddingsDIFactory:
+    """Tests for DI factory in embeddings routes."""
+
+    def test_get_embeddings_returns_embedding_service(self) -> None:
+        """get_embeddings() returns an EmbeddingService."""
+        from ontokit.api.routes.embeddings import get_embeddings
+        from ontokit.services.embedding_service import EmbeddingService
+
+        mock_db = AsyncMock()
+        result = get_embeddings(mock_db)
+        assert isinstance(result, EmbeddingService)
+
+
+class TestSemanticSearchDIFactory:
+    """Tests for DI factory in semantic_search routes."""
+
+    def test_get_embeddings_returns_embedding_service(self) -> None:
+        """get_embeddings() in semantic_search returns an EmbeddingService."""
+        from ontokit.api.routes.semantic_search import get_embeddings
+        from ontokit.services.embedding_service import EmbeddingService
+
+        mock_db = AsyncMock()
+        result = get_embeddings(mock_db)
+        assert isinstance(result, EmbeddingService)
+
+
+class TestAnalyticsDIFactory:
+    """Tests for DI factory in analytics routes."""
+
+    def test_get_change_events_returns_change_event_service(self) -> None:
+        """get_change_events() in analytics returns a ChangeEventService."""
+        from ontokit.api.routes.analytics import get_change_events as analytics_get_change_events
+
+        mock_db = AsyncMock()
+        result = analytics_get_change_events(mock_db)
+        assert isinstance(result, ChangeEventService)

--- a/tests/unit/test_embedding_service.py
+++ b/tests/unit/test_embedding_service.py
@@ -834,6 +834,179 @@ class TestEmbedProject:
         ):
             await service.embed_project(PROJECT_ID, "feature-branch", job_id)
 
+    @pytest.mark.asyncio
+    async def test_embed_project_no_source_and_no_integration_raises(
+        self, service: EmbeddingService, mock_db: AsyncMock
+    ) -> None:
+        """Raises ValueError when project has no source_file_path and no integration."""
+        job_id = uuid.uuid4()
+
+        # No existing job
+        job_result = MagicMock()
+        job_result.scalar_one_or_none.return_value = None
+
+        # Project with no source and no integration
+        mock_project = MagicMock()
+        mock_project.source_file_path = None
+        mock_project.github_integration = None
+        proj_result = MagicMock()
+        proj_result.scalar_one_or_none.return_value = mock_project
+
+        mock_db.execute = AsyncMock(
+            side_effect=[
+                job_result,  # select EmbeddingJob
+                proj_result,  # select Project
+                MagicMock(),  # except handler: update EmbeddingJob status
+            ]
+        )
+
+        with pytest.raises(ValueError, match="has no ontology file"):
+            await service.embed_project(PROJECT_ID, BRANCH, job_id)
+
+    @pytest.mark.asyncio
+    async def test_embed_project_no_source_file_reraises_on_git_failure(
+        self, service: EmbeddingService, mock_db: AsyncMock
+    ) -> None:
+        """Re-raises when git load fails and project has no source_file_path for fallback."""
+        from unittest.mock import patch
+
+        job_id = uuid.uuid4()
+
+        # No existing job
+        job_result = MagicMock()
+        job_result.scalar_one_or_none.return_value = None
+
+        # Project with integration but no source_file_path
+        mock_project = MagicMock()
+        mock_project.source_file_path = None
+        mock_project.github_integration = MagicMock()
+        proj_result = MagicMock()
+        proj_result.scalar_one_or_none.return_value = mock_project
+
+        cfg_result = MagicMock()
+        cfg_result.scalar_one_or_none.return_value = _make_config_row()
+
+        mock_db.execute.side_effect = [
+            job_result,  # select EmbeddingJob
+            proj_result,  # select Project
+            cfg_result,  # _get_provider
+        ]
+
+        mock_ontology = MagicMock()
+        mock_ontology.load_from_git = AsyncMock(side_effect=FileNotFoundError("not found"))
+
+        with (
+            patch(
+                "ontokit.services.embedding_service.get_embedding_provider",
+                return_value=AsyncMock(provider_name="local", model_id="m"),
+            ),
+            patch(
+                "ontokit.services.ontology.get_ontology_service",
+                return_value=mock_ontology,
+            ),
+            patch(
+                "ontokit.git.bare_repository.BareGitRepositoryService",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "ontokit.services.storage.get_storage_service",
+                return_value=MagicMock(),
+            ),
+            pytest.raises(FileNotFoundError),
+        ):
+            await service.embed_project(PROJECT_ID, BRANCH, job_id)
+
+    @pytest.mark.asyncio
+    async def test_embed_project_storage_fallback_when_no_git(
+        self, service: EmbeddingService, mock_db: AsyncMock
+    ) -> None:
+        """Falls back to storage loading when git load fails on default branch."""
+        from unittest.mock import patch
+
+        from rdflib import Graph
+
+        job_id = uuid.uuid4()
+
+        # No existing job
+        job_result = MagicMock()
+        job_result.scalar_one_or_none.return_value = None
+
+        # Project with source_file_path
+        mock_project = MagicMock()
+        mock_project.source_file_path = "ontology.ttl"
+        mock_project.github_integration = MagicMock()
+        proj_result = MagicMock()
+        proj_result.scalar_one_or_none.return_value = mock_project
+
+        cfg = _make_config_row()
+        cfg_result = MagicMock()
+        cfg_result.scalar_one_or_none.return_value = cfg
+
+        empty_graph = Graph()
+
+        mock_ontology = MagicMock()
+        mock_ontology.load_from_git = AsyncMock(side_effect=FileNotFoundError("not found"))
+        mock_ontology.load_from_storage = AsyncMock(return_value=empty_graph)
+
+        mock_git = MagicMock()
+        mock_git.get_default_branch.return_value = "main"
+
+        mock_db.execute.side_effect = [
+            job_result,  # select EmbeddingJob
+            proj_result,  # select Project
+            cfg_result,  # _get_provider
+            MagicMock(),  # delete prune
+            cfg_result,  # config for last_full_embed_at
+        ]
+
+        with (
+            patch(
+                "ontokit.services.embedding_service.get_embedding_provider",
+                return_value=AsyncMock(provider_name="local", model_id="m"),
+            ),
+            patch(
+                "ontokit.services.ontology.get_ontology_service",
+                return_value=mock_ontology,
+            ),
+            patch(
+                "ontokit.git.bare_repository.BareGitRepositoryService",
+                return_value=mock_git,
+            ),
+            patch(
+                "ontokit.services.storage.get_storage_service",
+                return_value=MagicMock(),
+            ),
+        ):
+            await service.embed_project(PROJECT_ID, "main", job_id)
+
+        mock_ontology.load_from_storage.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_embed_project_not_found_raises(
+        self, service: EmbeddingService, mock_db: AsyncMock
+    ) -> None:
+        """Raises ValueError when project is not found in the database."""
+        job_id = uuid.uuid4()
+
+        # No existing job
+        job_result = MagicMock()
+        job_result.scalar_one_or_none.return_value = None
+
+        # Project not found
+        proj_result = MagicMock()
+        proj_result.scalar_one_or_none.return_value = None
+
+        mock_db.execute = AsyncMock(
+            side_effect=[
+                job_result,  # select EmbeddingJob
+                proj_result,  # select Project
+                MagicMock(),  # except handler: update EmbeddingJob status
+            ]
+        )
+
+        with pytest.raises(ValueError, match="Project not found"):
+            await service.embed_project(PROJECT_ID, BRANCH, job_id)
+
 
 # ---------------------------------------------------------------------------
 # embed_single_entity

--- a/tests/unit/test_get_git_ontology_path.py
+++ b/tests/unit/test_get_git_ontology_path.py
@@ -1,0 +1,80 @@
+"""Tests for the standalone get_git_ontology_path function in models/project.py."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from ontokit.models.project import get_git_ontology_path
+
+
+def _make_project(
+    *,
+    source_file_path: str | None = None,
+    github_integration: MagicMock | None = None,
+) -> MagicMock:
+    """Create a mock Project with the given attributes."""
+    project = MagicMock()
+    project.source_file_path = source_file_path
+    project.github_integration = github_integration
+    return project
+
+
+class TestGetGitOntologyPath:
+    """Tests for the standalone get_git_ontology_path() function."""
+
+    def test_github_integration_turtle_file_path(self) -> None:
+        """Returns turtle_file_path when github_integration has it set."""
+        integration = MagicMock()
+        integration.turtle_file_path = "src/ontology.ttl"
+        integration.ontology_file_path = "src/ontology.owl"
+        project = _make_project(github_integration=integration)
+
+        result = get_git_ontology_path(project)
+        assert result == "src/ontology.ttl"
+
+    def test_github_integration_ontology_file_path_fallback(self) -> None:
+        """Falls back to ontology_file_path when turtle_file_path is None."""
+        integration = MagicMock()
+        integration.turtle_file_path = None
+        integration.ontology_file_path = "src/ontology.owl"
+        project = _make_project(github_integration=integration)
+
+        result = get_git_ontology_path(project)
+        assert result == "src/ontology.owl"
+
+    def test_source_file_path_basename(self) -> None:
+        """Uses basename of source_file_path when no GitHub integration."""
+        project = _make_project(source_file_path="projects/abc/ontology.ttl")
+
+        result = get_git_ontology_path(project)
+        assert result == "ontology.ttl"
+
+    def test_default_fallback(self) -> None:
+        """Returns 'ontology.ttl' when no integration and no source_file_path."""
+        project = _make_project()
+
+        result = get_git_ontology_path(project)
+        assert result == "ontology.ttl"
+
+    def test_github_integration_both_paths_none(self) -> None:
+        """Falls through to source_file_path when both integration paths are None."""
+        integration = MagicMock()
+        integration.turtle_file_path = None
+        integration.ontology_file_path = None
+        project = _make_project(
+            source_file_path="uploads/my-project/my-onto.ttl",
+            github_integration=integration,
+        )
+
+        result = get_git_ontology_path(project)
+        assert result == "my-onto.ttl"
+
+    def test_github_integration_both_paths_none_no_source(self) -> None:
+        """Falls through to default when integration paths are None and no source."""
+        integration = MagicMock()
+        integration.turtle_file_path = None
+        integration.ontology_file_path = None
+        project = _make_project(github_integration=integration)
+
+        result = get_git_ontology_path(project)
+        assert result == "ontology.ttl"

--- a/tests/unit/test_index_status_route.py
+++ b/tests/unit/test_index_status_route.py
@@ -3,29 +3,19 @@
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncGenerator, Generator
+from collections.abc import Generator
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
-from sqlalchemy.ext.asyncio import AsyncSession
 
-from ontokit.core.database import get_db
+from ontokit.api.routes.projects import get_git, get_service
 from ontokit.main import app
 from ontokit.models.ontology_index import IndexingStatus
 
 PROJECT_ID = uuid.UUID("12345678-1234-5678-1234-567812345678")
 URL = f"/api/v1/projects/{PROJECT_ID}/ontology/index-status"
-
-
-def _fake_user() -> MagicMock:
-    """Return a minimal mock user for RequiredUser."""
-    user = MagicMock()
-    user.sub = "user-1"
-    user.email = "test@example.com"
-    user.is_superadmin = False
-    return user
 
 
 def _fake_project(role: str = "viewer") -> MagicMock:
@@ -39,6 +29,7 @@ def _fake_project(role: str = "viewer") -> MagicMock:
 def _fake_index_status(
     status: str = IndexingStatus.READY.value,
     entity_count: int = 42,
+    error_message: str | None = None,
 ) -> MagicMock:
     """Return a mock OntologyIndexStatus."""
     idx = MagicMock()
@@ -46,64 +37,149 @@ def _fake_index_status(
     idx.entity_count = entity_count
     idx.indexed_at = datetime(2026, 1, 15, 12, 0, 0, tzinfo=UTC)
     idx.commit_hash = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
-    idx.error_message = None
+    idx.error_message = error_message
     return idx
 
 
 @pytest.fixture
-def mock_db_client() -> Generator[TestClient]:
-    mock_session = MagicMock()
+def mock_project_service() -> Generator[AsyncMock, None, None]:
+    mock_svc = AsyncMock()
+    app.dependency_overrides[get_service] = lambda: mock_svc
+    try:
+        yield mock_svc
+    finally:
+        app.dependency_overrides.pop(get_service, None)
 
-    async def _override_get_db() -> AsyncGenerator[AsyncSession]:
-        yield mock_session
 
-    app.dependency_overrides[get_db] = _override_get_db
-    client = TestClient(app, raise_server_exceptions=False)
-    yield client
-    app.dependency_overrides.clear()
+@pytest.fixture
+def mock_git_service() -> Generator[MagicMock, None, None]:
+    mock_git = MagicMock()
+    mock_git.get_default_branch.return_value = "main"
+    app.dependency_overrides[get_git] = lambda: mock_git
+    try:
+        yield mock_git
+    finally:
+        app.dependency_overrides.pop(get_git, None)
 
 
 class TestGetOntologyIndexStatus:
     """Tests for the GET index-status endpoint."""
 
     @patch("ontokit.api.routes.projects.OntologyIndexService")
-    @patch("ontokit.api.routes.projects.get_git_service")
     def test_returns_status_when_index_exists(
         self,
-        mock_get_git: MagicMock,
         mock_index_cls: MagicMock,
-        mock_db_client: TestClient,
+        authed_client: tuple[TestClient, AsyncMock],
+        mock_project_service: AsyncMock,
+        mock_git_service: MagicMock,  # noqa: ARG002
     ) -> None:
         """Returns 200 with index status fields when a record exists."""
-        mock_git = MagicMock()
-        mock_git.get_default_branch.return_value = "main"
-        mock_get_git.return_value = mock_git
+        client, _ = authed_client
+        mock_project_service.get.return_value = _fake_project()
 
-        mock_service = AsyncMock()
-        mock_service.get_index_status.return_value = _fake_index_status()
-        mock_index_cls.return_value = mock_service
+        mock_index_svc = AsyncMock()
+        mock_index_svc.get_index_status.return_value = _fake_index_status()
+        mock_index_cls.return_value = mock_index_svc
 
-        with (
-            patch("ontokit.api.routes.projects.ProjectService") as mock_ps_cls,
-            patch("ontokit.core.auth.get_current_user", return_value=_fake_user()),
-        ):
-            mock_ps = AsyncMock()
-            mock_ps.get.return_value = _fake_project()
-            mock_ps_cls.return_value = mock_ps
+        response = client.get(URL)
 
-            response = mock_db_client.get(URL)
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == IndexingStatus.READY.value
+        assert data["entity_count"] == 42
+        assert data["commit_hash"] == "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+        assert data["indexed_at"] == "2026-01-15T12:00:00+00:00"
+        assert data["error_message"] is None
 
-        # The route is registered and reachable (not 404/405 from routing)
-        assert response.status_code != 404
-        assert response.status_code != 405
+    @patch("ontokit.api.routes.projects.OntologyIndexService")
+    def test_returns_404_when_no_index_record(
+        self,
+        mock_index_cls: MagicMock,
+        authed_client: tuple[TestClient, AsyncMock],
+        mock_project_service: AsyncMock,
+        mock_git_service: MagicMock,  # noqa: ARG002
+    ) -> None:
+        """Returns 404 when no index status record exists for the branch."""
+        client, _ = authed_client
+        mock_project_service.get.return_value = _fake_project()
 
-    def test_route_is_registered(self, mock_db_client: TestClient) -> None:
-        """The GET index-status route is reachable (not a 404/405 routing error)."""
-        response = mock_db_client.get(URL)
-        # Without auth it will likely be 401/403, but NOT 404/405
-        assert response.status_code not in (404, 405)
+        mock_index_svc = AsyncMock()
+        mock_index_svc.get_index_status.return_value = None
+        mock_index_cls.return_value = mock_index_svc
 
-    def test_route_accepts_branch_query_param(self, mock_db_client: TestClient) -> None:
-        """The route accepts a branch query parameter without routing errors."""
-        response = mock_db_client.get(URL, params={"branch": "develop"})
-        assert response.status_code not in (404, 405)
+        response = client.get(URL)
+
+        assert response.status_code == 404
+        assert "No index status found" in response.json()["detail"]
+
+    @patch("ontokit.api.routes.projects.OntologyIndexService")
+    def test_uses_explicit_branch_param(
+        self,
+        mock_index_cls: MagicMock,
+        authed_client: tuple[TestClient, AsyncMock],
+        mock_project_service: AsyncMock,
+        mock_git_service: MagicMock,
+    ) -> None:
+        """Passes the explicit branch query param to the service."""
+        client, _ = authed_client
+        mock_project_service.get.return_value = _fake_project()
+
+        mock_index_svc = AsyncMock()
+        mock_index_svc.get_index_status.return_value = _fake_index_status()
+        mock_index_cls.return_value = mock_index_svc
+
+        response = client.get(URL, params={"branch": "develop"})
+
+        assert response.status_code == 200
+        mock_index_svc.get_index_status.assert_awaited_once_with(PROJECT_ID, "develop")
+        mock_git_service.get_default_branch.assert_not_called()
+
+    @patch("ontokit.api.routes.projects.OntologyIndexService")
+    def test_defaults_to_project_default_branch(
+        self,
+        mock_index_cls: MagicMock,
+        authed_client: tuple[TestClient, AsyncMock],
+        mock_project_service: AsyncMock,
+        mock_git_service: MagicMock,
+    ) -> None:
+        """Falls back to the project default branch when no branch param is given."""
+        client, _ = authed_client
+        mock_project_service.get.return_value = _fake_project()
+
+        mock_index_svc = AsyncMock()
+        mock_index_svc.get_index_status.return_value = _fake_index_status()
+        mock_index_cls.return_value = mock_index_svc
+
+        response = client.get(URL)
+
+        assert response.status_code == 200
+        mock_git_service.get_default_branch.assert_called_once_with(PROJECT_ID)
+        mock_index_svc.get_index_status.assert_awaited_once_with(PROJECT_ID, "main")
+
+    @patch("ontokit.api.routes.projects.OntologyIndexService")
+    def test_returns_failed_status_with_error_message(
+        self,
+        mock_index_cls: MagicMock,
+        authed_client: tuple[TestClient, AsyncMock],
+        mock_project_service: AsyncMock,
+        mock_git_service: MagicMock,  # noqa: ARG002
+    ) -> None:
+        """Returns error_message when index status is failed."""
+        client, _ = authed_client
+        mock_project_service.get.return_value = _fake_project()
+
+        mock_index_svc = AsyncMock()
+        mock_index_svc.get_index_status.return_value = _fake_index_status(
+            status=IndexingStatus.FAILED.value,
+            entity_count=0,
+            error_message="Parse error in ontology.ttl",
+        )
+        mock_index_cls.return_value = mock_index_svc
+
+        response = client.get(URL)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "failed"
+        assert data["error_message"] == "Parse error in ontology.ttl"
+        assert data["entity_count"] == 0

--- a/tests/unit/test_index_status_route.py
+++ b/tests/unit/test_index_status_route.py
@@ -1,0 +1,109 @@
+"""Tests for GET /api/v1/projects/{id}/ontology/index-status endpoint."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator, Generator
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ontokit.core.database import get_db
+from ontokit.main import app
+from ontokit.models.ontology_index import IndexingStatus
+
+PROJECT_ID = uuid.UUID("12345678-1234-5678-1234-567812345678")
+URL = f"/api/v1/projects/{PROJECT_ID}/ontology/index-status"
+
+
+def _fake_user() -> MagicMock:
+    """Return a minimal mock user for RequiredUser."""
+    user = MagicMock()
+    user.sub = "user-1"
+    user.email = "test@example.com"
+    user.is_superadmin = False
+    return user
+
+
+def _fake_project(role: str = "viewer") -> MagicMock:
+    """Return a mock project with the given user role."""
+    project = MagicMock()
+    project.id = PROJECT_ID
+    project.user_role = role
+    return project
+
+
+def _fake_index_status(
+    status: str = IndexingStatus.READY.value,
+    entity_count: int = 42,
+) -> MagicMock:
+    """Return a mock OntologyIndexStatus."""
+    idx = MagicMock()
+    idx.status = status
+    idx.entity_count = entity_count
+    idx.indexed_at = datetime(2026, 1, 15, 12, 0, 0, tzinfo=UTC)
+    idx.commit_hash = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+    idx.error_message = None
+    return idx
+
+
+@pytest.fixture
+def mock_db_client() -> Generator[TestClient]:
+    mock_session = MagicMock()
+
+    async def _override_get_db() -> AsyncGenerator[AsyncSession]:
+        yield mock_session
+
+    app.dependency_overrides[get_db] = _override_get_db
+    client = TestClient(app, raise_server_exceptions=False)
+    yield client
+    app.dependency_overrides.clear()
+
+
+class TestGetOntologyIndexStatus:
+    """Tests for the GET index-status endpoint."""
+
+    @patch("ontokit.api.routes.projects.OntologyIndexService")
+    @patch("ontokit.api.routes.projects.get_git_service")
+    def test_returns_status_when_index_exists(
+        self,
+        mock_get_git: MagicMock,
+        mock_index_cls: MagicMock,
+        mock_db_client: TestClient,
+    ) -> None:
+        """Returns 200 with index status fields when a record exists."""
+        mock_git = MagicMock()
+        mock_git.get_default_branch.return_value = "main"
+        mock_get_git.return_value = mock_git
+
+        mock_service = AsyncMock()
+        mock_service.get_index_status.return_value = _fake_index_status()
+        mock_index_cls.return_value = mock_service
+
+        with (
+            patch("ontokit.api.routes.projects.ProjectService") as mock_ps_cls,
+            patch("ontokit.core.auth.get_current_user", return_value=_fake_user()),
+        ):
+            mock_ps = AsyncMock()
+            mock_ps.get.return_value = _fake_project()
+            mock_ps_cls.return_value = mock_ps
+
+            response = mock_db_client.get(URL)
+
+        # The route is registered and reachable (not 404/405 from routing)
+        assert response.status_code != 404
+        assert response.status_code != 405
+
+    def test_route_is_registered(self, mock_db_client: TestClient) -> None:
+        """The GET index-status route is reachable (not a 404/405 routing error)."""
+        response = mock_db_client.get(URL)
+        # Without auth it will likely be 401/403, but NOT 404/405
+        assert response.status_code not in (404, 405)
+
+    def test_route_accepts_branch_query_param(self, mock_db_client: TestClient) -> None:
+        """The route accepts a branch query parameter without routing errors."""
+        response = mock_db_client.get(URL, params={"branch": "develop"})
+        assert response.status_code not in (404, 405)

--- a/tests/unit/test_index_status_route.py
+++ b/tests/unit/test_index_status_route.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 import uuid
 from collections.abc import Generator
 from datetime import UTC, datetime
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastapi.testclient import TestClient
 
-from ontokit.api.routes.projects import get_git, get_service
+from ontokit.api.routes.projects import get_git, get_index, get_service
 from ontokit.main import app
 from ontokit.models.ontology_index import IndexingStatus
 
@@ -62,24 +62,30 @@ def mock_git_service() -> Generator[MagicMock, None, None]:
         app.dependency_overrides.pop(get_git, None)
 
 
+@pytest.fixture
+def mock_index_service() -> Generator[AsyncMock, None, None]:
+    mock_idx = AsyncMock()
+    app.dependency_overrides[get_index] = lambda: mock_idx
+    try:
+        yield mock_idx
+    finally:
+        app.dependency_overrides.pop(get_index, None)
+
+
 class TestGetOntologyIndexStatus:
     """Tests for the GET index-status endpoint."""
 
-    @patch("ontokit.api.routes.projects.OntologyIndexService")
     def test_returns_status_when_index_exists(
         self,
-        mock_index_cls: MagicMock,
         authed_client: tuple[TestClient, AsyncMock],
         mock_project_service: AsyncMock,
         mock_git_service: MagicMock,  # noqa: ARG002
+        mock_index_service: AsyncMock,
     ) -> None:
         """Returns 200 with index status fields when a record exists."""
         client, _ = authed_client
         mock_project_service.get.return_value = _fake_project()
-
-        mock_index_svc = AsyncMock()
-        mock_index_svc.get_index_status.return_value = _fake_index_status()
-        mock_index_cls.return_value = mock_index_svc
+        mock_index_service.get_index_status.return_value = _fake_index_status()
 
         response = client.get(URL)
 
@@ -91,90 +97,74 @@ class TestGetOntologyIndexStatus:
         assert data["indexed_at"] == "2026-01-15T12:00:00+00:00"
         assert data["error_message"] is None
 
-    @patch("ontokit.api.routes.projects.OntologyIndexService")
     def test_returns_404_when_no_index_record(
         self,
-        mock_index_cls: MagicMock,
         authed_client: tuple[TestClient, AsyncMock],
         mock_project_service: AsyncMock,
         mock_git_service: MagicMock,  # noqa: ARG002
+        mock_index_service: AsyncMock,
     ) -> None:
         """Returns 404 when no index status record exists for the branch."""
         client, _ = authed_client
         mock_project_service.get.return_value = _fake_project()
-
-        mock_index_svc = AsyncMock()
-        mock_index_svc.get_index_status.return_value = None
-        mock_index_cls.return_value = mock_index_svc
+        mock_index_service.get_index_status.return_value = None
 
         response = client.get(URL)
 
         assert response.status_code == 404
         assert "No index status found" in response.json()["detail"]
 
-    @patch("ontokit.api.routes.projects.OntologyIndexService")
     def test_uses_explicit_branch_param(
         self,
-        mock_index_cls: MagicMock,
         authed_client: tuple[TestClient, AsyncMock],
         mock_project_service: AsyncMock,
         mock_git_service: MagicMock,
+        mock_index_service: AsyncMock,
     ) -> None:
         """Passes the explicit branch query param to the service."""
         client, _ = authed_client
         mock_project_service.get.return_value = _fake_project()
-
-        mock_index_svc = AsyncMock()
-        mock_index_svc.get_index_status.return_value = _fake_index_status()
-        mock_index_cls.return_value = mock_index_svc
+        mock_index_service.get_index_status.return_value = _fake_index_status()
 
         response = client.get(URL, params={"branch": "develop"})
 
         assert response.status_code == 200
-        mock_index_svc.get_index_status.assert_awaited_once_with(PROJECT_ID, "develop")
+        mock_index_service.get_index_status.assert_awaited_once_with(PROJECT_ID, "develop")
         mock_git_service.get_default_branch.assert_not_called()
 
-    @patch("ontokit.api.routes.projects.OntologyIndexService")
     def test_defaults_to_project_default_branch(
         self,
-        mock_index_cls: MagicMock,
         authed_client: tuple[TestClient, AsyncMock],
         mock_project_service: AsyncMock,
         mock_git_service: MagicMock,
+        mock_index_service: AsyncMock,
     ) -> None:
         """Falls back to the project default branch when no branch param is given."""
         client, _ = authed_client
         mock_project_service.get.return_value = _fake_project()
-
-        mock_index_svc = AsyncMock()
-        mock_index_svc.get_index_status.return_value = _fake_index_status()
-        mock_index_cls.return_value = mock_index_svc
+        mock_index_service.get_index_status.return_value = _fake_index_status()
 
         response = client.get(URL)
 
         assert response.status_code == 200
         mock_git_service.get_default_branch.assert_called_once_with(PROJECT_ID)
-        mock_index_svc.get_index_status.assert_awaited_once_with(PROJECT_ID, "main")
+        mock_index_service.get_index_status.assert_awaited_once_with(PROJECT_ID, "main")
 
-    @patch("ontokit.api.routes.projects.OntologyIndexService")
     def test_returns_failed_status_with_error_message(
         self,
-        mock_index_cls: MagicMock,
         authed_client: tuple[TestClient, AsyncMock],
         mock_project_service: AsyncMock,
         mock_git_service: MagicMock,  # noqa: ARG002
+        mock_index_service: AsyncMock,
     ) -> None:
         """Returns error_message when index status is failed."""
         client, _ = authed_client
         mock_project_service.get.return_value = _fake_project()
-
-        mock_index_svc = AsyncMock()
-        mock_index_svc.get_index_status.return_value = _fake_index_status(
+        mock_index_service.get_index_status.return_value = _fake_index_status(
             status=IndexingStatus.FAILED.value,
             entity_count=0,
             error_message="Parse error in ontology.ttl",
         )
-        mock_index_cls.return_value = mock_index_svc
 
         response = client.get(URL)
 

--- a/tests/unit/test_index_ws.py
+++ b/tests/unit/test_index_ws.py
@@ -18,6 +18,7 @@ from ontokit.api.routes.projects import (
 
 PROJECT_ID = "12345678-1234-5678-1234-567812345678"
 PROJECT_UUID = UUID(PROJECT_ID)
+FAKE_TOKEN = "fake-jwt-token"
 
 
 # ---------------------------------------------------------------------------
@@ -74,27 +75,36 @@ class TestIndexConnectionManager:
 
 
 # ---------------------------------------------------------------------------
-# Helper: mock DB context manager
+# Helpers
 # ---------------------------------------------------------------------------
 
 
-def _mock_db_context(project_exists: bool = True) -> tuple[AsyncMock, AsyncMock]:
-    """Return (mock_session_maker, mock_db) with project query configured."""
-    mock_db = AsyncMock()
-    mock_result = Mock()
-    if project_exists:
-        mock_project = Mock()
-        mock_project.id = PROJECT_ID
-        mock_result.scalar_one_or_none.return_value = mock_project
-    else:
-        mock_result.scalar_one_or_none.return_value = None
-    mock_db.execute.return_value = mock_result
+def _fake_token_payload() -> Mock:
+    """Return a mock TokenPayload from validate_token."""
+    payload = Mock()
+    payload.sub = "user-1"
+    payload.name = "Test User"
+    payload.email = "test@example.com"
+    payload.preferred_username = "testuser"
+    payload.roles = ["owner"]
+    return payload
 
-    mock_ctx = AsyncMock()
-    mock_ctx.__aenter__ = AsyncMock(return_value=mock_db)
-    mock_ctx.__aexit__ = AsyncMock(return_value=False)
-    mock_session_maker = Mock(return_value=mock_ctx)
-    return mock_session_maker, mock_db
+
+def _mock_auth_and_project(
+    project_exists: bool = True,
+) -> tuple[AsyncMock, AsyncMock]:
+    """Return (mock_validate_token, mock_project_service_cls) patches."""
+    mock_validate = AsyncMock(return_value=_fake_token_payload())
+
+    mock_svc = AsyncMock()
+    if project_exists:
+        mock_svc.get.return_value = Mock()  # project response
+    else:
+        from fastapi import HTTPException
+
+        mock_svc.get.side_effect = HTTPException(status_code=404, detail="Not found")
+
+    return mock_validate, mock_svc
 
 
 def _mock_pubsub(messages: list[Any]) -> tuple[AsyncMock, AsyncMock]:
@@ -116,7 +126,6 @@ def _mock_pubsub(messages: list[Any]) -> tuple[AsyncMock, AsyncMock]:
     mock_pubsub = AsyncMock()
     mock_pubsub.get_message = fake_get_message
     mock_pool = AsyncMock()
-    # pubsub() is a sync method that returns the PubSub object
     mock_pool.pubsub = Mock(return_value=mock_pubsub)
     return mock_pool, mock_pubsub
 
@@ -130,35 +139,68 @@ class TestOntologyIndexWebSocketUnit:
     """Direct async tests for ontology_index_websocket function."""
 
     @pytest.mark.asyncio
-    async def test_project_not_found_closes_ws(self) -> None:
-        """Closes with 4004 when project doesn't exist."""
+    async def test_no_token_closes_with_4001(self) -> None:
+        """Closes with 4001 when no token is provided."""
         ws = AsyncMock(spec=WebSocket)
-        mock_sm, _ = _mock_db_context(project_exists=False)
+        await ontology_index_websocket(ws, PROJECT_UUID, token=None)
+        ws.close.assert_awaited_once_with(code=4001, reason="Authentication required")
 
-        with patch("ontokit.api.routes.projects.async_session_maker", mock_sm):
-            await ontology_index_websocket(ws, PROJECT_UUID)
+    @pytest.mark.asyncio
+    async def test_invalid_token_closes_with_4001(self) -> None:
+        """Closes with 4001 when token validation fails."""
+        ws = AsyncMock(spec=WebSocket)
+        mock_validate = AsyncMock(side_effect=ValueError("bad token"))
 
-        ws.close.assert_awaited_once_with(code=4004, reason="Project not found")
+        with patch("ontokit.core.auth.validate_token", mock_validate):
+            await ontology_index_websocket(ws, PROJECT_UUID, token="bad-token")
+
+        ws.close.assert_awaited_once_with(code=4001, reason="Invalid or expired token")
+
+    @pytest.mark.asyncio
+    async def test_project_not_found_closes_with_4004(self) -> None:
+        """Closes with 4004 when project access is denied."""
+        ws = AsyncMock(spec=WebSocket)
+        mock_validate, mock_svc = _mock_auth_and_project(project_exists=False)
+
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=AsyncMock())
+        mock_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch("ontokit.core.auth.validate_token", mock_validate),
+            patch("ontokit.core.auth.fetch_userinfo", AsyncMock(return_value=None)),
+            patch("ontokit.api.routes.projects.async_session_maker", Mock(return_value=mock_ctx)),
+            patch("ontokit.api.routes.projects.ProjectService", return_value=mock_svc),
+        ):
+            await ontology_index_websocket(ws, PROJECT_UUID, token=FAKE_TOKEN)
+
+        ws.close.assert_awaited_once_with(code=4004, reason="Project not found or access denied")
 
     @pytest.mark.asyncio
     async def test_connects_and_forwards_matching_message(self) -> None:
         """Forwards messages matching the project_id."""
         ws = AsyncMock(spec=WebSocket)
-        # After first pubsub cycle returns None, receive_text raises disconnect
         ws.receive_text = AsyncMock(side_effect=WebSocketDisconnect(code=1000))
 
-        mock_sm, _ = _mock_db_context(project_exists=True)
+        mock_validate, mock_svc = _mock_auth_and_project(project_exists=True)
         index_msg = {"type": "index_complete", "project_id": PROJECT_ID, "entity_count": 100}
         mock_pool, mock_pubsub = _mock_pubsub([index_msg])
+
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=AsyncMock())
+        mock_ctx.__aexit__ = AsyncMock(return_value=False)
 
         mock_mgr = AsyncMock()
 
         with (
-            patch("ontokit.api.routes.projects.async_session_maker", mock_sm),
+            patch("ontokit.core.auth.validate_token", mock_validate),
+            patch("ontokit.core.auth.fetch_userinfo", AsyncMock(return_value=None)),
+            patch("ontokit.api.routes.projects.async_session_maker", Mock(return_value=mock_ctx)),
+            patch("ontokit.api.routes.projects.ProjectService", return_value=mock_svc),
             patch("ontokit.api.routes.projects.get_arq_pool", return_value=mock_pool),
             patch("ontokit.api.routes.projects.index_ws_manager", mock_mgr),
         ):
-            await ontology_index_websocket(ws, PROJECT_UUID)
+            await ontology_index_websocket(ws, PROJECT_UUID, token=FAKE_TOKEN)
 
         mock_mgr.connect.assert_awaited_once()
         ws.send_json.assert_awaited_once_with(index_msg)
@@ -171,16 +213,23 @@ class TestOntologyIndexWebSocketUnit:
         ws = AsyncMock(spec=WebSocket)
         ws.receive_text = AsyncMock(side_effect=WebSocketDisconnect(code=1000))
 
-        mock_sm, _ = _mock_db_context(project_exists=True)
+        mock_validate, mock_svc = _mock_auth_and_project(project_exists=True)
         other_msg = {"type": "index_complete", "project_id": "other-project"}
         mock_pool, _ = _mock_pubsub([other_msg])
 
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=AsyncMock())
+        mock_ctx.__aexit__ = AsyncMock(return_value=False)
+
         with (
-            patch("ontokit.api.routes.projects.async_session_maker", mock_sm),
+            patch("ontokit.core.auth.validate_token", mock_validate),
+            patch("ontokit.core.auth.fetch_userinfo", AsyncMock(return_value=None)),
+            patch("ontokit.api.routes.projects.async_session_maker", Mock(return_value=mock_ctx)),
+            patch("ontokit.api.routes.projects.ProjectService", return_value=mock_svc),
             patch("ontokit.api.routes.projects.get_arq_pool", return_value=mock_pool),
             patch("ontokit.api.routes.projects.index_ws_manager", AsyncMock()),
         ):
-            await ontology_index_websocket(ws, PROJECT_UUID)
+            await ontology_index_websocket(ws, PROJECT_UUID, token=FAKE_TOKEN)
 
         ws.send_json.assert_not_awaited()
 
@@ -188,19 +237,25 @@ class TestOntologyIndexWebSocketUnit:
     async def test_handles_malformed_json(self) -> None:
         """Skips malformed JSON without crashing, delivers valid ones."""
         ws = AsyncMock(spec=WebSocket)
-        # First iteration: TimeoutError (loop continues), second: disconnect
         ws.receive_text = AsyncMock(side_effect=[TimeoutError, WebSocketDisconnect(code=1000)])
 
-        mock_sm, _ = _mock_db_context(project_exists=True)
+        mock_validate, mock_svc = _mock_auth_and_project(project_exists=True)
         valid_msg = {"type": "index_started", "project_id": PROJECT_ID}
         mock_pool, _ = _mock_pubsub(["not valid json{{{", valid_msg])
 
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=AsyncMock())
+        mock_ctx.__aexit__ = AsyncMock(return_value=False)
+
         with (
-            patch("ontokit.api.routes.projects.async_session_maker", mock_sm),
+            patch("ontokit.core.auth.validate_token", mock_validate),
+            patch("ontokit.core.auth.fetch_userinfo", AsyncMock(return_value=None)),
+            patch("ontokit.api.routes.projects.async_session_maker", Mock(return_value=mock_ctx)),
+            patch("ontokit.api.routes.projects.ProjectService", return_value=mock_svc),
             patch("ontokit.api.routes.projects.get_arq_pool", return_value=mock_pool),
             patch("ontokit.api.routes.projects.index_ws_manager", AsyncMock()),
         ):
-            await ontology_index_websocket(ws, PROJECT_UUID)
+            await ontology_index_websocket(ws, PROJECT_UUID, token=FAKE_TOKEN)
 
         ws.send_json.assert_awaited_once_with(valid_msg)
 
@@ -209,20 +264,27 @@ class TestOntologyIndexWebSocketUnit:
         """Disconnects and unsubscribes even on unexpected errors."""
         ws = AsyncMock(spec=WebSocket)
 
-        mock_sm, _ = _mock_db_context(project_exists=True)
+        mock_validate, mock_svc = _mock_auth_and_project(project_exists=True)
         mock_pubsub = AsyncMock()
         mock_pubsub.get_message = AsyncMock(side_effect=RuntimeError("Redis down"))
         mock_pool = AsyncMock()
         mock_pool.pubsub = Mock(return_value=mock_pubsub)
 
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=AsyncMock())
+        mock_ctx.__aexit__ = AsyncMock(return_value=False)
+
         mock_mgr = AsyncMock()
 
         with (
-            patch("ontokit.api.routes.projects.async_session_maker", mock_sm),
+            patch("ontokit.core.auth.validate_token", mock_validate),
+            patch("ontokit.core.auth.fetch_userinfo", AsyncMock(return_value=None)),
+            patch("ontokit.api.routes.projects.async_session_maker", Mock(return_value=mock_ctx)),
+            patch("ontokit.api.routes.projects.ProjectService", return_value=mock_svc),
             patch("ontokit.api.routes.projects.get_arq_pool", return_value=mock_pool),
             patch("ontokit.api.routes.projects.index_ws_manager", mock_mgr),
         ):
-            await ontology_index_websocket(ws, PROJECT_UUID)
+            await ontology_index_websocket(ws, PROJECT_UUID, token=FAKE_TOKEN)
 
         mock_mgr.disconnect.assert_called_once()
         mock_pubsub.unsubscribe.assert_awaited()

--- a/tests/unit/test_index_ws.py
+++ b/tests/unit/test_index_ws.py
@@ -18,7 +18,6 @@ from ontokit.api.routes.projects import (
 
 PROJECT_ID = "12345678-1234-5678-1234-567812345678"
 PROJECT_UUID = UUID(PROJECT_ID)
-FAKE_TOKEN = "fake-jwt-token"
 
 
 # ---------------------------------------------------------------------------
@@ -79,34 +78,6 @@ class TestIndexConnectionManager:
 # ---------------------------------------------------------------------------
 
 
-def _fake_token_payload() -> Mock:
-    """Return a mock TokenPayload from validate_token."""
-    payload = Mock()
-    payload.sub = "user-1"
-    payload.name = "Test User"
-    payload.email = "test@example.com"
-    payload.preferred_username = "testuser"
-    payload.roles = ["owner"]
-    return payload
-
-
-def _mock_auth_and_project(
-    project_exists: bool = True,
-) -> tuple[AsyncMock, AsyncMock]:
-    """Return (mock_validate_token, mock_project_service_cls) patches."""
-    mock_validate = AsyncMock(return_value=_fake_token_payload())
-
-    mock_svc = AsyncMock()
-    if project_exists:
-        mock_svc.get.return_value = Mock()  # project response
-    else:
-        from fastapi import HTTPException
-
-        mock_svc.get.side_effect = HTTPException(status_code=404, detail="Not found")
-
-    return mock_validate, mock_svc
-
-
 def _mock_pubsub(messages: list[Any]) -> tuple[AsyncMock, AsyncMock]:
     """Return (mock_pool, mock_pubsub) that delivers messages then returns None."""
     call_count = 0
@@ -131,76 +102,43 @@ def _mock_pubsub(messages: list[Any]) -> tuple[AsyncMock, AsyncMock]:
 
 
 # ---------------------------------------------------------------------------
-# ontology_index_websocket async unit tests
+# ontology_index_websocket tests (auth delegated to authenticate_ws)
 # ---------------------------------------------------------------------------
 
 
 class TestOntologyIndexWebSocketUnit:
-    """Direct async tests for ontology_index_websocket function."""
+    """Tests for ontology_index_websocket message handling."""
 
     @pytest.mark.asyncio
-    async def test_no_token_closes_with_4001(self) -> None:
-        """Closes with 4001 when no token is provided."""
+    async def test_auth_failure_returns_early(self) -> None:
+        """Returns without connecting when authenticate_ws returns False."""
         ws = AsyncMock(spec=WebSocket)
-        await ontology_index_websocket(ws, PROJECT_UUID, token=None)
-        ws.close.assert_awaited_once_with(code=4001, reason="Authentication required")
-
-    @pytest.mark.asyncio
-    async def test_invalid_token_closes_with_4001(self) -> None:
-        """Closes with 4001 when token validation fails."""
-        ws = AsyncMock(spec=WebSocket)
-        mock_validate = AsyncMock(side_effect=ValueError("bad token"))
-
-        with patch("ontokit.core.auth.validate_token", mock_validate):
-            await ontology_index_websocket(ws, PROJECT_UUID, token="bad-token")
-
-        ws.close.assert_awaited_once_with(code=4001, reason="Invalid or expired token")
-
-    @pytest.mark.asyncio
-    async def test_project_not_found_closes_with_4004(self) -> None:
-        """Closes with 4004 when project access is denied."""
-        ws = AsyncMock(spec=WebSocket)
-        mock_validate, mock_svc = _mock_auth_and_project(project_exists=False)
-
-        mock_ctx = AsyncMock()
-        mock_ctx.__aenter__ = AsyncMock(return_value=AsyncMock())
-        mock_ctx.__aexit__ = AsyncMock(return_value=False)
-
-        with (
-            patch("ontokit.core.auth.validate_token", mock_validate),
-            patch("ontokit.core.auth.fetch_userinfo", AsyncMock(return_value=None)),
-            patch("ontokit.api.routes.projects.async_session_maker", Mock(return_value=mock_ctx)),
-            patch("ontokit.api.routes.projects.ProjectService", return_value=mock_svc),
-        ):
-            await ontology_index_websocket(ws, PROJECT_UUID, token=FAKE_TOKEN)
-
-        ws.close.assert_awaited_once_with(code=4004, reason="Project not found or access denied")
-
-    @pytest.mark.asyncio
-    async def test_connects_and_forwards_matching_message(self) -> None:
-        """Forwards messages matching the project_id."""
-        ws = AsyncMock(spec=WebSocket)
-        ws.receive_text = AsyncMock(side_effect=WebSocketDisconnect(code=1000))
-
-        mock_validate, mock_svc = _mock_auth_and_project(project_exists=True)
-        index_msg = {"type": "index_complete", "project_id": PROJECT_ID, "entity_count": 100}
-        mock_pool, mock_pubsub = _mock_pubsub([index_msg])
-
-        mock_ctx = AsyncMock()
-        mock_ctx.__aenter__ = AsyncMock(return_value=AsyncMock())
-        mock_ctx.__aexit__ = AsyncMock(return_value=False)
-
+        mock_auth = AsyncMock(return_value=False)
         mock_mgr = AsyncMock()
 
         with (
-            patch("ontokit.core.auth.validate_token", mock_validate),
-            patch("ontokit.core.auth.fetch_userinfo", AsyncMock(return_value=None)),
-            patch("ontokit.api.routes.projects.async_session_maker", Mock(return_value=mock_ctx)),
-            patch("ontokit.api.routes.projects.ProjectService", return_value=mock_svc),
+            patch("ontokit.api.utils.ws_auth.authenticate_ws", mock_auth),
+            patch("ontokit.api.routes.projects.index_ws_manager", mock_mgr),
+        ):
+            await ontology_index_websocket(ws, PROJECT_UUID, token="t")
+
+        mock_mgr.connect.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_connects_and_forwards_matching_message(self) -> None:
+        ws = AsyncMock(spec=WebSocket)
+        ws.receive_text = AsyncMock(side_effect=WebSocketDisconnect(code=1000))
+
+        index_msg = {"type": "index_complete", "project_id": PROJECT_ID, "entity_count": 100}
+        mock_pool, mock_pubsub = _mock_pubsub([index_msg])
+        mock_mgr = AsyncMock()
+
+        with (
+            patch("ontokit.api.utils.ws_auth.authenticate_ws", AsyncMock(return_value=True)),
             patch("ontokit.api.routes.projects.get_arq_pool", return_value=mock_pool),
             patch("ontokit.api.routes.projects.index_ws_manager", mock_mgr),
         ):
-            await ontology_index_websocket(ws, PROJECT_UUID, token=FAKE_TOKEN)
+            await ontology_index_websocket(ws, PROJECT_UUID, token="t")
 
         mock_mgr.connect.assert_awaited_once()
         ws.send_json.assert_awaited_once_with(index_msg)
@@ -209,82 +147,54 @@ class TestOntologyIndexWebSocketUnit:
 
     @pytest.mark.asyncio
     async def test_skips_messages_for_other_projects(self) -> None:
-        """Does not forward messages for other project IDs."""
         ws = AsyncMock(spec=WebSocket)
         ws.receive_text = AsyncMock(side_effect=WebSocketDisconnect(code=1000))
 
-        mock_validate, mock_svc = _mock_auth_and_project(project_exists=True)
         other_msg = {"type": "index_complete", "project_id": "other-project"}
         mock_pool, _ = _mock_pubsub([other_msg])
 
-        mock_ctx = AsyncMock()
-        mock_ctx.__aenter__ = AsyncMock(return_value=AsyncMock())
-        mock_ctx.__aexit__ = AsyncMock(return_value=False)
-
         with (
-            patch("ontokit.core.auth.validate_token", mock_validate),
-            patch("ontokit.core.auth.fetch_userinfo", AsyncMock(return_value=None)),
-            patch("ontokit.api.routes.projects.async_session_maker", Mock(return_value=mock_ctx)),
-            patch("ontokit.api.routes.projects.ProjectService", return_value=mock_svc),
+            patch("ontokit.api.utils.ws_auth.authenticate_ws", AsyncMock(return_value=True)),
             patch("ontokit.api.routes.projects.get_arq_pool", return_value=mock_pool),
             patch("ontokit.api.routes.projects.index_ws_manager", AsyncMock()),
         ):
-            await ontology_index_websocket(ws, PROJECT_UUID, token=FAKE_TOKEN)
+            await ontology_index_websocket(ws, PROJECT_UUID, token="t")
 
         ws.send_json.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_handles_malformed_json(self) -> None:
-        """Skips malformed JSON without crashing, delivers valid ones."""
         ws = AsyncMock(spec=WebSocket)
         ws.receive_text = AsyncMock(side_effect=[TimeoutError, WebSocketDisconnect(code=1000)])
 
-        mock_validate, mock_svc = _mock_auth_and_project(project_exists=True)
         valid_msg = {"type": "index_started", "project_id": PROJECT_ID}
         mock_pool, _ = _mock_pubsub(["not valid json{{{", valid_msg])
 
-        mock_ctx = AsyncMock()
-        mock_ctx.__aenter__ = AsyncMock(return_value=AsyncMock())
-        mock_ctx.__aexit__ = AsyncMock(return_value=False)
-
         with (
-            patch("ontokit.core.auth.validate_token", mock_validate),
-            patch("ontokit.core.auth.fetch_userinfo", AsyncMock(return_value=None)),
-            patch("ontokit.api.routes.projects.async_session_maker", Mock(return_value=mock_ctx)),
-            patch("ontokit.api.routes.projects.ProjectService", return_value=mock_svc),
+            patch("ontokit.api.utils.ws_auth.authenticate_ws", AsyncMock(return_value=True)),
             patch("ontokit.api.routes.projects.get_arq_pool", return_value=mock_pool),
             patch("ontokit.api.routes.projects.index_ws_manager", AsyncMock()),
         ):
-            await ontology_index_websocket(ws, PROJECT_UUID, token=FAKE_TOKEN)
+            await ontology_index_websocket(ws, PROJECT_UUID, token="t")
 
         ws.send_json.assert_awaited_once_with(valid_msg)
 
     @pytest.mark.asyncio
     async def test_cleans_up_on_exception(self) -> None:
-        """Disconnects and unsubscribes even on unexpected errors."""
         ws = AsyncMock(spec=WebSocket)
 
-        mock_validate, mock_svc = _mock_auth_and_project(project_exists=True)
         mock_pubsub = AsyncMock()
         mock_pubsub.get_message = AsyncMock(side_effect=RuntimeError("Redis down"))
         mock_pool = AsyncMock()
         mock_pool.pubsub = Mock(return_value=mock_pubsub)
-
-        mock_ctx = AsyncMock()
-        mock_ctx.__aenter__ = AsyncMock(return_value=AsyncMock())
-        mock_ctx.__aexit__ = AsyncMock(return_value=False)
-
         mock_mgr = AsyncMock()
 
         with (
-            patch("ontokit.core.auth.validate_token", mock_validate),
-            patch("ontokit.core.auth.fetch_userinfo", AsyncMock(return_value=None)),
-            patch("ontokit.api.routes.projects.async_session_maker", Mock(return_value=mock_ctx)),
-            patch("ontokit.api.routes.projects.ProjectService", return_value=mock_svc),
+            patch("ontokit.api.utils.ws_auth.authenticate_ws", AsyncMock(return_value=True)),
             patch("ontokit.api.routes.projects.get_arq_pool", return_value=mock_pool),
             patch("ontokit.api.routes.projects.index_ws_manager", mock_mgr),
         ):
-            await ontology_index_websocket(ws, PROJECT_UUID, token=FAKE_TOKEN)
+            await ontology_index_websocket(ws, PROJECT_UUID, token="t")
 
         mock_mgr.disconnect.assert_called_once()
         mock_pubsub.unsubscribe.assert_awaited()

--- a/tests/unit/test_index_ws.py
+++ b/tests/unit/test_index_ws.py
@@ -33,7 +33,6 @@ class TestIndexConnectionManager:
         mgr = IndexConnectionManager()
         ws = AsyncMock(spec=WebSocket)
         await mgr.connect(ws, "proj")
-        ws.accept.assert_awaited_once()
         assert ws in mgr.active_connections["proj"]
 
     @pytest.mark.asyncio

--- a/tests/unit/test_index_ws.py
+++ b/tests/unit/test_index_ws.py
@@ -1,0 +1,127 @@
+"""Tests for IndexConnectionManager and ontology_index_websocket endpoint."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from fastapi import WebSocket
+from fastapi.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
+
+from ontokit.api.routes.projects import IndexConnectionManager
+
+PROJECT_ID = "12345678-1234-5678-1234-567812345678"
+
+
+# ---------------------------------------------------------------------------
+# IndexConnectionManager unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestIndexConnectionManager:
+    """Tests for IndexConnectionManager connect/disconnect."""
+
+    @pytest.mark.asyncio
+    async def test_connect_adds_websocket(self) -> None:
+        """connect() accepts the websocket and adds it to active_connections."""
+        mgr = IndexConnectionManager()
+        ws = AsyncMock(spec=WebSocket)
+        project_id = "test-project"
+
+        await mgr.connect(ws, project_id)
+
+        ws.accept.assert_awaited_once()
+        assert ws in mgr.active_connections[project_id]
+
+    @pytest.mark.asyncio
+    async def test_connect_multiple_to_same_project(self) -> None:
+        """connect() adds multiple websockets to the same project."""
+        mgr = IndexConnectionManager()
+        ws1 = AsyncMock(spec=WebSocket)
+        ws2 = AsyncMock(spec=WebSocket)
+        project_id = "test-project"
+
+        await mgr.connect(ws1, project_id)
+        await mgr.connect(ws2, project_id)
+
+        assert len(mgr.active_connections[project_id]) == 2
+
+    def test_disconnect_removes_websocket(self) -> None:
+        """disconnect() removes the websocket from active connections."""
+        mgr = IndexConnectionManager()
+        ws = Mock(spec=WebSocket)
+        project_id = "test-project"
+
+        mgr.active_connections[project_id] = [ws]
+
+        mgr.disconnect(ws, project_id)
+        assert project_id not in mgr.active_connections
+
+    def test_disconnect_keeps_other_connections(self) -> None:
+        """disconnect() only removes the specific websocket, keeps others."""
+        mgr = IndexConnectionManager()
+        ws1 = Mock(spec=WebSocket)
+        ws2 = Mock(spec=WebSocket)
+        project_id = "test-project"
+
+        mgr.active_connections[project_id] = [ws1, ws2]
+
+        mgr.disconnect(ws1, project_id)
+        assert mgr.active_connections[project_id] == [ws2]
+
+    def test_disconnect_nonexistent_project(self) -> None:
+        """disconnect() is a no-op if the project has no connections."""
+        mgr = IndexConnectionManager()
+        ws = Mock(spec=WebSocket)
+
+        # Should not raise
+        mgr.disconnect(ws, "nonexistent")
+        assert "nonexistent" not in mgr.active_connections
+
+    def test_disconnect_websocket_not_in_list(self) -> None:
+        """disconnect() is a no-op when websocket is not in the connection list."""
+        mgr = IndexConnectionManager()
+        ws1 = Mock(spec=WebSocket)
+        ws2 = Mock(spec=WebSocket)
+        project_id = "test-project"
+
+        mgr.active_connections[project_id] = [ws1]
+        # Disconnect ws2 which is not in the list - should not raise
+        mgr.disconnect(ws2, project_id)
+        assert mgr.active_connections[project_id] == [ws1]
+
+
+# ---------------------------------------------------------------------------
+# WebSocket endpoint integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestOntologyIndexWebSocket:
+    """Tests for the ontology_index_websocket endpoint via TestClient."""
+
+    def test_ws_project_not_found_closes_with_4004(
+        self,
+        authed_client: tuple[TestClient, AsyncMock],
+    ) -> None:
+        """WebSocket is closed with code 4004 when project doesn't exist."""
+        from unittest.mock import patch
+
+        client, mock_session = authed_client
+
+        # DB query returns no project
+        mock_result = Mock()
+        mock_result.scalar_one_or_none.return_value = None
+
+        with patch("ontokit.api.routes.projects.async_session_maker") as mock_session_maker:
+            mock_ctx = AsyncMock()
+            mock_ctx.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_ctx.__aexit__ = AsyncMock(return_value=False)
+            mock_session_maker.return_value = mock_ctx
+            mock_session.execute.return_value = mock_result
+
+            with (
+                pytest.raises(WebSocketDisconnect),
+                client.websocket_connect(f"/api/v1/projects/{PROJECT_ID}/ontology/index-ws"),
+            ):
+                pass  # pragma: no cover

--- a/tests/unit/test_index_ws.py
+++ b/tests/unit/test_index_ws.py
@@ -2,16 +2,22 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, Mock
+import json
+from typing import Any
+from unittest.mock import AsyncMock, Mock, patch
+from uuid import UUID
 
 import pytest
 from fastapi import WebSocket
-from fastapi.testclient import TestClient
 from starlette.websockets import WebSocketDisconnect
 
-from ontokit.api.routes.projects import IndexConnectionManager
+from ontokit.api.routes.projects import (
+    IndexConnectionManager,
+    ontology_index_websocket,
+)
 
 PROJECT_ID = "12345678-1234-5678-1234-567812345678"
+PROJECT_UUID = UUID(PROJECT_ID)
 
 
 # ---------------------------------------------------------------------------
@@ -24,104 +30,199 @@ class TestIndexConnectionManager:
 
     @pytest.mark.asyncio
     async def test_connect_adds_websocket(self) -> None:
-        """connect() accepts the websocket and adds it to active_connections."""
         mgr = IndexConnectionManager()
         ws = AsyncMock(spec=WebSocket)
-        project_id = "test-project"
-
-        await mgr.connect(ws, project_id)
-
+        await mgr.connect(ws, "proj")
         ws.accept.assert_awaited_once()
-        assert ws in mgr.active_connections[project_id]
+        assert ws in mgr.active_connections["proj"]
 
     @pytest.mark.asyncio
     async def test_connect_multiple_to_same_project(self) -> None:
-        """connect() adds multiple websockets to the same project."""
         mgr = IndexConnectionManager()
         ws1 = AsyncMock(spec=WebSocket)
         ws2 = AsyncMock(spec=WebSocket)
-        project_id = "test-project"
-
-        await mgr.connect(ws1, project_id)
-        await mgr.connect(ws2, project_id)
-
-        assert len(mgr.active_connections[project_id]) == 2
+        await mgr.connect(ws1, "proj")
+        await mgr.connect(ws2, "proj")
+        assert len(mgr.active_connections["proj"]) == 2
 
     def test_disconnect_removes_websocket(self) -> None:
-        """disconnect() removes the websocket from active connections."""
         mgr = IndexConnectionManager()
         ws = Mock(spec=WebSocket)
-        project_id = "test-project"
-
-        mgr.active_connections[project_id] = [ws]
-
-        mgr.disconnect(ws, project_id)
-        assert project_id not in mgr.active_connections
+        mgr.active_connections["proj"] = [ws]
+        mgr.disconnect(ws, "proj")
+        assert "proj" not in mgr.active_connections
 
     def test_disconnect_keeps_other_connections(self) -> None:
-        """disconnect() only removes the specific websocket, keeps others."""
         mgr = IndexConnectionManager()
         ws1 = Mock(spec=WebSocket)
         ws2 = Mock(spec=WebSocket)
-        project_id = "test-project"
-
-        mgr.active_connections[project_id] = [ws1, ws2]
-
-        mgr.disconnect(ws1, project_id)
-        assert mgr.active_connections[project_id] == [ws2]
+        mgr.active_connections["proj"] = [ws1, ws2]
+        mgr.disconnect(ws1, "proj")
+        assert mgr.active_connections["proj"] == [ws2]
 
     def test_disconnect_nonexistent_project(self) -> None:
-        """disconnect() is a no-op if the project has no connections."""
         mgr = IndexConnectionManager()
-        ws = Mock(spec=WebSocket)
-
-        # Should not raise
-        mgr.disconnect(ws, "nonexistent")
-        assert "nonexistent" not in mgr.active_connections
+        mgr.disconnect(Mock(spec=WebSocket), "nonexistent")
 
     def test_disconnect_websocket_not_in_list(self) -> None:
-        """disconnect() is a no-op when websocket is not in the connection list."""
         mgr = IndexConnectionManager()
         ws1 = Mock(spec=WebSocket)
         ws2 = Mock(spec=WebSocket)
-        project_id = "test-project"
-
-        mgr.active_connections[project_id] = [ws1]
-        # Disconnect ws2 which is not in the list - should not raise
-        mgr.disconnect(ws2, project_id)
-        assert mgr.active_connections[project_id] == [ws1]
+        mgr.active_connections["proj"] = [ws1]
+        mgr.disconnect(ws2, "proj")
+        assert mgr.active_connections["proj"] == [ws1]
 
 
 # ---------------------------------------------------------------------------
-# WebSocket endpoint integration tests
+# Helper: mock DB context manager
 # ---------------------------------------------------------------------------
 
 
-class TestOntologyIndexWebSocket:
-    """Tests for the ontology_index_websocket endpoint via TestClient."""
-
-    def test_ws_project_not_found_closes_with_4004(
-        self,
-        authed_client: tuple[TestClient, AsyncMock],
-    ) -> None:
-        """WebSocket is closed with code 4004 when project doesn't exist."""
-        from unittest.mock import patch
-
-        client, mock_session = authed_client
-
-        # DB query returns no project
-        mock_result = Mock()
+def _mock_db_context(project_exists: bool = True) -> tuple[AsyncMock, AsyncMock]:
+    """Return (mock_session_maker, mock_db) with project query configured."""
+    mock_db = AsyncMock()
+    mock_result = Mock()
+    if project_exists:
+        mock_project = Mock()
+        mock_project.id = PROJECT_ID
+        mock_result.scalar_one_or_none.return_value = mock_project
+    else:
         mock_result.scalar_one_or_none.return_value = None
+    mock_db.execute.return_value = mock_result
 
-        with patch("ontokit.api.routes.projects.async_session_maker") as mock_session_maker:
-            mock_ctx = AsyncMock()
-            mock_ctx.__aenter__ = AsyncMock(return_value=mock_session)
-            mock_ctx.__aexit__ = AsyncMock(return_value=False)
-            mock_session_maker.return_value = mock_ctx
-            mock_session.execute.return_value = mock_result
+    mock_ctx = AsyncMock()
+    mock_ctx.__aenter__ = AsyncMock(return_value=mock_db)
+    mock_ctx.__aexit__ = AsyncMock(return_value=False)
+    mock_session_maker = Mock(return_value=mock_ctx)
+    return mock_session_maker, mock_db
 
-            with (
-                pytest.raises(WebSocketDisconnect),
-                client.websocket_connect(f"/api/v1/projects/{PROJECT_ID}/ontology/index-ws"),
-            ):
-                pass  # pragma: no cover
+
+def _mock_pubsub(messages: list[Any]) -> tuple[AsyncMock, AsyncMock]:
+    """Return (mock_pool, mock_pubsub) that delivers messages then returns None."""
+    call_count = 0
+
+    async def fake_get_message(
+        ignore_subscribe_messages: bool = True,  # noqa: ARG001
+        timeout: float = 0.1,  # noqa: ARG001
+    ) -> dict[str, Any] | None:
+        nonlocal call_count
+        call_count += 1
+        if call_count <= len(messages):
+            msg = messages[call_count - 1]
+            data = json.dumps(msg) if isinstance(msg, dict) else msg
+            return {"type": "message", "data": data}
+        return None
+
+    mock_pubsub = AsyncMock()
+    mock_pubsub.get_message = fake_get_message
+    mock_pool = AsyncMock()
+    # pubsub() is a sync method that returns the PubSub object
+    mock_pool.pubsub = Mock(return_value=mock_pubsub)
+    return mock_pool, mock_pubsub
+
+
+# ---------------------------------------------------------------------------
+# ontology_index_websocket async unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestOntologyIndexWebSocketUnit:
+    """Direct async tests for ontology_index_websocket function."""
+
+    @pytest.mark.asyncio
+    async def test_project_not_found_closes_ws(self) -> None:
+        """Closes with 4004 when project doesn't exist."""
+        ws = AsyncMock(spec=WebSocket)
+        mock_sm, _ = _mock_db_context(project_exists=False)
+
+        with patch("ontokit.api.routes.projects.async_session_maker", mock_sm):
+            await ontology_index_websocket(ws, PROJECT_UUID)
+
+        ws.close.assert_awaited_once_with(code=4004, reason="Project not found")
+
+    @pytest.mark.asyncio
+    async def test_connects_and_forwards_matching_message(self) -> None:
+        """Forwards messages matching the project_id."""
+        ws = AsyncMock(spec=WebSocket)
+        # After first pubsub cycle returns None, receive_text raises disconnect
+        ws.receive_text = AsyncMock(side_effect=WebSocketDisconnect(code=1000))
+
+        mock_sm, _ = _mock_db_context(project_exists=True)
+        index_msg = {"type": "index_complete", "project_id": PROJECT_ID, "entity_count": 100}
+        mock_pool, mock_pubsub = _mock_pubsub([index_msg])
+
+        mock_mgr = AsyncMock()
+
+        with (
+            patch("ontokit.api.routes.projects.async_session_maker", mock_sm),
+            patch("ontokit.api.routes.projects.get_arq_pool", return_value=mock_pool),
+            patch("ontokit.api.routes.projects.index_ws_manager", mock_mgr),
+        ):
+            await ontology_index_websocket(ws, PROJECT_UUID)
+
+        mock_mgr.connect.assert_awaited_once()
+        ws.send_json.assert_awaited_once_with(index_msg)
+        mock_mgr.disconnect.assert_called_once()
+        mock_pubsub.unsubscribe.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_skips_messages_for_other_projects(self) -> None:
+        """Does not forward messages for other project IDs."""
+        ws = AsyncMock(spec=WebSocket)
+        ws.receive_text = AsyncMock(side_effect=WebSocketDisconnect(code=1000))
+
+        mock_sm, _ = _mock_db_context(project_exists=True)
+        other_msg = {"type": "index_complete", "project_id": "other-project"}
+        mock_pool, _ = _mock_pubsub([other_msg])
+
+        with (
+            patch("ontokit.api.routes.projects.async_session_maker", mock_sm),
+            patch("ontokit.api.routes.projects.get_arq_pool", return_value=mock_pool),
+            patch("ontokit.api.routes.projects.index_ws_manager", AsyncMock()),
+        ):
+            await ontology_index_websocket(ws, PROJECT_UUID)
+
+        ws.send_json.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_handles_malformed_json(self) -> None:
+        """Skips malformed JSON without crashing, delivers valid ones."""
+        ws = AsyncMock(spec=WebSocket)
+        # First iteration: TimeoutError (loop continues), second: disconnect
+        ws.receive_text = AsyncMock(side_effect=[TimeoutError, WebSocketDisconnect(code=1000)])
+
+        mock_sm, _ = _mock_db_context(project_exists=True)
+        valid_msg = {"type": "index_started", "project_id": PROJECT_ID}
+        mock_pool, _ = _mock_pubsub(["not valid json{{{", valid_msg])
+
+        with (
+            patch("ontokit.api.routes.projects.async_session_maker", mock_sm),
+            patch("ontokit.api.routes.projects.get_arq_pool", return_value=mock_pool),
+            patch("ontokit.api.routes.projects.index_ws_manager", AsyncMock()),
+        ):
+            await ontology_index_websocket(ws, PROJECT_UUID)
+
+        ws.send_json.assert_awaited_once_with(valid_msg)
+
+    @pytest.mark.asyncio
+    async def test_cleans_up_on_exception(self) -> None:
+        """Disconnects and unsubscribes even on unexpected errors."""
+        ws = AsyncMock(spec=WebSocket)
+
+        mock_sm, _ = _mock_db_context(project_exists=True)
+        mock_pubsub = AsyncMock()
+        mock_pubsub.get_message = AsyncMock(side_effect=RuntimeError("Redis down"))
+        mock_pool = AsyncMock()
+        mock_pool.pubsub = Mock(return_value=mock_pubsub)
+
+        mock_mgr = AsyncMock()
+
+        with (
+            patch("ontokit.api.routes.projects.async_session_maker", mock_sm),
+            patch("ontokit.api.routes.projects.get_arq_pool", return_value=mock_pool),
+            patch("ontokit.api.routes.projects.index_ws_manager", mock_mgr),
+        ):
+            await ontology_index_websocket(ws, PROJECT_UUID)
+
+        mock_mgr.disconnect.assert_called_once()
+        mock_pubsub.unsubscribe.assert_awaited()

--- a/tests/unit/test_lint_routes_extended.py
+++ b/tests/unit/test_lint_routes_extended.py
@@ -379,14 +379,13 @@ class TestLintConnectionManager:
 
     @pytest.mark.asyncio
     async def test_connect_adds_websocket(self) -> None:
-        """connect() accepts the websocket and adds it to active_connections."""
+        """connect() adds the websocket to active_connections."""
         mgr = LintConnectionManager()
         ws = AsyncMock(spec=WebSocket)
         project_id = "test-project"
 
         await mgr.connect(ws, project_id)
 
-        ws.accept.assert_awaited_once()
         assert ws in mgr.active_connections[project_id]
 
     @pytest.mark.asyncio

--- a/tests/unit/test_lint_ws.py
+++ b/tests/unit/test_lint_ws.py
@@ -1,0 +1,208 @@
+"""Tests for lint_websocket endpoint authentication and message forwarding."""
+
+from __future__ import annotations
+
+import contextlib
+import json
+from typing import Any
+from unittest.mock import AsyncMock, Mock, patch
+from uuid import UUID
+
+import pytest
+from fastapi import WebSocket
+from starlette.websockets import WebSocketDisconnect
+
+from ontokit.api.routes.lint import lint_websocket
+
+PROJECT_ID = "12345678-1234-5678-1234-567812345678"
+PROJECT_UUID = UUID(PROJECT_ID)
+FAKE_TOKEN = "fake-jwt-token"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _fake_token_payload() -> Mock:
+    payload = Mock()
+    payload.sub = "user-1"
+    payload.name = "Test User"
+    payload.email = "test@example.com"
+    payload.preferred_username = "testuser"
+    payload.roles = ["owner"]
+    return payload
+
+
+def _mock_auth_and_project(
+    project_exists: bool = True,
+) -> tuple[AsyncMock, AsyncMock]:
+    mock_validate = AsyncMock(return_value=_fake_token_payload())
+    mock_svc = AsyncMock()
+    if project_exists:
+        mock_svc.get.return_value = Mock()
+    else:
+        from fastapi import HTTPException
+
+        mock_svc.get.side_effect = HTTPException(status_code=404, detail="Not found")
+    return mock_validate, mock_svc
+
+
+def _mock_pubsub(messages: list[Any]) -> tuple[AsyncMock, AsyncMock]:
+    call_count = 0
+
+    async def fake_get_message(
+        ignore_subscribe_messages: bool = True,  # noqa: ARG001
+        timeout: float = 0.1,  # noqa: ARG001
+    ) -> dict[str, Any] | None:
+        nonlocal call_count
+        call_count += 1
+        if call_count <= len(messages):
+            msg = messages[call_count - 1]
+            data = json.dumps(msg) if isinstance(msg, dict) else msg
+            return {"type": "message", "data": data}
+        return None
+
+    mock_pubsub = AsyncMock()
+    mock_pubsub.get_message = fake_get_message
+    mock_pool = AsyncMock()
+    mock_pool.pubsub = Mock(return_value=mock_pubsub)
+    return mock_pool, mock_pubsub
+
+
+def _enter_auth_patches(
+    stack: contextlib.ExitStack,
+    mock_validate: AsyncMock,
+    mock_svc: AsyncMock,
+) -> None:
+    """Enter auth + project access patches into an ExitStack."""
+    mock_ctx = AsyncMock()
+    mock_ctx.__aenter__ = AsyncMock(return_value=AsyncMock())
+    mock_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    stack.enter_context(patch("ontokit.core.auth.validate_token", mock_validate))
+    stack.enter_context(patch("ontokit.core.auth.fetch_userinfo", AsyncMock(return_value=None)))
+    stack.enter_context(
+        patch("ontokit.api.routes.lint.async_session_maker", Mock(return_value=mock_ctx))
+    )
+    stack.enter_context(
+        patch("ontokit.services.project_service.ProjectService", return_value=mock_svc)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestLintWebSocketAuth:
+    """Tests for lint_websocket authentication."""
+
+    @pytest.mark.asyncio
+    async def test_no_token_closes_with_4001(self) -> None:
+        ws = AsyncMock(spec=WebSocket)
+        await lint_websocket(ws, PROJECT_UUID, token=None)
+        ws.close.assert_awaited_once_with(code=4001, reason="Authentication required")
+
+    @pytest.mark.asyncio
+    async def test_invalid_token_closes_with_4001(self) -> None:
+        ws = AsyncMock(spec=WebSocket)
+        with patch("ontokit.core.auth.validate_token", AsyncMock(side_effect=ValueError("bad"))):
+            await lint_websocket(ws, PROJECT_UUID, token="bad-token")
+        ws.close.assert_awaited_once_with(code=4001, reason="Invalid or expired token")
+
+    @pytest.mark.asyncio
+    async def test_project_not_found_closes_with_4004(self) -> None:
+        ws = AsyncMock(spec=WebSocket)
+        mock_validate, mock_svc = _mock_auth_and_project(project_exists=False)
+        with contextlib.ExitStack() as stack:
+            _enter_auth_patches(stack, mock_validate, mock_svc)
+            await lint_websocket(ws, PROJECT_UUID, token=FAKE_TOKEN)
+        ws.close.assert_awaited_once_with(code=4004, reason="Project not found or access denied")
+
+
+class TestLintWebSocketMessages:
+    """Tests for lint_websocket message forwarding."""
+
+    @pytest.mark.asyncio
+    async def test_connects_and_forwards_matching_message(self) -> None:
+        ws = AsyncMock(spec=WebSocket)
+        ws.receive_text = AsyncMock(side_effect=WebSocketDisconnect(code=1000))
+
+        mock_validate, mock_svc = _mock_auth_and_project(project_exists=True)
+        lint_msg = {"type": "lint_complete", "project_id": PROJECT_ID, "run_id": "r1"}
+        mock_pool, mock_pubsub = _mock_pubsub([lint_msg])
+        mock_mgr = AsyncMock()
+
+        with contextlib.ExitStack() as stack:
+            _enter_auth_patches(stack, mock_validate, mock_svc)
+            stack.enter_context(
+                patch("ontokit.api.routes.lint.get_arq_pool", return_value=mock_pool)
+            )
+            stack.enter_context(patch("ontokit.api.routes.lint.manager", mock_mgr))
+            await lint_websocket(ws, PROJECT_UUID, token=FAKE_TOKEN)
+
+        mock_mgr.connect.assert_awaited_once()
+        ws.send_json.assert_awaited_once_with(lint_msg)
+        mock_mgr.disconnect.assert_called_once()
+        mock_pubsub.unsubscribe.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_skips_messages_for_other_projects(self) -> None:
+        ws = AsyncMock(spec=WebSocket)
+        ws.receive_text = AsyncMock(side_effect=WebSocketDisconnect(code=1000))
+
+        mock_validate, mock_svc = _mock_auth_and_project(project_exists=True)
+        other_msg = {"type": "lint_complete", "project_id": "other-project"}
+        mock_pool, _ = _mock_pubsub([other_msg])
+
+        with contextlib.ExitStack() as stack:
+            _enter_auth_patches(stack, mock_validate, mock_svc)
+            stack.enter_context(
+                patch("ontokit.api.routes.lint.get_arq_pool", return_value=mock_pool)
+            )
+            stack.enter_context(patch("ontokit.api.routes.lint.manager", AsyncMock()))
+            await lint_websocket(ws, PROJECT_UUID, token=FAKE_TOKEN)
+
+        ws.send_json.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_handles_malformed_json(self) -> None:
+        ws = AsyncMock(spec=WebSocket)
+        ws.receive_text = AsyncMock(side_effect=[TimeoutError, WebSocketDisconnect(code=1000)])
+
+        mock_validate, mock_svc = _mock_auth_and_project(project_exists=True)
+        valid_msg = {"type": "lint_started", "project_id": PROJECT_ID}
+        mock_pool, _ = _mock_pubsub(["not valid json{{{", valid_msg])
+
+        with contextlib.ExitStack() as stack:
+            _enter_auth_patches(stack, mock_validate, mock_svc)
+            stack.enter_context(
+                patch("ontokit.api.routes.lint.get_arq_pool", return_value=mock_pool)
+            )
+            stack.enter_context(patch("ontokit.api.routes.lint.manager", AsyncMock()))
+            await lint_websocket(ws, PROJECT_UUID, token=FAKE_TOKEN)
+
+        ws.send_json.assert_awaited_once_with(valid_msg)
+
+    @pytest.mark.asyncio
+    async def test_cleans_up_on_exception(self) -> None:
+        ws = AsyncMock(spec=WebSocket)
+
+        mock_validate, mock_svc = _mock_auth_and_project(project_exists=True)
+        mock_pubsub = AsyncMock()
+        mock_pubsub.get_message = AsyncMock(side_effect=RuntimeError("Redis down"))
+        mock_pool = AsyncMock()
+        mock_pool.pubsub = Mock(return_value=mock_pubsub)
+        mock_mgr = AsyncMock()
+
+        with contextlib.ExitStack() as stack:
+            _enter_auth_patches(stack, mock_validate, mock_svc)
+            stack.enter_context(
+                patch("ontokit.api.routes.lint.get_arq_pool", return_value=mock_pool)
+            )
+            stack.enter_context(patch("ontokit.api.routes.lint.manager", mock_mgr))
+            await lint_websocket(ws, PROJECT_UUID, token=FAKE_TOKEN)
+
+        mock_mgr.disconnect.assert_called_once()
+        mock_pubsub.unsubscribe.assert_awaited()

--- a/tests/unit/test_lint_ws.py
+++ b/tests/unit/test_lint_ws.py
@@ -1,8 +1,7 @@
-"""Tests for lint_websocket endpoint authentication and message forwarding."""
+"""Tests for lint_websocket endpoint message forwarding."""
 
 from __future__ import annotations
 
-import contextlib
 import json
 from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
@@ -16,36 +15,11 @@ from ontokit.api.routes.lint import lint_websocket
 
 PROJECT_ID = "12345678-1234-5678-1234-567812345678"
 PROJECT_UUID = UUID(PROJECT_ID)
-FAKE_TOKEN = "fake-jwt-token"
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-
-def _fake_token_payload() -> Mock:
-    payload = Mock()
-    payload.sub = "user-1"
-    payload.name = "Test User"
-    payload.email = "test@example.com"
-    payload.preferred_username = "testuser"
-    payload.roles = ["owner"]
-    return payload
-
-
-def _mock_auth_and_project(
-    project_exists: bool = True,
-) -> tuple[AsyncMock, AsyncMock]:
-    mock_validate = AsyncMock(return_value=_fake_token_payload())
-    mock_svc = AsyncMock()
-    if project_exists:
-        mock_svc.get.return_value = Mock()
-    else:
-        from fastapi import HTTPException
-
-        mock_svc.get.side_effect = HTTPException(status_code=404, detail="Not found")
-    return mock_validate, mock_svc
 
 
 def _mock_pubsub(messages: list[Any]) -> tuple[AsyncMock, AsyncMock]:
@@ -70,55 +44,27 @@ def _mock_pubsub(messages: list[Any]) -> tuple[AsyncMock, AsyncMock]:
     return mock_pool, mock_pubsub
 
 
-def _enter_auth_patches(
-    stack: contextlib.ExitStack,
-    mock_validate: AsyncMock,
-    mock_svc: AsyncMock,
-) -> None:
-    """Enter auth + project access patches into an ExitStack."""
-    mock_ctx = AsyncMock()
-    mock_ctx.__aenter__ = AsyncMock(return_value=AsyncMock())
-    mock_ctx.__aexit__ = AsyncMock(return_value=False)
-
-    stack.enter_context(patch("ontokit.core.auth.validate_token", mock_validate))
-    stack.enter_context(patch("ontokit.core.auth.fetch_userinfo", AsyncMock(return_value=None)))
-    stack.enter_context(
-        patch("ontokit.api.routes.lint.async_session_maker", Mock(return_value=mock_ctx))
-    )
-    stack.enter_context(
-        patch("ontokit.services.project_service.ProjectService", return_value=mock_svc)
-    )
-
-
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
 
 
 class TestLintWebSocketAuth:
-    """Tests for lint_websocket authentication."""
+    """Tests for lint_websocket authentication delegation."""
 
     @pytest.mark.asyncio
-    async def test_no_token_closes_with_4001(self) -> None:
+    async def test_auth_failure_returns_early(self) -> None:
+        """Returns without connecting when authenticate_ws returns False."""
         ws = AsyncMock(spec=WebSocket)
-        await lint_websocket(ws, PROJECT_UUID, token=None)
-        ws.close.assert_awaited_once_with(code=4001, reason="Authentication required")
+        mock_mgr = AsyncMock()
 
-    @pytest.mark.asyncio
-    async def test_invalid_token_closes_with_4001(self) -> None:
-        ws = AsyncMock(spec=WebSocket)
-        with patch("ontokit.core.auth.validate_token", AsyncMock(side_effect=ValueError("bad"))):
-            await lint_websocket(ws, PROJECT_UUID, token="bad-token")
-        ws.close.assert_awaited_once_with(code=4001, reason="Invalid or expired token")
+        with (
+            patch("ontokit.api.utils.ws_auth.authenticate_ws", AsyncMock(return_value=False)),
+            patch("ontokit.api.routes.lint.manager", mock_mgr),
+        ):
+            await lint_websocket(ws, PROJECT_UUID, token="t")
 
-    @pytest.mark.asyncio
-    async def test_project_not_found_closes_with_4004(self) -> None:
-        ws = AsyncMock(spec=WebSocket)
-        mock_validate, mock_svc = _mock_auth_and_project(project_exists=False)
-        with contextlib.ExitStack() as stack:
-            _enter_auth_patches(stack, mock_validate, mock_svc)
-            await lint_websocket(ws, PROJECT_UUID, token=FAKE_TOKEN)
-        ws.close.assert_awaited_once_with(code=4004, reason="Project not found or access denied")
+        mock_mgr.connect.assert_not_awaited()
 
 
 class TestLintWebSocketMessages:
@@ -129,18 +75,16 @@ class TestLintWebSocketMessages:
         ws = AsyncMock(spec=WebSocket)
         ws.receive_text = AsyncMock(side_effect=WebSocketDisconnect(code=1000))
 
-        mock_validate, mock_svc = _mock_auth_and_project(project_exists=True)
         lint_msg = {"type": "lint_complete", "project_id": PROJECT_ID, "run_id": "r1"}
         mock_pool, mock_pubsub = _mock_pubsub([lint_msg])
         mock_mgr = AsyncMock()
 
-        with contextlib.ExitStack() as stack:
-            _enter_auth_patches(stack, mock_validate, mock_svc)
-            stack.enter_context(
-                patch("ontokit.api.routes.lint.get_arq_pool", return_value=mock_pool)
-            )
-            stack.enter_context(patch("ontokit.api.routes.lint.manager", mock_mgr))
-            await lint_websocket(ws, PROJECT_UUID, token=FAKE_TOKEN)
+        with (
+            patch("ontokit.api.utils.ws_auth.authenticate_ws", AsyncMock(return_value=True)),
+            patch("ontokit.api.routes.lint.get_arq_pool", return_value=mock_pool),
+            patch("ontokit.api.routes.lint.manager", mock_mgr),
+        ):
+            await lint_websocket(ws, PROJECT_UUID, token="t")
 
         mock_mgr.connect.assert_awaited_once()
         ws.send_json.assert_awaited_once_with(lint_msg)
@@ -152,17 +96,15 @@ class TestLintWebSocketMessages:
         ws = AsyncMock(spec=WebSocket)
         ws.receive_text = AsyncMock(side_effect=WebSocketDisconnect(code=1000))
 
-        mock_validate, mock_svc = _mock_auth_and_project(project_exists=True)
         other_msg = {"type": "lint_complete", "project_id": "other-project"}
         mock_pool, _ = _mock_pubsub([other_msg])
 
-        with contextlib.ExitStack() as stack:
-            _enter_auth_patches(stack, mock_validate, mock_svc)
-            stack.enter_context(
-                patch("ontokit.api.routes.lint.get_arq_pool", return_value=mock_pool)
-            )
-            stack.enter_context(patch("ontokit.api.routes.lint.manager", AsyncMock()))
-            await lint_websocket(ws, PROJECT_UUID, token=FAKE_TOKEN)
+        with (
+            patch("ontokit.api.utils.ws_auth.authenticate_ws", AsyncMock(return_value=True)),
+            patch("ontokit.api.routes.lint.get_arq_pool", return_value=mock_pool),
+            patch("ontokit.api.routes.lint.manager", AsyncMock()),
+        ):
+            await lint_websocket(ws, PROJECT_UUID, token="t")
 
         ws.send_json.assert_not_awaited()
 
@@ -171,17 +113,15 @@ class TestLintWebSocketMessages:
         ws = AsyncMock(spec=WebSocket)
         ws.receive_text = AsyncMock(side_effect=[TimeoutError, WebSocketDisconnect(code=1000)])
 
-        mock_validate, mock_svc = _mock_auth_and_project(project_exists=True)
         valid_msg = {"type": "lint_started", "project_id": PROJECT_ID}
         mock_pool, _ = _mock_pubsub(["not valid json{{{", valid_msg])
 
-        with contextlib.ExitStack() as stack:
-            _enter_auth_patches(stack, mock_validate, mock_svc)
-            stack.enter_context(
-                patch("ontokit.api.routes.lint.get_arq_pool", return_value=mock_pool)
-            )
-            stack.enter_context(patch("ontokit.api.routes.lint.manager", AsyncMock()))
-            await lint_websocket(ws, PROJECT_UUID, token=FAKE_TOKEN)
+        with (
+            patch("ontokit.api.utils.ws_auth.authenticate_ws", AsyncMock(return_value=True)),
+            patch("ontokit.api.routes.lint.get_arq_pool", return_value=mock_pool),
+            patch("ontokit.api.routes.lint.manager", AsyncMock()),
+        ):
+            await lint_websocket(ws, PROJECT_UUID, token="t")
 
         ws.send_json.assert_awaited_once_with(valid_msg)
 
@@ -189,20 +129,18 @@ class TestLintWebSocketMessages:
     async def test_cleans_up_on_exception(self) -> None:
         ws = AsyncMock(spec=WebSocket)
 
-        mock_validate, mock_svc = _mock_auth_and_project(project_exists=True)
         mock_pubsub = AsyncMock()
         mock_pubsub.get_message = AsyncMock(side_effect=RuntimeError("Redis down"))
         mock_pool = AsyncMock()
         mock_pool.pubsub = Mock(return_value=mock_pubsub)
         mock_mgr = AsyncMock()
 
-        with contextlib.ExitStack() as stack:
-            _enter_auth_patches(stack, mock_validate, mock_svc)
-            stack.enter_context(
-                patch("ontokit.api.routes.lint.get_arq_pool", return_value=mock_pool)
-            )
-            stack.enter_context(patch("ontokit.api.routes.lint.manager", mock_mgr))
-            await lint_websocket(ws, PROJECT_UUID, token=FAKE_TOKEN)
+        with (
+            patch("ontokit.api.utils.ws_auth.authenticate_ws", AsyncMock(return_value=True)),
+            patch("ontokit.api.routes.lint.get_arq_pool", return_value=mock_pool),
+            patch("ontokit.api.routes.lint.manager", mock_mgr),
+        ):
+            await lint_websocket(ws, PROJECT_UUID, token="t")
 
         mock_mgr.disconnect.assert_called_once()
         mock_pubsub.unsubscribe.assert_awaited()

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -63,9 +63,10 @@ class TestRunOntologyIndexTask:
     async def test_project_no_source_file_raises(
         self, mock_ctx: dict[str, Any], project_id: str
     ) -> None:
-        """Raises ValueError when the project has no source_file_path."""
+        """Raises ValueError when the project has no source_file_path and no integration."""
         project = Mock()
         project.source_file_path = None
+        project.github_integration = None
         mock_result = Mock()
         mock_result.scalar_one_or_none.return_value = project
         mock_ctx["db"].execute.return_value = mock_result

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -1017,6 +1017,30 @@ class TestRunOntologyIndexTaskEdgeCases:
 
         assert result["commit_hash"] == "unknown"
 
+    @pytest.mark.asyncio
+    async def test_no_git_repo_and_no_storage_file_raises(
+        self, mock_ctx: dict[str, Any], project_id: str
+    ) -> None:
+        """Raises ValueError when git repo doesn't exist and project has no source_file_path."""
+        project = Mock()
+        project.source_file_path = None
+        project.github_integration = MagicMock()  # has integration so early guard passes
+        mock_result = Mock()
+        mock_result.scalar_one_or_none.return_value = project
+        mock_ctx["db"].execute.return_value = mock_result
+
+        with (
+            patch("ontokit.worker.get_storage_service"),
+            patch("ontokit.worker.get_ontology_service"),
+            patch("ontokit.worker.BareGitRepositoryService") as mock_git_cls,
+            patch("ontokit.worker.get_git_ontology_path", return_value="ontology.ttl"),
+        ):
+            mock_git_svc = mock_git_cls.return_value
+            mock_git_svc.repository_exists.return_value = False
+
+            with pytest.raises(ValueError, match="no git repository and no storage file"):
+                await run_ontology_index_task(mock_ctx, project_id, "main")
+
 
 # ---------------------------------------------------------------------------
 # run_lint_task – failure path

--- a/tests/unit/test_ws_auth.py
+++ b/tests/unit/test_ws_auth.py
@@ -1,0 +1,152 @@
+"""Tests for the shared WebSocket authentication helper."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, Mock, patch
+from uuid import UUID
+
+import pytest
+from fastapi import HTTPException, WebSocket
+
+from ontokit.api.utils.ws_auth import authenticate_ws
+
+PROJECT_UUID = UUID("12345678-1234-5678-1234-567812345678")
+
+
+def _fake_token_payload() -> Mock:
+    payload = Mock()
+    payload.sub = "user-1"
+    payload.name = "Test User"
+    payload.email = "test@example.com"
+    payload.preferred_username = "testuser"
+    payload.roles = ["owner"]
+    return payload
+
+
+class TestAuthenticateWs:
+    """Tests for authenticate_ws helper."""
+
+    @pytest.mark.asyncio
+    async def test_no_token_closes_4001(self) -> None:
+        ws = AsyncMock(spec=WebSocket)
+        result = await authenticate_ws(ws, PROJECT_UUID, token=None)
+        assert result is False
+        ws.close.assert_awaited_once_with(code=4001, reason="Authentication required")
+
+    @pytest.mark.asyncio
+    async def test_invalid_token_http_exception_closes_4001(self) -> None:
+        ws = AsyncMock(spec=WebSocket)
+        with patch(
+            "ontokit.api.utils.ws_auth.validate_token",
+            AsyncMock(side_effect=HTTPException(status_code=401)),
+        ):
+            result = await authenticate_ws(ws, PROJECT_UUID, token="bad")
+        assert result is False
+        ws.close.assert_awaited_once_with(code=4001, reason="Invalid or expired token")
+
+    @pytest.mark.asyncio
+    async def test_unexpected_auth_error_closes_1011(self) -> None:
+        ws = AsyncMock(spec=WebSocket)
+        with patch(
+            "ontokit.api.utils.ws_auth.validate_token",
+            AsyncMock(side_effect=RuntimeError("network error")),
+        ):
+            result = await authenticate_ws(ws, PROJECT_UUID, token="tok")
+        assert result is False
+        ws.close.assert_awaited_once_with(code=1011, reason="Internal server error")
+
+    @pytest.mark.asyncio
+    async def test_project_not_found_closes_4004(self) -> None:
+        ws = AsyncMock(spec=WebSocket)
+        mock_svc = AsyncMock()
+        mock_svc.get.side_effect = HTTPException(status_code=404, detail="Not found")
+
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=AsyncMock())
+        mock_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch(
+                "ontokit.api.utils.ws_auth.validate_token",
+                AsyncMock(return_value=_fake_token_payload()),
+            ),
+            patch("ontokit.api.utils.ws_auth.fetch_userinfo", AsyncMock(return_value=None)),
+            patch("ontokit.api.utils.ws_auth.async_session_maker", Mock(return_value=mock_ctx)),
+            patch("ontokit.api.utils.ws_auth.ProjectService", return_value=mock_svc),
+        ):
+            result = await authenticate_ws(ws, PROJECT_UUID, token="tok")
+
+        assert result is False
+        ws.close.assert_awaited_once_with(code=4004, reason="Project not found")
+
+    @pytest.mark.asyncio
+    async def test_access_denied_closes_4003(self) -> None:
+        ws = AsyncMock(spec=WebSocket)
+        mock_svc = AsyncMock()
+        mock_svc.get.side_effect = HTTPException(status_code=403, detail="Forbidden")
+
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=AsyncMock())
+        mock_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch(
+                "ontokit.api.utils.ws_auth.validate_token",
+                AsyncMock(return_value=_fake_token_payload()),
+            ),
+            patch("ontokit.api.utils.ws_auth.fetch_userinfo", AsyncMock(return_value=None)),
+            patch("ontokit.api.utils.ws_auth.async_session_maker", Mock(return_value=mock_ctx)),
+            patch("ontokit.api.utils.ws_auth.ProjectService", return_value=mock_svc),
+        ):
+            result = await authenticate_ws(ws, PROJECT_UUID, token="tok")
+
+        assert result is False
+        ws.close.assert_awaited_once_with(code=4003, reason="Access denied")
+
+    @pytest.mark.asyncio
+    async def test_unexpected_project_error_closes_1011(self) -> None:
+        ws = AsyncMock(spec=WebSocket)
+        mock_svc = AsyncMock()
+        mock_svc.get.side_effect = RuntimeError("db down")
+
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=AsyncMock())
+        mock_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch(
+                "ontokit.api.utils.ws_auth.validate_token",
+                AsyncMock(return_value=_fake_token_payload()),
+            ),
+            patch("ontokit.api.utils.ws_auth.fetch_userinfo", AsyncMock(return_value=None)),
+            patch("ontokit.api.utils.ws_auth.async_session_maker", Mock(return_value=mock_ctx)),
+            patch("ontokit.api.utils.ws_auth.ProjectService", return_value=mock_svc),
+        ):
+            result = await authenticate_ws(ws, PROJECT_UUID, token="tok")
+
+        assert result is False
+        ws.close.assert_awaited_once_with(code=1011, reason="Internal server error")
+
+    @pytest.mark.asyncio
+    async def test_success_returns_true(self) -> None:
+        ws = AsyncMock(spec=WebSocket)
+        mock_svc = AsyncMock()
+        mock_svc.get.return_value = Mock()
+
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=AsyncMock())
+        mock_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch(
+                "ontokit.api.utils.ws_auth.validate_token",
+                AsyncMock(return_value=_fake_token_payload()),
+            ),
+            patch("ontokit.api.utils.ws_auth.fetch_userinfo", AsyncMock(return_value=None)),
+            patch("ontokit.api.utils.ws_auth.async_session_maker", Mock(return_value=mock_ctx)),
+            patch("ontokit.api.utils.ws_auth.ProjectService", return_value=mock_svc),
+        ):
+            result = await authenticate_ws(ws, PROJECT_UUID, token="tok")
+
+        assert result is True
+        ws.close.assert_not_awaited()

--- a/tests/unit/test_ws_auth.py
+++ b/tests/unit/test_ws_auth.py
@@ -31,6 +31,7 @@ class TestAuthenticateWs:
         ws = AsyncMock(spec=WebSocket)
         result = await authenticate_ws(ws, PROJECT_UUID, token=None)
         assert result is False
+        ws.accept.assert_awaited_once()
         ws.close.assert_awaited_once_with(code=4001, reason="Authentication required")
 
     @pytest.mark.asyncio
@@ -42,6 +43,7 @@ class TestAuthenticateWs:
         ):
             result = await authenticate_ws(ws, PROJECT_UUID, token="bad")
         assert result is False
+        ws.accept.assert_awaited_once()
         ws.close.assert_awaited_once_with(code=4001, reason="Invalid or expired token")
 
     @pytest.mark.asyncio
@@ -53,6 +55,7 @@ class TestAuthenticateWs:
         ):
             result = await authenticate_ws(ws, PROJECT_UUID, token="tok")
         assert result is False
+        ws.accept.assert_awaited_once()
         ws.close.assert_awaited_once_with(code=1011, reason="Internal server error")
 
     @pytest.mark.asyncio
@@ -77,6 +80,7 @@ class TestAuthenticateWs:
             result = await authenticate_ws(ws, PROJECT_UUID, token="tok")
 
         assert result is False
+        ws.accept.assert_awaited_once()
         ws.close.assert_awaited_once_with(code=4004, reason="Project not found")
 
     @pytest.mark.asyncio
@@ -101,6 +105,7 @@ class TestAuthenticateWs:
             result = await authenticate_ws(ws, PROJECT_UUID, token="tok")
 
         assert result is False
+        ws.accept.assert_awaited_once()
         ws.close.assert_awaited_once_with(code=4003, reason="Access denied")
 
     @pytest.mark.asyncio
@@ -125,6 +130,7 @@ class TestAuthenticateWs:
             result = await authenticate_ws(ws, PROJECT_UUID, token="tok")
 
         assert result is False
+        ws.accept.assert_awaited_once()
         ws.close.assert_awaited_once_with(code=1011, reason="Internal server error")
 
     @pytest.mark.asyncio
@@ -149,4 +155,5 @@ class TestAuthenticateWs:
             result = await authenticate_ws(ws, PROJECT_UUID, token="tok")
 
         assert result is True
+        ws.accept.assert_awaited_once()
         ws.close.assert_not_awaited()


### PR DESCRIPTION
## Summary

This PR started as a fix for issue #48 (missing GET index-status endpoint) but expanded to address several related improvements discovered during implementation and code review.

### New endpoints
- **GET `/projects/{id}/ontology/index-status`** — returns index status fields (`status`, `entity_count`, `indexed_at`, `commit_hash`, `error_message`); 404 if no record exists
- **WS `/projects/{id}/ontology/index-ws`** — real-time WebSocket for `index_started`, `index_complete`, `index_failed` events via Redis pubsub (mirrors lint WS pattern)

### Bug fixes
- **Fix git ontology file path resolution** — worker and embedding service used `getattr(project, "git_ontology_path", None)` which always returned `None` (field only exists on `ProjectResponse`, not the ORM model). Extracted `get_git_ontology_path()` into `models/project.py` and eagerly load `github_integration` relationship
- **Relax `source_file_path` guard** — worker and embedding service now allow projects with `github_integration` but no `source_file_path` to proceed with git-based loading
- **Add token-based auth to both WebSocket endpoints** — lint and index WebSockets now require a `token` query parameter, validated via Zitadel JWT + `ProjectService.get` access check (previously unauthenticated)

### Refactoring
- **FastAPI DI for all route-level services** — replaced direct `Service(db)` construction with `Depends()` factories:
  - `OntologyIndexService` (2 instances in `projects.py`)
  - `EmbeddingService` (7 instances across `embeddings.py`, `semantic_search.py`)
  - `ChangeEventService` (5 instances across `analytics.py`, `projects.py`)

### Tests
- 30+ new tests covering: index-status route, WebSocket manager, WebSocket endpoint (auth, message forwarding, filtering, malformed JSON, cleanup), DI factories, `get_git_ontology_path`, worker/embedding edge cases
- 1372 total tests, 89% overall coverage

Closes #48

## Test plan
- [x] All 1372 tests pass
- [x] ruff, ruff format, and mypy all pass
- [x] Verified end-to-end: settings page loads index status, rebuild index works with correct file path (15,173 entities indexed), status updates display correctly
- [x] CI passes (lint, test, build, codecov/patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GET endpoint to fetch ontology index status (status, entity count, indexed timestamp, commit, error).
  * WebSocket for real-time ontology indexing updates with token-based authentication and per-project filtering.

* **Refactoring**
  * Centralized ontology file path resolution and streamlined service dependency injection across API routes.

* **Tests**
  * Added extensive unit tests covering index status, WebSocket flows, DI factories, embedding edge cases, and auth.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->