### PR TITLE
refactor: offload quality endpoints to ARQ worker queue

### DIFF
--- a/.claude/commands/post-merge.md
+++ b/.claude/commands/post-merge.md
@@ -10,7 +10,10 @@ Steps to perform:
 
 3. **Delete the stale local branch**: Delete the candidate branch identified in step 1. If no candidate was identified (current branch was already `dev`/`main` and no argument given), list recent local branches (excluding dev and main) and ask which one to delete.
 
-4. **Check if a Docker rebuild is needed**: Compare the pulled changes to see if any of these files changed: `Dockerfile`, `Dockerfile.prod`, `pyproject.toml`, `uv.lock`, `compose.yaml`, or `alembic/`. If any of `Dockerfile`, `Dockerfile.prod`, `pyproject.toml`, `uv.lock`, or `compose.yaml` changed, run `docker compose up -d --build` to rebuild (this also recreates containers and re-runs migrations). If only `alembic/` changed (new migration files), run `docker compose up -d --force-recreate api worker` to recreate the containers so migrations run on startup. If none of the above changed, just run `docker compose restart api worker` to pick up the volume-mounted code changes.
+4. **Check if a Docker rebuild is needed**: Compare the pulled changes against `Dockerfile`, `Dockerfile.prod`, `pyproject.toml`, `uv.lock`, `compose.yaml`, and `alembic/`, then run the first matching command:
+   - `Dockerfile`, `Dockerfile.prod`, `pyproject.toml`, `uv.lock`, or `compose.yaml` changed → `docker compose up -d --build` (rebuilds images, recreates containers, re-runs migrations)
+   - Only `alembic/` changed (new migrations) → `docker compose up -d --force-recreate api worker` (recreates containers so migrations run on startup)
+   - None of the above changed → `docker compose restart api worker` (picks up volume-mounted code changes)
 
 5. **Verify**: Run `docker compose ps` to confirm all services are healthy.
 

--- a/.claude/commands/post-merge.md
+++ b/.claude/commands/post-merge.md
@@ -1,0 +1,20 @@
+Post-merge cleanup after a PR has been merged to dev on GitHub.
+
+Argument: $ARGUMENTS (optional: the branch name that was merged, e.g. "feat/my-feature")
+
+Steps to perform:
+
+1. **Detect the branch to delete** (before switching away): If no argument was provided, check the current branch name. If it is not `dev` or `main`, offer that branch as the candidate to delete. If an argument was provided, use that as the candidate.
+
+2. **Checkout dev and pull**: Switch to the `dev` branch and pull the latest changes from origin.
+
+3. **Delete the stale local branch**: Delete the candidate branch identified in step 1. If no candidate was identified (current branch was already `dev`/`main` and no argument given), list recent local branches (excluding dev and main) and ask which one to delete.
+
+4. **Check if a Docker rebuild is needed**: Compare the pulled changes to see if any of these files changed: `Dockerfile`, `Dockerfile.prod`, `pyproject.toml`, `uv.lock`, `compose.yaml`. If any of them changed, run `docker compose up -d --build` to rebuild. If none changed, just run `docker compose restart api worker` to pick up the volume-mounted code changes and re-trigger the entrypoint (which runs alembic migrations on startup).
+
+5. **Verify**: Run `docker compose ps` to confirm all services are healthy.
+
+Important:
+- The entrypoint.sh uses a marker file `/tmp/.migrations_done` to skip repeated migrations. A container restart clears this marker, so migrations will run automatically on restart.
+- Always confirm before deleting a branch if it looks like it might have unmerged changes.
+- Run all commands from the repository root (use `git rev-parse --show-toplevel` to find it).

--- a/.claude/commands/post-merge.md
+++ b/.claude/commands/post-merge.md
@@ -10,11 +10,11 @@ Steps to perform:
 
 3. **Delete the stale local branch**: Delete the candidate branch identified in step 1. If no candidate was identified (current branch was already `dev`/`main` and no argument given), list recent local branches (excluding dev and main) and ask which one to delete.
 
-4. **Check if a Docker rebuild is needed**: Compare the pulled changes to see if any of these files changed: `Dockerfile`, `Dockerfile.prod`, `pyproject.toml`, `uv.lock`, `compose.yaml`. If any of them changed, run `docker compose up -d --build` to rebuild. If none changed, just run `docker compose restart api worker` to pick up the volume-mounted code changes and re-trigger the entrypoint (which runs alembic migrations on startup).
+4. **Check if a Docker rebuild is needed**: Compare the pulled changes to see if any of these files changed: `Dockerfile`, `Dockerfile.prod`, `pyproject.toml`, `uv.lock`, `compose.yaml`, or `alembic/`. If any of `Dockerfile`, `Dockerfile.prod`, `pyproject.toml`, `uv.lock`, or `compose.yaml` changed, run `docker compose up -d --build` to rebuild (this also recreates containers and re-runs migrations). If only `alembic/` changed (new migration files), run `docker compose up -d --force-recreate api worker` to recreate the containers so migrations run on startup. If none of the above changed, just run `docker compose restart api worker` to pick up the volume-mounted code changes.
 
 5. **Verify**: Run `docker compose ps` to confirm all services are healthy.
 
 Important:
-- The entrypoint.sh uses a marker file `/tmp/.migrations_done` to skip repeated migrations. A container restart clears this marker, so migrations will run automatically on restart.
+- The entrypoint.sh uses a marker file `/tmp/.migrations_done` to skip repeated migrations. This marker lives inside the container filesystem, so `docker compose restart` preserves it and migrations will NOT re-run. Only container recreation (`--build` or `--force-recreate`) clears the marker.
 - Always confirm before deleting a branch if it looks like it might have unmerged changes.
 - Run all commands from the repository root (use `git rev-parse --show-toplevel` to find it).

--- a/ontokit/api/routes/quality.py
+++ b/ontokit/api/routes/quality.py
@@ -7,6 +7,7 @@ from typing import Annotated
 from urllib.parse import unquote
 from uuid import UUID
 
+import pydantic
 import redis.asyncio as aioredis
 from fastapi import APIRouter, Depends, HTTPException, Query, WebSocket, WebSocketDisconnect, status
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -111,18 +112,21 @@ async def get_quality_job_result(
     """Get consistency check results by job ID."""
     await verify_project_access(project_id, db, user)
 
+    redis = _get_redis()
+    cached = await redis.get(f"quality_job:{project_id}:{job_id}")
+    if cached is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Job result not found or expired",
+        )
     try:
-        redis = _get_redis()
-        cached = await redis.get(f"quality_job:{project_id}:{job_id}")
-        if cached:
-            return ConsistencyCheckResult.model_validate_json(cached)
-    except Exception:
-        logger.warning("Failed to read quality job from Redis", exc_info=True)
-
-    raise HTTPException(
-        status_code=status.HTTP_404_NOT_FOUND,
-        detail="Job result not found or expired",
-    )
+        return ConsistencyCheckResult.model_validate_json(cached)
+    except pydantic.ValidationError as e:
+        logger.error("Corrupt cached consistency result for job %s: %s", job_id, e)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Cached result is corrupt",
+        ) from e
 
 
 @router.get(
@@ -141,14 +145,17 @@ async def get_consistency_issues(
     # Resolve the branch so cache keys match what trigger_consistency_check stored
     resolved_branch = await resolve_branch(project_id, branch)
 
-    try:
-        redis = _get_redis()
-        cache_key = f"quality:{project_id}:{resolved_branch}"
-        cached = await redis.get(cache_key)
-        if cached:
+    redis = _get_redis()
+    cached = await redis.get(f"quality:{project_id}:{resolved_branch}")
+    if cached is not None:
+        try:
             return ConsistencyCheckResult.model_validate_json(cached)
-    except Exception:
-        logger.warning("Failed to read consistency cache from Redis", exc_info=True)
+        except pydantic.ValidationError as e:
+            logger.error("Corrupt cached consistency result: %s", e)
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Cached result is corrupt",
+            ) from e
 
     # No cached result — return empty
     from datetime import UTC, datetime
@@ -218,18 +225,21 @@ async def get_duplicate_job_result(
     """Get duplicate detection results by job ID."""
     await verify_project_access(project_id, db, user)
 
+    redis = _get_redis()
+    cached = await redis.get(f"duplicates_job:{project_id}:{job_id}")
+    if cached is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Job result not found or expired",
+        )
     try:
-        redis = _get_redis()
-        cached = await redis.get(f"duplicates_job:{project_id}:{job_id}")
-        if cached:
-            return DuplicateDetectionResult.model_validate_json(cached)
-    except Exception:
-        logger.warning("Failed to read duplicates job from Redis", exc_info=True)
-
-    raise HTTPException(
-        status_code=status.HTTP_404_NOT_FOUND,
-        detail="Job result not found or expired",
-    )
+        return DuplicateDetectionResult.model_validate_json(cached)
+    except pydantic.ValidationError as e:
+        logger.error("Corrupt cached duplicates result for job %s: %s", job_id, e)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Cached result is corrupt",
+        ) from e
 
 
 @router.get(
@@ -246,13 +256,17 @@ async def get_latest_duplicates(
     await verify_project_access(project_id, db, user)
     resolved_branch = await resolve_branch(project_id, branch)
 
-    try:
-        redis = _get_redis()
-        cached = await redis.get(f"duplicates:{project_id}:{resolved_branch}")
-        if cached:
+    redis = _get_redis()
+    cached = await redis.get(f"duplicates:{project_id}:{resolved_branch}")
+    if cached is not None:
+        try:
             return DuplicateDetectionResult.model_validate_json(cached)
-    except Exception:
-        logger.warning("Failed to read duplicates cache from Redis", exc_info=True)
+        except pydantic.ValidationError as e:
+            logger.error("Corrupt cached duplicates result: %s", e)
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Cached result is corrupt",
+            ) from e
 
     from datetime import UTC, datetime
 

--- a/ontokit/api/routes/quality.py
+++ b/ontokit/api/routes/quality.py
@@ -77,6 +77,11 @@ async def trigger_consistency_check(
 
     job_id = str(uuid.uuid4())
 
+    # Set pending status before enqueue to avoid race with fast-completing workers
+    redis = _get_redis()
+    status_key = f"quality_job_status:{project_id}:{job_id}"
+    await redis.set(status_key, "pending", ex=600)
+
     try:
         pool = await get_arq_pool()
         job = await pool.enqueue_job(
@@ -86,6 +91,7 @@ async def trigger_consistency_check(
             job_id,
         )
         if job is None:
+            await redis.delete(status_key)
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail="Failed to enqueue consistency check job",
@@ -93,15 +99,12 @@ async def trigger_consistency_check(
     except HTTPException:
         raise
     except Exception as e:
+        await redis.delete(status_key)
         logger.exception("Failed to enqueue consistency check: %s", e)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to enqueue consistency check job",
         ) from e
-
-    # Mark the job as pending so polling clients can distinguish queued from unknown
-    redis = _get_redis()
-    await redis.set(f"quality_job_status:{project_id}:{job_id}", "pending", ex=600)
 
     return ConsistencyCheckTriggerResponse(job_id=job_id)
 
@@ -136,9 +139,20 @@ async def get_quality_job_result(
                 detail="Cached result is corrupt",
             ) from e
 
-    # No result yet — check if the job is still pending
+    # No result yet — check if the job is still pending or failed
     job_status = await redis.get(f"quality_job_status:{project_id}:{job_id}")
     if job_status is not None:
+        status_str = job_status.decode() if isinstance(job_status, bytes) else str(job_status)
+        if status_str != "pending":
+            try:
+                failure = json.loads(status_str)
+                error_msg = failure.get("error", "Unknown error")
+            except json.JSONDecodeError:
+                error_msg = "Unknown error"
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Job failed: {error_msg}",
+            )
         return JSONResponse(
             status_code=status.HTTP_202_ACCEPTED,
             content=QualityJobPendingResponse(job_id=job_id).model_dump(),
@@ -207,6 +221,11 @@ async def detect_duplicates(
 
     job_id = str(uuid.uuid4())
 
+    # Set pending status before enqueue to avoid race with fast-completing workers
+    redis = _get_redis()
+    status_key = f"duplicates_job_status:{project_id}:{job_id}"
+    await redis.set(status_key, "pending", ex=600)
+
     try:
         pool = await get_arq_pool()
         job = await pool.enqueue_job(
@@ -217,6 +236,7 @@ async def detect_duplicates(
             job_id,
         )
         if job is None:
+            await redis.delete(status_key)
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail="Failed to enqueue duplicate detection job",
@@ -224,15 +244,12 @@ async def detect_duplicates(
     except HTTPException:
         raise
     except Exception as e:
+        await redis.delete(status_key)
         logger.exception("Failed to enqueue duplicate detection: %s", e)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to enqueue duplicate detection job",
         ) from e
-
-    # Mark the job as pending so polling clients can distinguish queued from unknown
-    redis = _get_redis()
-    await redis.set(f"duplicates_job_status:{project_id}:{job_id}", "pending", ex=600)
 
     return DuplicateDetectionTriggerResponse(job_id=job_id)
 
@@ -267,9 +284,20 @@ async def get_duplicate_job_result(
                 detail="Cached result is corrupt",
             ) from e
 
-    # No result yet — check if the job is still pending
+    # No result yet — check if the job is still pending or failed
     job_status = await redis.get(f"duplicates_job_status:{project_id}:{job_id}")
     if job_status is not None:
+        status_str = job_status.decode() if isinstance(job_status, bytes) else str(job_status)
+        if status_str != "pending":
+            try:
+                failure = json.loads(status_str)
+                error_msg = failure.get("error", "Unknown error")
+            except json.JSONDecodeError:
+                error_msg = "Unknown error"
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Job failed: {error_msg}",
+            )
         return JSONResponse(
             status_code=status.HTTP_202_ACCEPTED,
             content=QualityJobPendingResponse(job_id=job_id).model_dump(),

--- a/ontokit/api/routes/quality.py
+++ b/ontokit/api/routes/quality.py
@@ -294,6 +294,7 @@ async def quality_websocket(
     Pass ``token`` as a query parameter for authentication.
     """
     import asyncio
+    import contextlib
 
     from ontokit.api.utils.ws_auth import authenticate_ws
 
@@ -333,4 +334,6 @@ async def quality_websocket(
         logger.error("Quality WebSocket error for project %s: %s", project_id, e)
     finally:
         if pubsub:
-            await pubsub.unsubscribe(QUALITY_UPDATES_CHANNEL)
+            with contextlib.suppress(Exception):
+                await pubsub.unsubscribe(QUALITY_UPDATES_CHANNEL)
+                await pubsub.aclose()  # type: ignore[no-untyped-call]

--- a/ontokit/api/routes/quality.py
+++ b/ontokit/api/routes/quality.py
@@ -10,7 +10,9 @@ from uuid import UUID
 import pydantic
 import redis.asyncio as aioredis
 from fastapi import APIRouter, Depends, HTTPException, Query, WebSocket, WebSocketDisconnect, status
+from fastapi.responses import JSONResponse
 from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.responses import Response
 
 from ontokit.api.dependencies import load_project_graph, resolve_branch, verify_project_access
 from ontokit.api.utils.redis import get_arq_pool
@@ -23,6 +25,7 @@ from ontokit.schemas.quality import (
     CrossReferencesResponse,
     DuplicateDetectionResult,
     DuplicateDetectionTriggerResponse,
+    QualityJobPendingResponse,
 )
 from ontokit.services.cross_reference_service import get_cross_references
 
@@ -96,37 +99,55 @@ async def trigger_consistency_check(
             detail="Failed to enqueue consistency check job",
         ) from e
 
+    # Mark the job as pending so polling clients can distinguish queued from unknown
+    redis = _get_redis()
+    await redis.set(f"quality_job_status:{project_id}:{job_id}", "pending", ex=600)
+
     return ConsistencyCheckTriggerResponse(job_id=job_id)
 
 
 @router.get(
     "/{project_id}/quality/jobs/{job_id}",
     response_model=ConsistencyCheckResult,
+    responses={202: {"model": QualityJobPendingResponse, "description": "Job is still pending"}},
 )
 async def get_quality_job_result(
     project_id: UUID,
     job_id: str,
     db: Annotated[AsyncSession, Depends(get_db)],
     user: OptionalUser,
-) -> ConsistencyCheckResult:
-    """Get consistency check results by job ID."""
+) -> ConsistencyCheckResult | Response:
+    """Get consistency check results by job ID.
+
+    Returns 200 with results when complete, 202 when still pending,
+    or 404 when the job ID is unknown or expired.
+    """
     await verify_project_access(project_id, db, user)
 
     redis = _get_redis()
     cached = await redis.get(f"quality_job:{project_id}:{job_id}")
-    if cached is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Job result not found or expired",
+    if cached is not None:
+        try:
+            return ConsistencyCheckResult.model_validate_json(cached)
+        except pydantic.ValidationError as e:
+            logger.error("Corrupt cached consistency result for job %s: %s", job_id, e)
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Cached result is corrupt",
+            ) from e
+
+    # No result yet — check if the job is still pending
+    job_status = await redis.get(f"quality_job_status:{project_id}:{job_id}")
+    if job_status is not None:
+        return JSONResponse(
+            status_code=status.HTTP_202_ACCEPTED,
+            content=QualityJobPendingResponse(job_id=job_id).model_dump(),
         )
-    try:
-        return ConsistencyCheckResult.model_validate_json(cached)
-    except pydantic.ValidationError as e:
-        logger.error("Corrupt cached consistency result for job %s: %s", job_id, e)
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Cached result is corrupt",
-        ) from e
+
+    raise HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND,
+        detail="Job result not found or expired",
+    )
 
 
 @router.get(
@@ -209,37 +230,55 @@ async def detect_duplicates(
             detail="Failed to enqueue duplicate detection job",
         ) from e
 
+    # Mark the job as pending so polling clients can distinguish queued from unknown
+    redis = _get_redis()
+    await redis.set(f"duplicates_job_status:{project_id}:{job_id}", "pending", ex=600)
+
     return DuplicateDetectionTriggerResponse(job_id=job_id)
 
 
 @router.get(
     "/{project_id}/quality/duplicates/jobs/{job_id}",
     response_model=DuplicateDetectionResult,
+    responses={202: {"model": QualityJobPendingResponse, "description": "Job is still pending"}},
 )
 async def get_duplicate_job_result(
     project_id: UUID,
     job_id: str,
     db: Annotated[AsyncSession, Depends(get_db)],
     user: OptionalUser,
-) -> DuplicateDetectionResult:
-    """Get duplicate detection results by job ID."""
+) -> DuplicateDetectionResult | Response:
+    """Get duplicate detection results by job ID.
+
+    Returns 200 with results when complete, 202 when still pending,
+    or 404 when the job ID is unknown or expired.
+    """
     await verify_project_access(project_id, db, user)
 
     redis = _get_redis()
     cached = await redis.get(f"duplicates_job:{project_id}:{job_id}")
-    if cached is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Job result not found or expired",
+    if cached is not None:
+        try:
+            return DuplicateDetectionResult.model_validate_json(cached)
+        except pydantic.ValidationError as e:
+            logger.error("Corrupt cached duplicates result for job %s: %s", job_id, e)
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Cached result is corrupt",
+            ) from e
+
+    # No result yet — check if the job is still pending
+    job_status = await redis.get(f"duplicates_job_status:{project_id}:{job_id}")
+    if job_status is not None:
+        return JSONResponse(
+            status_code=status.HTTP_202_ACCEPTED,
+            content=QualityJobPendingResponse(job_id=job_id).model_dump(),
         )
-    try:
-        return DuplicateDetectionResult.model_validate_json(cached)
-    except pydantic.ValidationError as e:
-        logger.error("Corrupt cached duplicates result for job %s: %s", job_id, e)
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Cached result is corrupt",
-        ) from e
+
+    raise HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND,
+        detail="Job result not found or expired",
+    )
 
 
 @router.get(
@@ -309,8 +348,11 @@ async def quality_websocket(
         pubsub = pool.pubsub()
         await pubsub.subscribe(QUALITY_UPDATES_CHANNEL)
 
+        # TODO: Replace this 0.1s poll loop with concurrent coroutines
+        # (blocking Redis listener + blocking WS receive) when tackling #78
+        # (per-project Redis pubsub channels). The lint WS uses the same
+        # pattern and both should be refactored together.
         while True:
-            # Check for Redis messages (non-blocking with short timeout)
             message = await pubsub.get_message(ignore_subscribe_messages=True, timeout=0.1)
             if message and message["type"] == "message":
                 try:

--- a/ontokit/api/routes/quality.py
+++ b/ontokit/api/routes/quality.py
@@ -1,5 +1,6 @@
 """Quality API endpoints — cross-references, consistency checks, duplicate detection."""
 
+import json
 import logging
 import uuid
 from typing import Annotated
@@ -7,21 +8,22 @@ from urllib.parse import unquote
 from uuid import UUID
 
 import redis.asyncio as aioredis
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, WebSocket, WebSocketDisconnect, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ontokit.api.dependencies import load_project_graph, resolve_branch, verify_project_access
+from ontokit.api.utils.redis import get_arq_pool
 from ontokit.core.auth import OptionalUser, RequiredUser
+from ontokit.core.constants import QUALITY_UPDATES_CHANNEL
 from ontokit.core.database import get_db
 from ontokit.schemas.quality import (
     ConsistencyCheckResult,
     ConsistencyCheckTriggerResponse,
     CrossReferencesResponse,
     DuplicateDetectionResult,
+    DuplicateDetectionTriggerResponse,
 )
-from ontokit.services.consistency_service import run_consistency_check
 from ontokit.services.cross_reference_service import get_cross_references
-from ontokit.services.duplicate_detection_service import find_duplicates
 
 logger = logging.getLogger(__name__)
 
@@ -65,23 +67,33 @@ async def trigger_consistency_check(
     user: RequiredUser,
     branch: str | None = Query(default=None, description="Branch name"),
 ) -> ConsistencyCheckTriggerResponse:
-    """Run consistency checks and cache the result."""
+    """Enqueue a consistency check as a background job."""
     await verify_project_access(project_id, db, user)
-    graph, resolved_branch = await load_project_graph(project_id, branch, db)
+    resolved_branch = await resolve_branch(project_id, branch)
 
-    result = run_consistency_check(graph, str(project_id), resolved_branch)
-
-    # Cache in Redis with 10-min TTL
     job_id = str(uuid.uuid4())
+
     try:
-        redis = _get_redis()
-        result_json = result.model_dump_json()
-        cache_key = f"quality:{project_id}:{resolved_branch}"
-        job_key = f"quality_job:{project_id}:{job_id}"
-        await redis.set(cache_key, result_json, ex=600)
-        await redis.set(job_key, result_json, ex=600)
-    except Exception:
-        logger.warning("Failed to cache consistency result in Redis", exc_info=True)
+        pool = await get_arq_pool()
+        job = await pool.enqueue_job(
+            "run_consistency_check_task",
+            str(project_id),
+            resolved_branch,
+            job_id,
+        )
+        if job is None:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to enqueue consistency check job",
+            )
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.exception("Failed to enqueue consistency check: %s", e)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to enqueue consistency check job",
+        ) from e
 
     return ConsistencyCheckTriggerResponse(job_id=job_id)
 
@@ -152,7 +164,7 @@ async def get_consistency_issues(
 
 @router.post(
     "/{project_id}/quality/duplicates",
-    response_model=DuplicateDetectionResult,
+    response_model=DuplicateDetectionTriggerResponse,
 )
 async def detect_duplicates(
     project_id: UUID,
@@ -160,8 +172,151 @@ async def detect_duplicates(
     user: RequiredUser,
     branch: str | None = Query(default=None, description="Branch name"),
     threshold: float = Query(default=0.85, ge=0.5, le=1.0),
-) -> DuplicateDetectionResult:
-    """Detect duplicate entities based on label similarity."""
+) -> DuplicateDetectionTriggerResponse:
+    """Enqueue duplicate detection as a background job."""
     await verify_project_access(project_id, db, user)
-    graph, _ = await load_project_graph(project_id, branch, db)
-    return find_duplicates(graph, threshold)
+    resolved_branch = await resolve_branch(project_id, branch)
+
+    job_id = str(uuid.uuid4())
+
+    try:
+        pool = await get_arq_pool()
+        job = await pool.enqueue_job(
+            "run_duplicate_detection_task",
+            str(project_id),
+            resolved_branch,
+            threshold,
+            job_id,
+        )
+        if job is None:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to enqueue duplicate detection job",
+            )
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.exception("Failed to enqueue duplicate detection: %s", e)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to enqueue duplicate detection job",
+        ) from e
+
+    return DuplicateDetectionTriggerResponse(job_id=job_id)
+
+
+@router.get(
+    "/{project_id}/quality/duplicates/jobs/{job_id}",
+    response_model=DuplicateDetectionResult,
+)
+async def get_duplicate_job_result(
+    project_id: UUID,
+    job_id: str,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    user: OptionalUser,
+) -> DuplicateDetectionResult:
+    """Get duplicate detection results by job ID."""
+    await verify_project_access(project_id, db, user)
+
+    try:
+        redis = _get_redis()
+        cached = await redis.get(f"duplicates_job:{project_id}:{job_id}")
+        if cached:
+            return DuplicateDetectionResult.model_validate_json(cached)
+    except Exception:
+        logger.warning("Failed to read duplicates job from Redis", exc_info=True)
+
+    raise HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND,
+        detail="Job result not found or expired",
+    )
+
+
+@router.get(
+    "/{project_id}/quality/duplicates/latest",
+    response_model=DuplicateDetectionResult,
+)
+async def get_latest_duplicates(
+    project_id: UUID,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    user: OptionalUser,
+    branch: str | None = Query(default=None, description="Branch name"),
+) -> DuplicateDetectionResult:
+    """Get cached duplicate detection results."""
+    await verify_project_access(project_id, db, user)
+    resolved_branch = await resolve_branch(project_id, branch)
+
+    try:
+        redis = _get_redis()
+        cached = await redis.get(f"duplicates:{project_id}:{resolved_branch}")
+        if cached:
+            return DuplicateDetectionResult.model_validate_json(cached)
+    except Exception:
+        logger.warning("Failed to read duplicates cache from Redis", exc_info=True)
+
+    from datetime import UTC, datetime
+
+    return DuplicateDetectionResult(
+        clusters=[],
+        threshold=0.85,
+        checked_at=datetime.now(UTC).isoformat(),
+    )
+
+
+@router.websocket("/{project_id}/quality/ws")
+async def quality_websocket(
+    websocket: WebSocket,
+    project_id: UUID,
+    token: str | None = Query(default=None, description="Bearer token for authentication"),
+) -> None:
+    """
+    WebSocket endpoint for real-time quality check updates.
+
+    Connect to receive notifications when:
+    - Consistency check starts / completes / fails
+    - Duplicate detection starts / completes / fails
+
+    Messages are JSON objects with a "type" field indicating the event type.
+    Pass ``token`` as a query parameter for authentication.
+    """
+    import asyncio
+
+    from ontokit.api.utils.ws_auth import authenticate_ws
+
+    project_id_str = str(project_id)
+
+    if not await authenticate_ws(websocket, project_id, token):
+        return
+
+    pubsub = None
+    try:
+        pool = await get_arq_pool()
+        pubsub = pool.pubsub()
+        await pubsub.subscribe(QUALITY_UPDATES_CHANNEL)
+
+        while True:
+            # Check for Redis messages (non-blocking with short timeout)
+            message = await pubsub.get_message(ignore_subscribe_messages=True, timeout=0.1)
+            if message and message["type"] == "message":
+                try:
+                    data = json.loads(message["data"])
+                    if data.get("project_id") == project_id_str:
+                        await websocket.send_json(data)
+                except json.JSONDecodeError:
+                    pass
+
+            # Check for WebSocket messages (keepalive/close)
+            try:
+                await asyncio.wait_for(websocket.receive_text(), timeout=0.1)
+            except TimeoutError:
+                pass
+            except WebSocketDisconnect:
+                break
+
+    except WebSocketDisconnect:
+        pass
+    except Exception as e:
+        logger.error("Quality WebSocket error for project %s: %s", project_id, e)
+    finally:
+        if pubsub:
+            await pubsub.unsubscribe(QUALITY_UPDATES_CHANNEL)

--- a/ontokit/core/constants.py
+++ b/ontokit/core/constants.py
@@ -19,4 +19,5 @@ ONTOKIT_COMMITTER_EMAILS: frozenset[str] = frozenset(
 LINT_UPDATES_CHANNEL = "lint:updates"
 NORMALIZATION_UPDATES_CHANNEL = "normalization:updates"
 ONTOLOGY_INDEX_UPDATES_CHANNEL = "ontology_index:updates"
+QUALITY_UPDATES_CHANNEL = "quality:updates"
 REMOTE_SYNC_UPDATES_CHANNEL = "remote_sync:updates"

--- a/ontokit/schemas/quality.py
+++ b/ontokit/schemas/quality.py
@@ -115,3 +115,11 @@ class DuplicateDetectionResult(BaseModel):
     clusters: list[DuplicateCluster]
     threshold: float
     checked_at: str
+
+
+# --- Shared job status ---
+
+
+class QualityJobPendingResponse(BaseModel):
+    job_id: str
+    status: Literal["pending"] = "pending"

--- a/ontokit/schemas/quality.py
+++ b/ontokit/schemas/quality.py
@@ -107,6 +107,10 @@ class DuplicateCluster(BaseModel):
     similarity: float
 
 
+class DuplicateDetectionTriggerResponse(BaseModel):
+    job_id: str
+
+
 class DuplicateDetectionResult(BaseModel):
     clusters: list[DuplicateCluster]
     threshold: float

--- a/ontokit/services/duplicate_detection_service.py
+++ b/ontokit/services/duplicate_detection_service.py
@@ -17,6 +17,24 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from ontokit.schemas.quality import DuplicateCluster, DuplicateDetectionResult, DuplicateEntity
 
 
+class DisjointSet:
+    """Union-find data structure with path compression."""
+
+    def __init__(self) -> None:
+        self._parent: dict[str, str] = {}
+
+    def find(self, x: str) -> str:
+        while self._parent.get(x, x) != x:
+            self._parent[x] = self._parent.get(self._parent[x], self._parent[x])
+            x = self._parent[x]
+        return x
+
+    def union(self, x: str, y: str) -> None:
+        px, py = self.find(x), self.find(y)
+        if px != py:
+            self._parent[px] = py
+
+
 async def find_duplicates_sql(
     db: AsyncSession,
     project_id: UUID,
@@ -56,7 +74,7 @@ async def find_duplicates_sql(
 
     # Step 2: For each entity's label, find similar labels using GIN index.
     # The GIN trigram index on indexed_labels.value makes `value % 'literal'`
-    # an indexed O(1) lookup instead of a full table scan.
+    # a sub-linear indexed lookup instead of a full table scan.
     pair_sim: dict[tuple[str, str], float] = {}
     matched: set[str] = set()
 
@@ -97,25 +115,14 @@ async def find_duplicates_sql(
             matched.add(mid)
 
     # Build clusters via union-find from the collected pair_sim data
-    parent: dict[str, str] = {}
-
-    def find(x: str) -> str:
-        while parent.get(x, x) != x:
-            parent[x] = parent.get(parent[x], parent[x])
-            x = parent[x]
-        return x
-
-    def union(x: str, y: str) -> None:
-        px, py = find(x), find(y)
-        if px != py:
-            parent[px] = py
+    ds = DisjointSet()
 
     # Union all matched pairs and build entity_info lookup
     entity_info: dict[str, tuple[str, str]] = {}  # iri → (label, entity_type)
     iri_lookup = {iri: (label, etype) for _eid, (iri, label, etype) in entity_map.items()}
 
     for iri_a, iri_b in pair_sim:
-        union(iri_a, iri_b)
+        ds.union(iri_a, iri_b)
         if iri_a in iri_lookup:
             entity_info[iri_a] = (iri_lookup[iri_a][0], iri_lookup[iri_a][1])
         if iri_b in iri_lookup:
@@ -124,7 +131,7 @@ async def find_duplicates_sql(
     # Build clusters
     clusters_map: dict[str, list[str]] = defaultdict(list)
     for iri in entity_info:
-        clusters_map[find(iri)].append(iri)
+        clusters_map[ds.find(iri)].append(iri)
 
     clusters = []
     for _root, members in clusters_map.items():
@@ -191,19 +198,7 @@ def find_duplicates(graph: Graph, threshold: float = 0.85) -> DuplicateDetection
     for iri, label, etype in entities:
         by_type[etype].append((iri, label))
 
-    parent: dict[str, str] = {}
-
-    def find(x: str) -> str:
-        while parent.get(x, x) != x:
-            parent[x] = parent.get(parent[x], parent[x])
-            x = parent[x]
-        return x
-
-    def union(x: str, y: str) -> None:
-        px, py = find(x), find(y)
-        if px != py:
-            parent[px] = py
-
+    ds = DisjointSet()
     pair_sim: dict[tuple[str, str], float] = {}
 
     for _etype, etype_entities in by_type.items():
@@ -217,12 +212,12 @@ def find_duplicates(graph: Graph, threshold: float = 0.85) -> DuplicateDetection
                 sim = difflib.SequenceMatcher(None, norm_a, norm_b).ratio()
                 pair_sim[(iri_a, iri_b)] = sim
                 if sim >= threshold:
-                    union(iri_a, iri_b)
+                    ds.union(iri_a, iri_b)
 
     clusters_map: dict[str, list[tuple[str, str, str]]] = defaultdict(list)
     entity_lookup = {iri: (label, etype) for iri, label, etype in entities}
     for iri, (label, etype) in entity_lookup.items():
-        root = find(iri)
+        root = ds.find(iri)
         clusters_map[root].append((iri, label, etype))
 
     clusters = []

--- a/ontokit/services/duplicate_detection_service.py
+++ b/ontokit/services/duplicate_detection_service.py
@@ -76,14 +76,8 @@ async def find_duplicates_sql(
     # The GIN trigram index on indexed_labels.value makes `value % 'literal'`
     # a sub-linear indexed lookup instead of a full table scan.
     pair_sim: dict[tuple[str, str], float] = {}
-    queried: set[str] = set()  # Track seeds already queried (not just matched)
 
     for row in entities:
-        eid = str(row.entity_id)
-        if eid in queried:
-            continue
-        queried.add(eid)
-
         similar = await db.execute(
             text("""
                 SELECT e.id AS entity_id, e.iri, l.value,
@@ -97,7 +91,7 @@ async def find_duplicates_sql(
                   AND e.entity_type = :entity_type
                   AND e.id != :entity_id
                 ORDER BY sim DESC
-                LIMIT 10
+                LIMIT 50
             """),
             {
                 "label": row.value,
@@ -111,7 +105,9 @@ async def find_duplicates_sql(
             mid = str(match.entity_id)
             if mid not in entity_ids:
                 continue
-            pair_sim[(row.iri, match.iri)] = float(match.sim)
+            key = (row.iri, match.iri)
+            sim = float(match.sim)
+            pair_sim[key] = max(pair_sim.get(key, 0.0), sim)
 
     # Build clusters via union-find from the collected pair_sim data
     ds = DisjointSet()

--- a/ontokit/services/duplicate_detection_service.py
+++ b/ontokit/services/duplicate_detection_service.py
@@ -76,12 +76,13 @@ async def find_duplicates_sql(
     # The GIN trigram index on indexed_labels.value makes `value % 'literal'`
     # a sub-linear indexed lookup instead of a full table scan.
     pair_sim: dict[tuple[str, str], float] = {}
-    matched: set[str] = set()
+    queried: set[str] = set()  # Track seeds already queried (not just matched)
 
     for row in entities:
         eid = str(row.entity_id)
-        if eid in matched:
-            continue  # Skip entities already clustered
+        if eid in queried:
+            continue
+        queried.add(eid)
 
         similar = await db.execute(
             text("""
@@ -111,8 +112,6 @@ async def find_duplicates_sql(
             if mid not in entity_ids:
                 continue
             pair_sim[(row.iri, match.iri)] = float(match.sim)
-            matched.add(eid)
-            matched.add(mid)
 
     # Build clusters via union-find from the collected pair_sim data
     ds = DisjointSet()

--- a/ontokit/services/duplicate_detection_service.py
+++ b/ontokit/services/duplicate_detection_service.py
@@ -1,43 +1,102 @@
-"""Duplicate detection service — find entities with similar labels."""
+"""Duplicate detection service — find entities with similar labels.
 
-import difflib
+Uses PostgreSQL's pg_trgm extension with the existing GIN trigram index on
+indexed_labels.value for fast fuzzy matching.  Falls back to the legacy
+in-memory rdflib approach when the project has no PostgreSQL index.
+"""
+
+from __future__ import annotations
+
 from collections import defaultdict
 from datetime import UTC, datetime
+from uuid import UUID
 
-from rdflib import Graph, URIRef
-from rdflib import Literal as RDFLiteral
-from rdflib.namespace import OWL, RDF, RDFS
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from ontokit.schemas.quality import DuplicateCluster, DuplicateDetectionResult, DuplicateEntity
-from ontokit.services.rdf_utils import get_entity_type as _get_entity_type
 
 
-def _extract_entities(graph: Graph) -> list[tuple[str, str, str]]:
-    """Extract (iri, label, entity_type) for all labelled entities."""
-    entities = []
-    for s in graph.subjects(RDF.type, None):
-        if not isinstance(s, URIRef) or s == OWL.Thing:
-            continue
-        etype = _get_entity_type(graph, s)
-        if etype == "unknown":
-            continue
-        for obj in graph.objects(s, RDFS.label):
-            if isinstance(obj, RDFLiteral):
-                entities.append((str(s), str(obj), etype))
-                break  # Use first label
-    return entities
+async def find_duplicates_sql(
+    db: AsyncSession,
+    project_id: UUID,
+    branch: str,
+    threshold: float = 0.85,
+) -> DuplicateDetectionResult:
+    """Find duplicate entities using PostgreSQL trigram similarity.
 
+    For each rdfs:label in the project, queries the GIN trigram index for
+    similar labels belonging to *other* entities of the same type.  This
+    avoids parsing the ontology file and runs in seconds rather than minutes.
+    """
+    # Set the similarity threshold for this transaction
+    await db.execute(text(f"SET LOCAL pg_trgm.similarity_threshold = {float(threshold)}"))
 
-def find_duplicates(graph: Graph, threshold: float = 0.85) -> DuplicateDetectionResult:
-    """Find entities with similar labels using string similarity."""
-    entities = _extract_entities(graph)
+    # Step 1: Get one rdfs:label per entity for this project/branch
+    labels_result = await db.execute(
+        text("""
+            SELECT DISTINCT ON (e.id)
+                e.id AS entity_id, e.iri, e.entity_type, l.value
+            FROM indexed_entities e
+            JOIN indexed_labels l ON l.entity_id = e.id
+            WHERE e.project_id = :project_id
+              AND e.branch = :branch
+              AND l.property_iri = 'http://www.w3.org/2000/01/rdf-schema#label'
+            ORDER BY e.id, l.lang NULLS LAST
+        """),
+        {"project_id": project_id, "branch": branch},
+    )
+    entities = labels_result.fetchall()
 
-    # Group by entity type for comparison (only compare within same type)
-    by_type: dict[str, list[tuple[str, str]]] = defaultdict(list)
-    for iri, label, etype in entities:
-        by_type[etype].append((iri, label))
+    # Build lookup maps
+    entity_ids = {str(row.entity_id) for row in entities}
+    entity_map: dict[str, tuple[str, str, str]] = {}  # entity_id → (iri, label, type)
+    for row in entities:
+        entity_map[str(row.entity_id)] = (row.iri, row.value, row.entity_type)
 
-    # Union-find for clustering
+    # Step 2: For each entity's label, find similar labels using GIN index.
+    # The GIN trigram index on indexed_labels.value makes `value % 'literal'`
+    # an indexed O(1) lookup instead of a full table scan.
+    pair_sim: dict[tuple[str, str], float] = {}
+    matched: set[str] = set()
+
+    for row in entities:
+        eid = str(row.entity_id)
+        if eid in matched:
+            continue  # Skip entities already clustered
+
+        similar = await db.execute(
+            text("""
+                SELECT e.id AS entity_id, e.iri, l.value,
+                       similarity(l.value, :label) AS sim
+                FROM indexed_labels l
+                JOIN indexed_entities e ON l.entity_id = e.id
+                WHERE l.value % :label
+                  AND l.property_iri = 'http://www.w3.org/2000/01/rdf-schema#label'
+                  AND e.project_id = :project_id
+                  AND e.branch = :branch
+                  AND e.entity_type = :entity_type
+                  AND e.id != :entity_id
+                ORDER BY sim DESC
+                LIMIT 10
+            """),
+            {
+                "label": row.value,
+                "project_id": project_id,
+                "branch": branch,
+                "entity_type": row.entity_type,
+                "entity_id": row.entity_id,
+            },
+        )
+        for match in similar:
+            mid = str(match.entity_id)
+            if mid not in entity_ids:
+                continue
+            pair_sim[(row.iri, match.iri)] = float(match.sim)
+            matched.add(eid)
+            matched.add(mid)
+
+    # Build clusters via union-find from the collected pair_sim data
     parent: dict[str, str] = {}
 
     def find(x: str) -> str:
@@ -51,7 +110,100 @@ def find_duplicates(graph: Graph, threshold: float = 0.85) -> DuplicateDetection
         if px != py:
             parent[px] = py
 
-    # Track pairwise similarities
+    # Union all matched pairs and build entity_info lookup
+    entity_info: dict[str, tuple[str, str]] = {}  # iri → (label, entity_type)
+    iri_lookup = {iri: (label, etype) for _eid, (iri, label, etype) in entity_map.items()}
+
+    for iri_a, iri_b in pair_sim:
+        union(iri_a, iri_b)
+        if iri_a in iri_lookup:
+            entity_info[iri_a] = (iri_lookup[iri_a][0], iri_lookup[iri_a][1])
+        if iri_b in iri_lookup:
+            entity_info[iri_b] = (iri_lookup[iri_b][0], iri_lookup[iri_b][1])
+
+    # Build clusters
+    clusters_map: dict[str, list[str]] = defaultdict(list)
+    for iri in entity_info:
+        clusters_map[find(iri)].append(iri)
+
+    clusters = []
+    for _root, members in clusters_map.items():
+        if len(members) < 2:
+            continue
+        sims = []
+        for i in range(len(members)):
+            for j in range(i + 1, len(members)):
+                key = (members[i], members[j])
+                rev = (members[j], members[i])
+                if key in pair_sim:
+                    sims.append(pair_sim[key])
+                elif rev in pair_sim:
+                    sims.append(pair_sim[rev])
+        avg_sim = sum(sims) / len(sims) if sims else threshold
+
+        clusters.append(
+            DuplicateCluster(
+                entities=[
+                    DuplicateEntity(
+                        iri=iri,
+                        label=entity_info[iri][0],
+                        entity_type=entity_info[iri][1],
+                    )
+                    for iri in members
+                ],
+                similarity=round(avg_sim, 3),
+            )
+        )
+
+    return DuplicateDetectionResult(
+        clusters=clusters,
+        threshold=threshold,
+        checked_at=datetime.now(UTC).isoformat(),
+    )
+
+
+# Legacy in-memory approach (kept for projects without a PostgreSQL index)
+
+
+def find_duplicates(graph: Graph, threshold: float = 0.85) -> DuplicateDetectionResult:  # type: ignore[name-defined]  # noqa: F821
+    """Find entities with similar labels using string similarity (legacy, slow)."""
+    import difflib
+
+    from rdflib import Literal as RDFLiteral
+    from rdflib import URIRef  # noqa: F811
+    from rdflib.namespace import OWL, RDF, RDFS
+
+    from ontokit.services.rdf_utils import get_entity_type as _get_entity_type
+
+    entities: list[tuple[str, str, str]] = []
+    for s in graph.subjects(RDF.type, None):
+        if not isinstance(s, URIRef) or s == OWL.Thing:
+            continue
+        etype = _get_entity_type(graph, s)
+        if etype == "unknown":
+            continue
+        for obj in graph.objects(s, RDFS.label):
+            if isinstance(obj, RDFLiteral):
+                entities.append((str(s), str(obj), etype))
+                break
+
+    by_type: dict[str, list[tuple[str, str]]] = defaultdict(list)
+    for iri, label, etype in entities:
+        by_type[etype].append((iri, label))
+
+    parent: dict[str, str] = {}
+
+    def find(x: str) -> str:
+        while parent.get(x, x) != x:
+            parent[x] = parent.get(parent[x], parent[x])
+            x = parent[x]
+        return x
+
+    def union(x: str, y: str) -> None:
+        px, py = find(x), find(y)
+        if px != py:
+            parent[px] = py
+
     pair_sim: dict[tuple[str, str], float] = {}
 
     for _etype, etype_entities in by_type.items():
@@ -67,19 +219,16 @@ def find_duplicates(graph: Graph, threshold: float = 0.85) -> DuplicateDetection
                 if sim >= threshold:
                     union(iri_a, iri_b)
 
-    # Build clusters
     clusters_map: dict[str, list[tuple[str, str, str]]] = defaultdict(list)
     entity_lookup = {iri: (label, etype) for iri, label, etype in entities}
     for iri, (label, etype) in entity_lookup.items():
         root = find(iri)
         clusters_map[root].append((iri, label, etype))
 
-    # Build response clusters
     clusters = []
     for _root, members in clusters_map.items():
         if len(members) < 2:
             continue
-        # Average similarity between all pairs in cluster
         sims = []
         for i in range(len(members)):
             for j in range(i + 1, len(members)):

--- a/ontokit/worker.py
+++ b/ontokit/worker.py
@@ -558,12 +558,10 @@ async def run_consistency_check_task(
             raise ValueError(f"Project {project_id} has no ontology file")
 
         # Load ontology graph
-        import os
-
         storage = get_storage_service()
         ontology_service = get_ontology_service(storage)
         git_service = BareGitRepositoryService()
-        filename = os.path.basename(project.source_file_path)
+        filename = get_git_ontology_path(project)
 
         if git_service.repository_exists(project_uuid):
             graph = await ontology_service.load_from_git(
@@ -679,12 +677,10 @@ async def run_duplicate_detection_task(
             raise ValueError(f"Project {project_id} has no ontology file")
 
         # Load ontology graph
-        import os
-
         storage = get_storage_service()
         ontology_service = get_ontology_service(storage)
         git_service = BareGitRepositoryService()
-        filename = os.path.basename(project.source_file_path)
+        filename = get_git_ontology_path(project)
 
         if git_service.repository_exists(project_uuid):
             graph = await ontology_service.load_from_git(

--- a/ontokit/worker.py
+++ b/ontokit/worker.py
@@ -692,8 +692,8 @@ async def run_duplicate_detection_task(
     """
     Background task to detect duplicate entities in a project ontology.
 
-    Loads the graph, runs O(n²) label similarity comparisons, caches the
-    result in Redis, and publishes progress via the QUALITY_UPDATES_CHANNEL.
+    Uses the PostgreSQL trigram index on indexed_labels for fast fuzzy matching,
+    caches the result in Redis, and publishes progress via QUALITY_UPDATES_CHANNEL.
     """
     db: AsyncSession = ctx["db"]
     redis: ArqRedis = ctx["redis"]
@@ -714,47 +714,10 @@ async def run_duplicate_detection_task(
             ),
         )
 
-        # Load project (eagerly load github_integration for file path resolution)
-        result = await db.execute(
-            select(Project)
-            .options(selectinload(Project.github_integration))
-            .where(Project.id == project_uuid)
-        )
-        project = result.scalar_one_or_none()
-        if not project:
-            raise ValueError(f"Project {project_id} not found")
-        if not project.source_file_path and not project.github_integration:
-            raise ValueError(f"Project {project_id} has no ontology file")
+        # Run duplicate detection via PostgreSQL trigram similarity
+        from ontokit.services.duplicate_detection_service import find_duplicates_sql
 
-        # Load ontology content and parse in a subprocess (CPU-bound, holds GIL)
-        import asyncio
-        from concurrent.futures import ProcessPoolExecutor
-
-        git_service = BareGitRepositoryService()
-        filename = get_git_ontology_path(project)
-
-        if git_service.repository_exists(project_uuid):
-            content_bytes = git_service.get_file_from_branch(project_uuid, branch, filename)
-            content_str = content_bytes.decode("utf-8")
-        elif project.source_file_path:
-            storage = get_storage_service()
-            content_bytes = await storage.download_file(project.source_file_path)
-            content_str = content_bytes.decode("utf-8")
-        else:
-            raise ValueError(f"Project {project_id} has no git repository and no storage file")
-
-        ext = "." + filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
-        rdf_format = _FORMAT_MAP.get(ext, "turtle")
-
-        loop = asyncio.get_running_loop()
-        with ProcessPoolExecutor(max_workers=1) as pool:
-            graph = await loop.run_in_executor(pool, _parse_rdf, content_str, rdf_format)
-
-        # Run duplicate detection (also CPU-bound)
-        from ontokit.services.duplicate_detection_service import find_duplicates
-
-        with ProcessPoolExecutor(max_workers=1) as pool:
-            detection_result = await loop.run_in_executor(pool, find_duplicates, graph, threshold)
+        detection_result = await find_duplicates_sql(db, project_uuid, branch, threshold)
 
         # Cache result in Redis and clear the pending status key
         result_json = detection_result.model_dump_json()

--- a/ontokit/worker.py
+++ b/ontokit/worker.py
@@ -549,12 +549,16 @@ async def run_consistency_check_task(
             ),
         )
 
-        # Load project
-        result = await db.execute(select(Project).where(Project.id == project_uuid))
+        # Load project (eagerly load github_integration for file path resolution)
+        result = await db.execute(
+            select(Project)
+            .options(selectinload(Project.github_integration))
+            .where(Project.id == project_uuid)
+        )
         project = result.scalar_one_or_none()
         if not project:
             raise ValueError(f"Project {project_id} not found")
-        if not project.source_file_path:
+        if not project.source_file_path and not project.github_integration:
             raise ValueError(f"Project {project_id} has no ontology file")
 
         # Load ontology graph
@@ -567,10 +571,12 @@ async def run_consistency_check_task(
             graph = await ontology_service.load_from_git(
                 project_uuid, branch, filename, git_service
             )
-        else:
+        elif project.source_file_path:
             graph = await ontology_service.load_from_storage(
                 project_uuid, project.source_file_path, branch
             )
+        else:
+            raise ValueError(f"Project {project_id} has no git repository and no storage file")
 
         # Run consistency check (CPU-bound, run in thread)
         import asyncio
@@ -671,12 +677,16 @@ async def run_duplicate_detection_task(
             ),
         )
 
-        # Load project
-        result = await db.execute(select(Project).where(Project.id == project_uuid))
+        # Load project (eagerly load github_integration for file path resolution)
+        result = await db.execute(
+            select(Project)
+            .options(selectinload(Project.github_integration))
+            .where(Project.id == project_uuid)
+        )
         project = result.scalar_one_or_none()
         if not project:
             raise ValueError(f"Project {project_id} not found")
-        if not project.source_file_path:
+        if not project.source_file_path and not project.github_integration:
             raise ValueError(f"Project {project_id} has no ontology file")
 
         # Load ontology graph
@@ -689,10 +699,12 @@ async def run_duplicate_detection_task(
             graph = await ontology_service.load_from_git(
                 project_uuid, branch, filename, git_service
             )
-        else:
+        elif project.source_file_path:
             graph = await ontology_service.load_from_storage(
                 project_uuid, project.source_file_path, branch
             )
+        else:
+            raise ValueError(f"Project {project_id} has no git repository and no storage file")
 
         # Run duplicate detection (CPU-bound, run in thread)
         import asyncio

--- a/ontokit/worker.py
+++ b/ontokit/worker.py
@@ -59,6 +59,19 @@ def _parse_rdf(content_str: str, rdf_format: str) -> Any:
     return graph
 
 
+def _parse_and_run_consistency_check(
+    content_str: str, rdf_format: str, project_id: str, branch: str
+) -> Any:
+    """Parse RDF and run consistency check in a single subprocess.
+
+    Avoids double-pickling the Graph object across process boundaries.
+    """
+    from ontokit.services.consistency_service import run_consistency_check
+
+    graph = _parse_rdf(content_str, rdf_format)
+    return run_consistency_check(graph, project_id, branch)
+
+
 async def run_ontology_index_task(
     ctx: dict[str, Any],
     project_id: str,
@@ -605,16 +618,17 @@ async def run_consistency_check_task(
         ext = "." + filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
         rdf_format = _FORMAT_MAP.get(ext, "turtle")
 
+        # Parse RDF and run consistency check in a single subprocess
+        # (avoids double-pickling the Graph object across process boundaries)
         loop = asyncio.get_running_loop()
         with ProcessPoolExecutor(max_workers=1) as pool:
-            graph = await loop.run_in_executor(pool, _parse_rdf, content_str, rdf_format)
-
-        # Run consistency check (also CPU-bound)
-        from ontokit.services.consistency_service import run_consistency_check
-
-        with ProcessPoolExecutor(max_workers=1) as pool:
             check_result = await loop.run_in_executor(
-                pool, run_consistency_check, graph, project_id, branch
+                pool,
+                _parse_and_run_consistency_check,
+                content_str,
+                rdf_format,
+                project_id,
+                branch,
             )
 
         # Cache result in Redis and clear the pending status key

--- a/ontokit/worker.py
+++ b/ontokit/worker.py
@@ -34,6 +34,38 @@ from ontokit.services.storage import get_storage_service
 
 logger = logging.getLogger(__name__)
 
+# Format map matching ontokit.services.ontology.FORMAT_MAP
+_FORMAT_MAP: dict[str, str] = {
+    ".ttl": "turtle",
+    ".owl": "xml",
+    ".rdf": "xml",
+    ".n3": "n3",
+    ".nt": "nt",
+    ".jsonld": "json-ld",
+    ".json": "json-ld",
+}
+
+
+def _sync_load_from_git(
+    git_service: BareGitRepositoryService,
+    project_id: UUID,
+    branch: str,
+    filename: str,
+) -> Any:
+    """Load and parse an ontology from git synchronously (for use with asyncio.to_thread).
+
+    RDFLib's graph.parse() is CPU-bound and can take minutes for large ontologies.
+    Running this in a thread keeps the worker event loop responsive.
+    """
+    from rdflib import Graph
+
+    content = git_service.get_file_from_branch(project_id, branch, filename)
+    ext = "." + filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
+    rdf_format = _FORMAT_MAP.get(ext, "turtle")
+    graph = Graph()
+    graph.parse(data=content.decode("utf-8"), format=rdf_format)
+    return graph
+
 
 async def run_ontology_index_task(
     ctx: dict[str, Any],
@@ -561,15 +593,18 @@ async def run_consistency_check_task(
         if not project.source_file_path and not project.github_integration:
             raise ValueError(f"Project {project_id} has no ontology file")
 
-        # Load ontology graph
+        # Load ontology graph (graph.parse is CPU-bound for large files)
+        import asyncio
+
         storage = get_storage_service()
         ontology_service = get_ontology_service(storage)
         git_service = BareGitRepositoryService()
         filename = get_git_ontology_path(project)
 
         if git_service.repository_exists(project_uuid):
-            graph = await ontology_service.load_from_git(
-                project_uuid, branch, filename, git_service
+            # load_from_git is async-in-name-only — run in thread to avoid blocking
+            graph = await asyncio.to_thread(
+                lambda: _sync_load_from_git(git_service, project_uuid, branch, filename)
             )
         elif project.source_file_path:
             graph = await ontology_service.load_from_storage(
@@ -579,8 +614,6 @@ async def run_consistency_check_task(
             raise ValueError(f"Project {project_id} has no git repository and no storage file")
 
         # Run consistency check (CPU-bound, run in thread)
-        import asyncio
-
         from ontokit.services.consistency_service import run_consistency_check
 
         check_result = await asyncio.to_thread(run_consistency_check, graph, project_id, branch)
@@ -694,15 +727,18 @@ async def run_duplicate_detection_task(
         if not project.source_file_path and not project.github_integration:
             raise ValueError(f"Project {project_id} has no ontology file")
 
-        # Load ontology graph
+        # Load ontology graph (graph.parse is CPU-bound for large files)
+        import asyncio
+
         storage = get_storage_service()
         ontology_service = get_ontology_service(storage)
         git_service = BareGitRepositoryService()
         filename = get_git_ontology_path(project)
 
         if git_service.repository_exists(project_uuid):
-            graph = await ontology_service.load_from_git(
-                project_uuid, branch, filename, git_service
+            # load_from_git is async-in-name-only — run in thread to avoid blocking
+            graph = await asyncio.to_thread(
+                lambda: _sync_load_from_git(git_service, project_uuid, branch, filename)
             )
         elif project.source_file_path:
             graph = await ontology_service.load_from_storage(
@@ -712,7 +748,6 @@ async def run_duplicate_detection_task(
             raise ValueError(f"Project {project_id} has no git repository and no storage file")
 
         # Run duplicate detection (CPU-bound, run in thread)
-        import asyncio
 
         from ontokit.services.duplicate_detection_service import find_duplicates
 

--- a/ontokit/worker.py
+++ b/ontokit/worker.py
@@ -629,7 +629,12 @@ async def run_consistency_check_task(
             e,
         )
         if job_id:
-            await redis.delete(f"quality_job_status:{project_id}:{job_id}")
+            # Write a short-lived failed status so polling clients can surface the error
+            await redis.set(
+                f"quality_job_status:{project_id}:{job_id}",
+                json.dumps({"state": "failed", "error": str(e)}),
+                ex=600,
+            )
         await redis.publish(
             QUALITY_UPDATES_CHANNEL,
             json.dumps(
@@ -757,7 +762,12 @@ async def run_duplicate_detection_task(
             e,
         )
         if job_id:
-            await redis.delete(f"duplicates_job_status:{project_id}:{job_id}")
+            # Write a short-lived failed status so polling clients can surface the error
+            await redis.set(
+                f"duplicates_job_status:{project_id}:{job_id}",
+                json.dumps({"state": "failed", "error": str(e)}),
+                ex=600,
+            )
         await redis.publish(
             QUALITY_UPDATES_CHANNEL,
             json.dumps(

--- a/ontokit/worker.py
+++ b/ontokit/worker.py
@@ -17,6 +17,7 @@ from ontokit.core.constants import (
     LINT_UPDATES_CHANNEL,
     NORMALIZATION_UPDATES_CHANNEL,
     ONTOLOGY_INDEX_UPDATES_CHANNEL,
+    QUALITY_UPDATES_CHANNEL,
     REMOTE_SYNC_UPDATES_CHANNEL,
 )
 from ontokit.core.encryption import decrypt_token
@@ -517,6 +518,247 @@ async def auto_submit_stale_suggestions(ctx: dict[str, Any]) -> dict[str, Any]:
         raise
 
 
+async def run_consistency_check_task(
+    ctx: dict[str, Any],
+    project_id: str,
+    branch: str = "main",
+    job_id: str | None = None,
+) -> dict[str, Any]:
+    """
+    Background task to run consistency checks on a project ontology.
+
+    Loads the graph, runs all consistency rules, caches the result in Redis,
+    and publishes progress via the QUALITY_UPDATES_CHANNEL.
+    """
+    db: AsyncSession = ctx["db"]
+    redis: ArqRedis = ctx["redis"]
+
+    project_uuid = UUID(project_id)
+
+    try:
+        # Notify start
+        await redis.publish(
+            QUALITY_UPDATES_CHANNEL,
+            json.dumps(
+                {
+                    "type": "consistency_started",
+                    "project_id": project_id,
+                    "branch": branch,
+                    "job_id": job_id,
+                }
+            ),
+        )
+
+        # Load project
+        result = await db.execute(select(Project).where(Project.id == project_uuid))
+        project = result.scalar_one_or_none()
+        if not project:
+            raise ValueError(f"Project {project_id} not found")
+        if not project.source_file_path:
+            raise ValueError(f"Project {project_id} has no ontology file")
+
+        # Load ontology graph
+        import os
+
+        storage = get_storage_service()
+        ontology_service = get_ontology_service(storage)
+        git_service = BareGitRepositoryService()
+        filename = os.path.basename(project.source_file_path)
+
+        if git_service.repository_exists(project_uuid):
+            graph = await ontology_service.load_from_git(
+                project_uuid, branch, filename, git_service
+            )
+        else:
+            graph = await ontology_service.load_from_storage(
+                project_uuid, project.source_file_path, branch
+            )
+
+        # Run consistency check (CPU-bound, run in thread)
+        import asyncio
+
+        from ontokit.services.consistency_service import run_consistency_check
+
+        check_result = await asyncio.to_thread(run_consistency_check, graph, project_id, branch)
+
+        # Cache result in Redis
+        result_json = check_result.model_dump_json()
+        cache_key = f"quality:{project_id}:{branch}"
+        if job_id:
+            job_key = f"quality_job:{project_id}:{job_id}"
+            await redis.set(job_key, result_json, ex=600)
+        await redis.set(cache_key, result_json, ex=600)
+
+        logger.info(
+            "Consistency check completed for project %s branch %s: %d issues",
+            project_id,
+            branch,
+            len(check_result.issues),
+        )
+
+        # Notify completion
+        await redis.publish(
+            QUALITY_UPDATES_CHANNEL,
+            json.dumps(
+                {
+                    "type": "consistency_complete",
+                    "project_id": project_id,
+                    "branch": branch,
+                    "job_id": job_id,
+                    "issues_found": len(check_result.issues),
+                }
+            ),
+        )
+
+        return {
+            "job_id": job_id,
+            "issues_found": len(check_result.issues),
+            "status": "completed",
+        }
+
+    except Exception as e:
+        logger.exception(
+            "Consistency check failed for project %s branch %s: %s",
+            project_id,
+            branch,
+            e,
+        )
+        await redis.publish(
+            QUALITY_UPDATES_CHANNEL,
+            json.dumps(
+                {
+                    "type": "consistency_failed",
+                    "project_id": project_id,
+                    "branch": branch,
+                    "job_id": job_id,
+                    "error": str(e),
+                }
+            ),
+        )
+        raise
+
+
+async def run_duplicate_detection_task(
+    ctx: dict[str, Any],
+    project_id: str,
+    branch: str = "main",
+    threshold: float = 0.85,
+    job_id: str | None = None,
+) -> dict[str, Any]:
+    """
+    Background task to detect duplicate entities in a project ontology.
+
+    Loads the graph, runs O(n²) label similarity comparisons, caches the
+    result in Redis, and publishes progress via the QUALITY_UPDATES_CHANNEL.
+    """
+    db: AsyncSession = ctx["db"]
+    redis: ArqRedis = ctx["redis"]
+
+    project_uuid = UUID(project_id)
+
+    try:
+        # Notify start
+        await redis.publish(
+            QUALITY_UPDATES_CHANNEL,
+            json.dumps(
+                {
+                    "type": "duplicates_started",
+                    "project_id": project_id,
+                    "branch": branch,
+                    "job_id": job_id,
+                }
+            ),
+        )
+
+        # Load project
+        result = await db.execute(select(Project).where(Project.id == project_uuid))
+        project = result.scalar_one_or_none()
+        if not project:
+            raise ValueError(f"Project {project_id} not found")
+        if not project.source_file_path:
+            raise ValueError(f"Project {project_id} has no ontology file")
+
+        # Load ontology graph
+        import os
+
+        storage = get_storage_service()
+        ontology_service = get_ontology_service(storage)
+        git_service = BareGitRepositoryService()
+        filename = os.path.basename(project.source_file_path)
+
+        if git_service.repository_exists(project_uuid):
+            graph = await ontology_service.load_from_git(
+                project_uuid, branch, filename, git_service
+            )
+        else:
+            graph = await ontology_service.load_from_storage(
+                project_uuid, project.source_file_path, branch
+            )
+
+        # Run duplicate detection (CPU-bound, run in thread)
+        import asyncio
+
+        from ontokit.services.duplicate_detection_service import find_duplicates
+
+        detection_result = await asyncio.to_thread(find_duplicates, graph, threshold)
+
+        # Cache result in Redis
+        result_json = detection_result.model_dump_json()
+        cache_key = f"duplicates:{project_id}:{branch}"
+        if job_id:
+            job_key = f"duplicates_job:{project_id}:{job_id}"
+            await redis.set(job_key, result_json, ex=600)
+        await redis.set(cache_key, result_json, ex=600)
+
+        logger.info(
+            "Duplicate detection completed for project %s branch %s: %d clusters",
+            project_id,
+            branch,
+            len(detection_result.clusters),
+        )
+
+        # Notify completion
+        await redis.publish(
+            QUALITY_UPDATES_CHANNEL,
+            json.dumps(
+                {
+                    "type": "duplicates_complete",
+                    "project_id": project_id,
+                    "branch": branch,
+                    "job_id": job_id,
+                    "clusters_found": len(detection_result.clusters),
+                }
+            ),
+        )
+
+        return {
+            "job_id": job_id,
+            "clusters_found": len(detection_result.clusters),
+            "status": "completed",
+        }
+
+    except Exception as e:
+        logger.exception(
+            "Duplicate detection failed for project %s branch %s: %s",
+            project_id,
+            branch,
+            e,
+        )
+        await redis.publish(
+            QUALITY_UPDATES_CHANNEL,
+            json.dumps(
+                {
+                    "type": "duplicates_failed",
+                    "project_id": project_id,
+                    "branch": branch,
+                    "job_id": job_id,
+                    "error": str(e),
+                }
+            ),
+        )
+        raise
+
+
 async def run_embedding_generation_task(
     ctx: dict[str, Any],
     project_id: str,
@@ -907,6 +1149,8 @@ class WorkerSettings:
     functions = [
         run_ontology_index_task,
         run_lint_task,
+        run_consistency_check_task,
+        run_duplicate_detection_task,
         check_normalization_status_task,
         run_normalization_task,
         check_all_projects_normalization,

--- a/ontokit/worker.py
+++ b/ontokit/worker.py
@@ -6,7 +6,7 @@ from datetime import UTC, datetime
 from typing import Any
 from uuid import UUID
 
-from arq import ArqRedis, cron
+from arq import ArqRedis, cron, func
 from arq.connections import RedisSettings
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
@@ -1211,8 +1211,8 @@ class WorkerSettings:
     functions = [
         run_ontology_index_task,
         run_lint_task,
-        run_consistency_check_task,
-        run_duplicate_detection_task,
+        func(run_consistency_check_task, timeout=900),  # 15 min for large ontologies
+        func(run_duplicate_detection_task, timeout=900),  # 15 min for large ontologies
         check_normalization_status_task,
         run_normalization_task,
         check_all_projects_normalization,

--- a/ontokit/worker.py
+++ b/ontokit/worker.py
@@ -46,24 +46,16 @@ _FORMAT_MAP: dict[str, str] = {
 }
 
 
-def _sync_load_from_git(
-    git_service: BareGitRepositoryService,
-    project_id: UUID,
-    branch: str,
-    filename: str,
-) -> Any:
-    """Load and parse an ontology from git synchronously (for use with asyncio.to_thread).
+def _parse_rdf(content_str: str, rdf_format: str) -> Any:
+    """Parse RDF content into a Graph (for use with ProcessPoolExecutor).
 
-    RDFLib's graph.parse() is CPU-bound and can take minutes for large ontologies.
-    Running this in a thread keeps the worker event loop responsive.
+    RDFLib's graph.parse() is CPU-bound and holds the GIL, so it must run
+    in a separate process to keep the worker event loop responsive.
     """
     from rdflib import Graph
 
-    content = git_service.get_file_from_branch(project_id, branch, filename)
-    ext = "." + filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
-    rdf_format = _FORMAT_MAP.get(ext, "turtle")
     graph = Graph()
-    graph.parse(data=content.decode("utf-8"), format=rdf_format)
+    graph.parse(data=content_str, format=rdf_format)
     return graph
 
 
@@ -593,30 +585,37 @@ async def run_consistency_check_task(
         if not project.source_file_path and not project.github_integration:
             raise ValueError(f"Project {project_id} has no ontology file")
 
-        # Load ontology graph (graph.parse is CPU-bound for large files)
+        # Load ontology content and parse in a subprocess (CPU-bound, holds GIL)
         import asyncio
+        from concurrent.futures import ProcessPoolExecutor
 
-        storage = get_storage_service()
-        ontology_service = get_ontology_service(storage)
         git_service = BareGitRepositoryService()
         filename = get_git_ontology_path(project)
 
         if git_service.repository_exists(project_uuid):
-            # load_from_git is async-in-name-only — run in thread to avoid blocking
-            graph = await asyncio.to_thread(
-                lambda: _sync_load_from_git(git_service, project_uuid, branch, filename)
-            )
+            content_bytes = git_service.get_file_from_branch(project_uuid, branch, filename)
+            content_str = content_bytes.decode("utf-8")
         elif project.source_file_path:
-            graph = await ontology_service.load_from_storage(
-                project_uuid, project.source_file_path, branch
-            )
+            storage = get_storage_service()
+            content_bytes = await storage.download_file(project.source_file_path)
+            content_str = content_bytes.decode("utf-8")
         else:
             raise ValueError(f"Project {project_id} has no git repository and no storage file")
 
-        # Run consistency check (CPU-bound, run in thread)
+        ext = "." + filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
+        rdf_format = _FORMAT_MAP.get(ext, "turtle")
+
+        loop = asyncio.get_running_loop()
+        with ProcessPoolExecutor(max_workers=1) as pool:
+            graph = await loop.run_in_executor(pool, _parse_rdf, content_str, rdf_format)
+
+        # Run consistency check (also CPU-bound)
         from ontokit.services.consistency_service import run_consistency_check
 
-        check_result = await asyncio.to_thread(run_consistency_check, graph, project_id, branch)
+        with ProcessPoolExecutor(max_workers=1) as pool:
+            check_result = await loop.run_in_executor(
+                pool, run_consistency_check, graph, project_id, branch
+            )
 
         # Cache result in Redis and clear the pending status key
         result_json = check_result.model_dump_json()
@@ -727,31 +726,35 @@ async def run_duplicate_detection_task(
         if not project.source_file_path and not project.github_integration:
             raise ValueError(f"Project {project_id} has no ontology file")
 
-        # Load ontology graph (graph.parse is CPU-bound for large files)
+        # Load ontology content and parse in a subprocess (CPU-bound, holds GIL)
         import asyncio
+        from concurrent.futures import ProcessPoolExecutor
 
-        storage = get_storage_service()
-        ontology_service = get_ontology_service(storage)
         git_service = BareGitRepositoryService()
         filename = get_git_ontology_path(project)
 
         if git_service.repository_exists(project_uuid):
-            # load_from_git is async-in-name-only — run in thread to avoid blocking
-            graph = await asyncio.to_thread(
-                lambda: _sync_load_from_git(git_service, project_uuid, branch, filename)
-            )
+            content_bytes = git_service.get_file_from_branch(project_uuid, branch, filename)
+            content_str = content_bytes.decode("utf-8")
         elif project.source_file_path:
-            graph = await ontology_service.load_from_storage(
-                project_uuid, project.source_file_path, branch
-            )
+            storage = get_storage_service()
+            content_bytes = await storage.download_file(project.source_file_path)
+            content_str = content_bytes.decode("utf-8")
         else:
             raise ValueError(f"Project {project_id} has no git repository and no storage file")
 
-        # Run duplicate detection (CPU-bound, run in thread)
+        ext = "." + filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
+        rdf_format = _FORMAT_MAP.get(ext, "turtle")
 
+        loop = asyncio.get_running_loop()
+        with ProcessPoolExecutor(max_workers=1) as pool:
+            graph = await loop.run_in_executor(pool, _parse_rdf, content_str, rdf_format)
+
+        # Run duplicate detection (also CPU-bound)
         from ontokit.services.duplicate_detection_service import find_duplicates
 
-        detection_result = await asyncio.to_thread(find_duplicates, graph, threshold)
+        with ProcessPoolExecutor(max_workers=1) as pool:
+            detection_result = await loop.run_in_executor(pool, find_duplicates, graph, threshold)
 
         # Cache result in Redis and clear the pending status key
         result_json = detection_result.model_dump_json()

--- a/ontokit/worker.py
+++ b/ontokit/worker.py
@@ -579,12 +579,13 @@ async def run_consistency_check_task(
 
         check_result = await asyncio.to_thread(run_consistency_check, graph, project_id, branch)
 
-        # Cache result in Redis
+        # Cache result in Redis and clear the pending status key
         result_json = check_result.model_dump_json()
         cache_key = f"quality:{project_id}:{branch}"
         if job_id:
             job_key = f"quality_job:{project_id}:{job_id}"
             await redis.set(job_key, result_json, ex=600)
+            await redis.delete(f"quality_job_status:{project_id}:{job_id}")
         await redis.set(cache_key, result_json, ex=600)
 
         logger.info(
@@ -621,6 +622,8 @@ async def run_consistency_check_task(
             branch,
             e,
         )
+        if job_id:
+            await redis.delete(f"quality_job_status:{project_id}:{job_id}")
         await redis.publish(
             QUALITY_UPDATES_CHANNEL,
             json.dumps(
@@ -698,12 +701,13 @@ async def run_duplicate_detection_task(
 
         detection_result = await asyncio.to_thread(find_duplicates, graph, threshold)
 
-        # Cache result in Redis
+        # Cache result in Redis and clear the pending status key
         result_json = detection_result.model_dump_json()
         cache_key = f"duplicates:{project_id}:{branch}"
         if job_id:
             job_key = f"duplicates_job:{project_id}:{job_id}"
             await redis.set(job_key, result_json, ex=600)
+            await redis.delete(f"duplicates_job_status:{project_id}:{job_id}")
         await redis.set(cache_key, result_json, ex=600)
 
         logger.info(
@@ -740,6 +744,8 @@ async def run_duplicate_detection_task(
             branch,
             e,
         )
+        if job_id:
+            await redis.delete(f"duplicates_job_status:{project_id}:{job_id}")
         await redis.publish(
             QUALITY_UPDATES_CHANNEL,
             json.dumps(

--- a/tests/unit/test_duplicate_detection.py
+++ b/tests/unit/test_duplicate_detection.py
@@ -1,11 +1,186 @@
 """Tests for duplicate detection service (ontokit/services/duplicate_detection_service.py)."""
 
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+from uuid import UUID
+
+import pytest
 from rdflib import Graph, Literal, Namespace
 from rdflib.namespace import OWL, RDF, RDFS
 
-from ontokit.services.duplicate_detection_service import find_duplicates
+from ontokit.services.duplicate_detection_service import find_duplicates, find_duplicates_sql
 
 EX = Namespace("http://example.org/")
+PROJECT_ID = UUID("12345678-1234-5678-1234-567812345678")
+
+
+def _row(**kwargs: Any) -> SimpleNamespace:
+    """Create a fake DB row with named attributes."""
+    return SimpleNamespace(**kwargs)
+
+
+def _mock_db(
+    entities: list[SimpleNamespace],
+    similar_map: dict[str, list[SimpleNamespace]] | None = None,
+) -> AsyncMock:
+    """Build a mock AsyncSession that returns entity rows then per-label similar rows."""
+    db = AsyncMock()
+    call_count = 0
+    if similar_map is None:
+        similar_map = {}
+
+    async def fake_execute(stmt: Any, params: dict[str, Any] | None = None) -> MagicMock:  # noqa: ARG001
+        nonlocal call_count
+        call_count += 1
+
+        # First call: SET LOCAL (no result needed)
+        if call_count == 1:
+            return MagicMock()
+
+        # Second call: entity labels query
+        if call_count == 2:
+            result = MagicMock()
+            result.fetchall.return_value = entities
+            return result
+
+        # Subsequent calls: per-entity similar labels lookup
+        if params and "label" in params:
+            label = params["label"]
+            matches = similar_map.get(label, [])
+            result = MagicMock()
+            # Make result iterable (for `for match in similar:`)
+            result.__iter__ = lambda self: iter(matches)  # noqa: ARG005
+            return result
+
+        result = MagicMock()
+        result.__iter__ = lambda self: iter([])  # noqa: ARG005
+        return result
+
+    db.execute = fake_execute
+    return db
+
+
+# ---------------------------------------------------------------------------
+# SQL-based tests
+# ---------------------------------------------------------------------------
+
+
+class TestFindDuplicatesSql:
+    """Tests for find_duplicates_sql (PostgreSQL trigram approach)."""
+
+    @pytest.mark.asyncio
+    async def test_finds_duplicates(self) -> None:
+        """Entities with similar labels are clustered."""
+        e1_id = UUID("aaaaaaaa-0000-0000-0000-000000000001")
+        e2_id = UUID("aaaaaaaa-0000-0000-0000-000000000002")
+
+        entities = [
+            _row(entity_id=e1_id, iri="http://ex.org/Foo", entity_type="class", value="Widget"),
+            _row(entity_id=e2_id, iri="http://ex.org/Bar", entity_type="class", value="Widget"),
+        ]
+
+        similar_map = {
+            "Widget": [
+                _row(entity_id=e2_id, iri="http://ex.org/Bar", value="Widget", sim=1.0),
+            ],
+        }
+
+        db = _mock_db(entities, similar_map)
+        result = await find_duplicates_sql(db, PROJECT_ID, "main", threshold=0.85)
+
+        assert len(result.clusters) == 1
+        iris = {e.iri for e in result.clusters[0].entities}
+        assert "http://ex.org/Foo" in iris
+        assert "http://ex.org/Bar" in iris
+        assert result.clusters[0].similarity == 1.0
+
+    @pytest.mark.asyncio
+    async def test_no_duplicates(self) -> None:
+        """Entities with different labels produce no clusters."""
+        e1_id = UUID("aaaaaaaa-0000-0000-0000-000000000001")
+        e2_id = UUID("aaaaaaaa-0000-0000-0000-000000000002")
+
+        entities = [
+            _row(entity_id=e1_id, iri="http://ex.org/Apple", entity_type="class", value="Apple"),
+            _row(entity_id=e2_id, iri="http://ex.org/Banana", entity_type="class", value="Banana"),
+        ]
+
+        db = _mock_db(entities)  # No similar_map → no matches
+        result = await find_duplicates_sql(db, PROJECT_ID, "main", threshold=0.85)
+
+        assert len(result.clusters) == 0
+
+    @pytest.mark.asyncio
+    async def test_empty_project(self) -> None:
+        """Empty project produces no clusters."""
+        db = _mock_db([])
+        result = await find_duplicates_sql(db, PROJECT_ID, "main")
+        assert len(result.clusters) == 0
+        assert result.threshold == 0.85
+
+    @pytest.mark.asyncio
+    async def test_skips_already_matched(self) -> None:
+        """Entities already matched are skipped in subsequent lookups."""
+        e1_id = UUID("aaaaaaaa-0000-0000-0000-000000000001")
+        e2_id = UUID("aaaaaaaa-0000-0000-0000-000000000002")
+        e3_id = UUID("aaaaaaaa-0000-0000-0000-000000000003")
+
+        entities = [
+            _row(entity_id=e1_id, iri="http://ex.org/A", entity_type="class", value="Thing"),
+            _row(entity_id=e2_id, iri="http://ex.org/B", entity_type="class", value="Thing"),
+            _row(entity_id=e3_id, iri="http://ex.org/C", entity_type="class", value="Other"),
+        ]
+
+        similar_map = {
+            "Thing": [
+                _row(entity_id=e2_id, iri="http://ex.org/B", value="Thing", sim=1.0),
+            ],
+            # e2 ("Thing") would also match e1, but e2 is already matched → skipped
+            # e3 ("Other") has no matches
+        }
+
+        db = _mock_db(entities, similar_map)
+        result = await find_duplicates_sql(db, PROJECT_ID, "main")
+
+        assert len(result.clusters) == 1
+        assert len(result.clusters[0].entities) == 2
+
+    @pytest.mark.asyncio
+    async def test_threshold_passed(self) -> None:
+        """Custom threshold is passed through and completes without error."""
+        db = _mock_db([])
+        result = await find_duplicates_sql(db, PROJECT_ID, "main", threshold=0.95)
+        assert result.threshold == 0.95
+
+    @pytest.mark.asyncio
+    async def test_reverse_pair_similarity(self) -> None:
+        """Cluster similarity uses reverse pair lookup when needed."""
+        e1_id = UUID("aaaaaaaa-0000-0000-0000-000000000001")
+        e2_id = UUID("aaaaaaaa-0000-0000-0000-000000000002")
+        e3_id = UUID("aaaaaaaa-0000-0000-0000-000000000003")
+
+        entities = [
+            _row(entity_id=e1_id, iri="http://ex.org/A", entity_type="class", value="Widget A"),
+            _row(entity_id=e2_id, iri="http://ex.org/B", entity_type="class", value="Widget B"),
+            _row(entity_id=e3_id, iri="http://ex.org/C", entity_type="class", value="Widget C"),
+        ]
+
+        similar_map = {
+            "Widget A": [
+                _row(entity_id=e2_id, iri="http://ex.org/B", value="Widget B", sim=0.9),
+                _row(entity_id=e3_id, iri="http://ex.org/C", value="Widget C", sim=0.88),
+            ],
+        }
+
+        db = _mock_db(entities, similar_map)
+        result = await find_duplicates_sql(db, PROJECT_ID, "main", threshold=0.85)
+
+        assert len(result.clusters) == 1
+        assert len(result.clusters[0].entities) == 3
+        assert result.clusters[0].similarity >= 0.85
 
 
 def test_find_duplicates_by_label() -> None:

--- a/tests/unit/test_duplicate_detection.py
+++ b/tests/unit/test_duplicate_detection.py
@@ -182,6 +182,37 @@ class TestFindDuplicatesSql:
         assert len(result.clusters[0].entities) == 3
         assert result.clusters[0].similarity >= 0.85
 
+    @pytest.mark.asyncio
+    async def test_transitive_clustering(self) -> None:
+        """A~B and B~C should cluster all three even if A!~C directly."""
+        e1_id = UUID("aaaaaaaa-0000-0000-0000-000000000001")
+        e2_id = UUID("aaaaaaaa-0000-0000-0000-000000000002")
+        e3_id = UUID("aaaaaaaa-0000-0000-0000-000000000003")
+
+        entities = [
+            _row(entity_id=e1_id, iri="http://ex.org/A", entity_type="class", value="Alpha"),
+            _row(entity_id=e2_id, iri="http://ex.org/B", entity_type="class", value="Alpho"),
+            _row(entity_id=e3_id, iri="http://ex.org/C", entity_type="class", value="Alphi"),
+        ]
+
+        # A matches B, B matches C, but A does NOT directly match C
+        similar_map = {
+            "Alpha": [
+                _row(entity_id=e2_id, iri="http://ex.org/B", value="Alpho", sim=0.9),
+            ],
+            "Alpho": [
+                _row(entity_id=e3_id, iri="http://ex.org/C", value="Alphi", sim=0.88),
+            ],
+            # "Alphi" → no matches (A is too different)
+        }
+
+        db = _mock_db(entities, similar_map)
+        result = await find_duplicates_sql(db, PROJECT_ID, "main", threshold=0.85)
+
+        assert len(result.clusters) == 1
+        iris = {e.iri for e in result.clusters[0].entities}
+        assert iris == {"http://ex.org/A", "http://ex.org/B", "http://ex.org/C"}
+
 
 def test_find_duplicates_by_label() -> None:
     g = Graph()

--- a/tests/unit/test_quality_routes.py
+++ b/tests/unit/test_quality_routes.py
@@ -107,6 +107,8 @@ class TestTriggerConsistencyCheck:
         mock_pool.enqueue_job.assert_called_once()
         call_args = mock_pool.enqueue_job.call_args[0]
         assert call_args[0] == "run_consistency_check_task"
+        # The job_id returned to the client must match what was enqueued
+        assert data["job_id"] == call_args[3]
 
     @patch("ontokit.api.routes.quality.get_arq_pool", new_callable=AsyncMock)
     @patch("ontokit.api.routes.quality.resolve_branch", new_callable=AsyncMock)
@@ -211,13 +213,13 @@ class TestGetQualityJobResult:
         mock_redis_fn: MagicMock,
         authed_client: tuple[TestClient, AsyncMock],
     ) -> None:
-        """Returns 404 when Redis raises an exception."""
+        """Returns 500 when Redis raises an operational exception."""
         client, _ = authed_client
 
         mock_redis_fn.side_effect = RuntimeError("Redis down")
 
         response = client.get(f"/api/v1/projects/{PROJECT_ID}/quality/jobs/{JOB_ID}")
-        assert response.status_code == 404
+        assert response.status_code == 500
 
 
 class TestGetConsistencyIssues:
@@ -292,23 +294,21 @@ class TestGetConsistencyIssues:
     @patch("ontokit.api.routes.quality._get_redis")
     @patch("ontokit.api.routes.quality.resolve_branch", new_callable=AsyncMock)
     @patch("ontokit.api.routes.quality.verify_project_access", new_callable=AsyncMock)
-    def test_get_issues_redis_failure_returns_empty(
+    def test_get_issues_redis_failure(
         self,
         mock_access: AsyncMock,  # noqa: ARG002
         mock_resolve: AsyncMock,
         mock_redis_fn: MagicMock,
         authed_client: tuple[TestClient, AsyncMock],
     ) -> None:
-        """Returns empty result when Redis raises an exception."""
+        """Returns 500 when Redis raises an operational exception."""
         client, _ = authed_client
 
         mock_resolve.return_value = "main"
         mock_redis_fn.side_effect = RuntimeError("Redis down")
 
         response = client.get(f"/api/v1/projects/{PROJECT_ID}/quality/issues")
-        assert response.status_code == 200
-        data = response.json()
-        assert data["issues"] == []
+        assert response.status_code == 500
 
 
 class TestDetectDuplicates:
@@ -342,6 +342,8 @@ class TestDetectDuplicates:
         mock_pool.enqueue_job.assert_called_once()
         call_args = mock_pool.enqueue_job.call_args[0]
         assert call_args[0] == "run_duplicate_detection_task"
+        # The job_id returned to the client must match what was enqueued
+        assert data["job_id"] == call_args[4]
 
     @patch("ontokit.api.routes.quality.get_arq_pool", new_callable=AsyncMock)
     @patch("ontokit.api.routes.quality.resolve_branch", new_callable=AsyncMock)
@@ -368,9 +370,12 @@ class TestDetectDuplicates:
             params={"threshold": 0.9},
         )
         assert response.status_code == 200
+        data = response.json()
         # Verify threshold was passed to enqueue_job
         call_args = mock_pool.enqueue_job.call_args[0]
         assert call_args[3] == 0.9  # threshold is the 4th positional arg
+        # The job_id returned to the client must match what was enqueued
+        assert data["job_id"] == call_args[4]
 
     @patch("ontokit.api.routes.quality.get_arq_pool", new_callable=AsyncMock)
     @patch("ontokit.api.routes.quality.resolve_branch", new_callable=AsyncMock)
@@ -472,13 +477,13 @@ class TestGetDuplicateJobResult:
         mock_redis_fn: MagicMock,
         authed_client: tuple[TestClient, AsyncMock],
     ) -> None:
-        """Returns 404 when Redis raises an exception."""
+        """Returns 500 when Redis raises an operational exception."""
         client, _ = authed_client
 
         mock_redis_fn.side_effect = RuntimeError("Redis down")
 
         response = client.get(f"/api/v1/projects/{PROJECT_ID}/quality/duplicates/jobs/{JOB_ID}")
-        assert response.status_code == 404
+        assert response.status_code == 500
 
 
 class TestGetLatestDuplicates:
@@ -552,20 +557,18 @@ class TestGetLatestDuplicates:
     @patch("ontokit.api.routes.quality._get_redis")
     @patch("ontokit.api.routes.quality.resolve_branch", new_callable=AsyncMock)
     @patch("ontokit.api.routes.quality.verify_project_access", new_callable=AsyncMock)
-    def test_get_latest_redis_failure_returns_empty(
+    def test_get_latest_redis_failure(
         self,
         mock_access: AsyncMock,  # noqa: ARG002
         mock_resolve: AsyncMock,
         mock_redis_fn: MagicMock,
         authed_client: tuple[TestClient, AsyncMock],
     ) -> None:
-        """Returns empty result when Redis raises an exception."""
+        """Returns 500 when Redis raises an operational exception."""
         client, _ = authed_client
 
         mock_resolve.return_value = "main"
         mock_redis_fn.side_effect = RuntimeError("Redis down")
 
         response = client.get(f"/api/v1/projects/{PROJECT_ID}/quality/duplicates/latest")
-        assert response.status_code == 200
-        data = response.json()
-        assert data["clusters"] == []
+        assert response.status_code == 500

--- a/tests/unit/test_quality_routes.py
+++ b/tests/unit/test_quality_routes.py
@@ -220,6 +220,26 @@ class TestGetQualityJobResult:
 
     @patch("ontokit.api.routes.quality._get_redis")
     @patch("ontokit.api.routes.quality.verify_project_access", new_callable=AsyncMock)
+    def test_get_job_result_failed(
+        self,
+        mock_access: AsyncMock,  # noqa: ARG002
+        mock_redis_fn: MagicMock,
+        authed_client: tuple[TestClient, AsyncMock],
+    ) -> None:
+        """Returns 500 when the job failed and status key contains error."""
+        client, _ = authed_client
+
+        mock_redis = AsyncMock()
+        failed_status = json.dumps({"state": "failed", "error": "Out of memory"})
+        mock_redis.get.side_effect = [None, failed_status.encode()]
+        mock_redis_fn.return_value = mock_redis
+
+        response = client.get(f"/api/v1/projects/{PROJECT_ID}/quality/jobs/{JOB_ID}")
+        assert response.status_code == 500
+        assert "Out of memory" in response.json()["detail"]
+
+    @patch("ontokit.api.routes.quality._get_redis")
+    @patch("ontokit.api.routes.quality.verify_project_access", new_callable=AsyncMock)
     def test_get_job_result_not_found(
         self,
         mock_access: AsyncMock,  # noqa: ARG002
@@ -518,6 +538,26 @@ class TestGetDuplicateJobResult:
         data = response.json()
         assert data["status"] == "pending"
         assert data["job_id"] == JOB_ID
+
+    @patch("ontokit.api.routes.quality._get_redis")
+    @patch("ontokit.api.routes.quality.verify_project_access", new_callable=AsyncMock)
+    def test_get_job_result_failed(
+        self,
+        mock_access: AsyncMock,  # noqa: ARG002
+        mock_redis_fn: MagicMock,
+        authed_client: tuple[TestClient, AsyncMock],
+    ) -> None:
+        """Returns 500 when the job failed and status key contains error."""
+        client, _ = authed_client
+
+        mock_redis = AsyncMock()
+        failed_status = json.dumps({"state": "failed", "error": "Timeout exceeded"})
+        mock_redis.get.side_effect = [None, failed_status.encode()]
+        mock_redis_fn.return_value = mock_redis
+
+        response = client.get(f"/api/v1/projects/{PROJECT_ID}/quality/duplicates/jobs/{JOB_ID}")
+        assert response.status_code == 500
+        assert "Timeout exceeded" in response.json()["detail"]
 
     @patch("ontokit.api.routes.quality._get_redis")
     @patch("ontokit.api.routes.quality.verify_project_access", new_callable=AsyncMock)

--- a/tests/unit/test_quality_routes.py
+++ b/tests/unit/test_quality_routes.py
@@ -120,6 +120,7 @@ class TestTriggerConsistencyCheck:
         assert "quality_job_status" in set_args[0][0]
         assert set_args[0][1] == "pending"
 
+    @patch("ontokit.api.routes.quality._get_redis")
     @patch("ontokit.api.routes.quality.get_arq_pool", new_callable=AsyncMock)
     @patch("ontokit.api.routes.quality.resolve_branch", new_callable=AsyncMock)
     @patch("ontokit.api.routes.quality.verify_project_access", new_callable=AsyncMock)
@@ -128,9 +129,10 @@ class TestTriggerConsistencyCheck:
         mock_access: AsyncMock,  # noqa: ARG002
         mock_resolve: AsyncMock,
         mock_pool_fn: AsyncMock,
+        mock_redis_fn: MagicMock,
         authed_client: tuple[TestClient, AsyncMock],
     ) -> None:
-        """Returns 500 when ARQ job enqueue returns None."""
+        """Returns 500 and cleans up pending key when enqueue returns None."""
         client, _ = authed_client
 
         mock_resolve.return_value = "main"
@@ -139,9 +141,16 @@ class TestTriggerConsistencyCheck:
         mock_pool.enqueue_job.return_value = None
         mock_pool_fn.return_value = mock_pool
 
+        mock_redis = AsyncMock()
+        mock_redis_fn.return_value = mock_redis
+
         response = client.post(f"/api/v1/projects/{PROJECT_ID}/quality/check")
         assert response.status_code == 500
+        # Pending key should be set then deleted
+        mock_redis.set.assert_called_once()
+        mock_redis.delete.assert_called_once()
 
+    @patch("ontokit.api.routes.quality._get_redis")
     @patch("ontokit.api.routes.quality.get_arq_pool", new_callable=AsyncMock)
     @patch("ontokit.api.routes.quality.resolve_branch", new_callable=AsyncMock)
     @patch("ontokit.api.routes.quality.verify_project_access", new_callable=AsyncMock)
@@ -150,16 +159,21 @@ class TestTriggerConsistencyCheck:
         mock_access: AsyncMock,  # noqa: ARG002
         mock_resolve: AsyncMock,
         mock_pool_fn: AsyncMock,
+        mock_redis_fn: MagicMock,
         authed_client: tuple[TestClient, AsyncMock],
     ) -> None:
-        """Returns 500 when ARQ pool raises an exception."""
+        """Returns 500 and cleans up pending key when ARQ pool raises."""
         client, _ = authed_client
 
         mock_resolve.return_value = "main"
         mock_pool_fn.side_effect = RuntimeError("Redis unavailable")
 
+        mock_redis = AsyncMock()
+        mock_redis_fn.return_value = mock_redis
+
         response = client.post(f"/api/v1/projects/{PROJECT_ID}/quality/check")
         assert response.status_code == 500
+        mock_redis.delete.assert_called_once()
 
 
 class TestGetQualityJobResult:
@@ -237,6 +251,44 @@ class TestGetQualityJobResult:
         response = client.get(f"/api/v1/projects/{PROJECT_ID}/quality/jobs/{JOB_ID}")
         assert response.status_code == 500
         assert "Out of memory" in response.json()["detail"]
+
+    @patch("ontokit.api.routes.quality._get_redis")
+    @patch("ontokit.api.routes.quality.verify_project_access", new_callable=AsyncMock)
+    def test_get_job_result_failed_unparseable(
+        self,
+        mock_access: AsyncMock,  # noqa: ARG002
+        mock_redis_fn: MagicMock,
+        authed_client: tuple[TestClient, AsyncMock],
+    ) -> None:
+        """Returns 500 with unknown error when failed status is not valid JSON."""
+        client, _ = authed_client
+
+        mock_redis = AsyncMock()
+        mock_redis.get.side_effect = [None, b"not-json"]
+        mock_redis_fn.return_value = mock_redis
+
+        response = client.get(f"/api/v1/projects/{PROJECT_ID}/quality/jobs/{JOB_ID}")
+        assert response.status_code == 500
+        assert "Unknown error" in response.json()["detail"]
+
+    @patch("ontokit.api.routes.quality._get_redis")
+    @patch("ontokit.api.routes.quality.verify_project_access", new_callable=AsyncMock)
+    def test_get_job_result_corrupt_cached(
+        self,
+        mock_access: AsyncMock,  # noqa: ARG002
+        mock_redis_fn: MagicMock,
+        authed_client: tuple[TestClient, AsyncMock],
+    ) -> None:
+        """Returns 500 when cached result fails Pydantic validation."""
+        client, _ = authed_client
+
+        mock_redis = AsyncMock()
+        mock_redis.get.return_value = b'{"not": "a valid result"}'
+        mock_redis_fn.return_value = mock_redis
+
+        response = client.get(f"/api/v1/projects/{PROJECT_ID}/quality/jobs/{JOB_ID}")
+        assert response.status_code == 500
+        assert "corrupt" in response.json()["detail"].lower()
 
     @patch("ontokit.api.routes.quality._get_redis")
     @patch("ontokit.api.routes.quality.verify_project_access", new_callable=AsyncMock)
@@ -318,6 +370,29 @@ class TestGetConsistencyIssues:
         assert response.status_code == 200
         data = response.json()
         assert len(data["issues"]) == 1
+
+    @patch("ontokit.api.routes.quality._get_redis")
+    @patch("ontokit.api.routes.quality.resolve_branch", new_callable=AsyncMock)
+    @patch("ontokit.api.routes.quality.verify_project_access", new_callable=AsyncMock)
+    def test_get_issues_corrupt_cached(
+        self,
+        mock_access: AsyncMock,  # noqa: ARG002
+        mock_resolve: AsyncMock,
+        mock_redis_fn: MagicMock,
+        authed_client: tuple[TestClient, AsyncMock],
+    ) -> None:
+        """Returns 500 when cached result fails Pydantic validation."""
+        client, _ = authed_client
+
+        mock_resolve.return_value = "main"
+
+        mock_redis = AsyncMock()
+        mock_redis.get.return_value = b'{"invalid": true}'
+        mock_redis_fn.return_value = mock_redis
+
+        response = client.get(f"/api/v1/projects/{PROJECT_ID}/quality/issues")
+        assert response.status_code == 500
+        assert "corrupt" in response.json()["detail"].lower()
 
     @patch("ontokit.api.routes.quality._get_redis")
     @patch("ontokit.api.routes.quality.resolve_branch", new_callable=AsyncMock)
@@ -444,6 +519,7 @@ class TestDetectDuplicates:
         # The job_id returned to the client must match what was enqueued
         assert data["job_id"] == call_args[4]
 
+    @patch("ontokit.api.routes.quality._get_redis")
     @patch("ontokit.api.routes.quality.get_arq_pool", new_callable=AsyncMock)
     @patch("ontokit.api.routes.quality.resolve_branch", new_callable=AsyncMock)
     @patch("ontokit.api.routes.quality.verify_project_access", new_callable=AsyncMock)
@@ -452,9 +528,10 @@ class TestDetectDuplicates:
         mock_access: AsyncMock,  # noqa: ARG002
         mock_resolve: AsyncMock,
         mock_pool_fn: AsyncMock,
+        mock_redis_fn: MagicMock,
         authed_client: tuple[TestClient, AsyncMock],
     ) -> None:
-        """Returns 500 when ARQ job enqueue returns None."""
+        """Returns 500 and cleans up pending key when enqueue returns None."""
         client, _ = authed_client
 
         mock_resolve.return_value = "main"
@@ -463,9 +540,15 @@ class TestDetectDuplicates:
         mock_pool.enqueue_job.return_value = None
         mock_pool_fn.return_value = mock_pool
 
+        mock_redis = AsyncMock()
+        mock_redis_fn.return_value = mock_redis
+
         response = client.post(f"/api/v1/projects/{PROJECT_ID}/quality/duplicates")
         assert response.status_code == 500
+        mock_redis.set.assert_called_once()
+        mock_redis.delete.assert_called_once()
 
+    @patch("ontokit.api.routes.quality._get_redis")
     @patch("ontokit.api.routes.quality.get_arq_pool", new_callable=AsyncMock)
     @patch("ontokit.api.routes.quality.resolve_branch", new_callable=AsyncMock)
     @patch("ontokit.api.routes.quality.verify_project_access", new_callable=AsyncMock)
@@ -474,16 +557,21 @@ class TestDetectDuplicates:
         mock_access: AsyncMock,  # noqa: ARG002
         mock_resolve: AsyncMock,
         mock_pool_fn: AsyncMock,
+        mock_redis_fn: MagicMock,
         authed_client: tuple[TestClient, AsyncMock],
     ) -> None:
-        """Returns 500 when ARQ pool raises an exception."""
+        """Returns 500 and cleans up pending key when ARQ pool raises."""
         client, _ = authed_client
 
         mock_resolve.return_value = "main"
         mock_pool_fn.side_effect = RuntimeError("Redis unavailable")
 
+        mock_redis = AsyncMock()
+        mock_redis_fn.return_value = mock_redis
+
         response = client.post(f"/api/v1/projects/{PROJECT_ID}/quality/duplicates")
         assert response.status_code == 500
+        mock_redis.delete.assert_called_once()
 
 
 class TestGetDuplicateJobResult:
@@ -558,6 +646,44 @@ class TestGetDuplicateJobResult:
         response = client.get(f"/api/v1/projects/{PROJECT_ID}/quality/duplicates/jobs/{JOB_ID}")
         assert response.status_code == 500
         assert "Timeout exceeded" in response.json()["detail"]
+
+    @patch("ontokit.api.routes.quality._get_redis")
+    @patch("ontokit.api.routes.quality.verify_project_access", new_callable=AsyncMock)
+    def test_get_job_result_failed_unparseable(
+        self,
+        mock_access: AsyncMock,  # noqa: ARG002
+        mock_redis_fn: MagicMock,
+        authed_client: tuple[TestClient, AsyncMock],
+    ) -> None:
+        """Returns 500 with unknown error when failed status is not valid JSON."""
+        client, _ = authed_client
+
+        mock_redis = AsyncMock()
+        mock_redis.get.side_effect = [None, b"not-json"]
+        mock_redis_fn.return_value = mock_redis
+
+        response = client.get(f"/api/v1/projects/{PROJECT_ID}/quality/duplicates/jobs/{JOB_ID}")
+        assert response.status_code == 500
+        assert "Unknown error" in response.json()["detail"]
+
+    @patch("ontokit.api.routes.quality._get_redis")
+    @patch("ontokit.api.routes.quality.verify_project_access", new_callable=AsyncMock)
+    def test_get_job_result_corrupt_cached(
+        self,
+        mock_access: AsyncMock,  # noqa: ARG002
+        mock_redis_fn: MagicMock,
+        authed_client: tuple[TestClient, AsyncMock],
+    ) -> None:
+        """Returns 500 when cached result fails Pydantic validation."""
+        client, _ = authed_client
+
+        mock_redis = AsyncMock()
+        mock_redis.get.return_value = b'{"not": "valid"}'
+        mock_redis_fn.return_value = mock_redis
+
+        response = client.get(f"/api/v1/projects/{PROJECT_ID}/quality/duplicates/jobs/{JOB_ID}")
+        assert response.status_code == 500
+        assert "corrupt" in response.json()["detail"].lower()
 
     @patch("ontokit.api.routes.quality._get_redis")
     @patch("ontokit.api.routes.quality.verify_project_access", new_callable=AsyncMock)
@@ -637,6 +763,29 @@ class TestGetLatestDuplicates:
         data = response.json()
         assert len(data["clusters"]) == 1
         assert data["clusters"][0]["similarity"] == 0.92
+
+    @patch("ontokit.api.routes.quality._get_redis")
+    @patch("ontokit.api.routes.quality.resolve_branch", new_callable=AsyncMock)
+    @patch("ontokit.api.routes.quality.verify_project_access", new_callable=AsyncMock)
+    def test_get_latest_corrupt_cached(
+        self,
+        mock_access: AsyncMock,  # noqa: ARG002
+        mock_resolve: AsyncMock,
+        mock_redis_fn: MagicMock,
+        authed_client: tuple[TestClient, AsyncMock],
+    ) -> None:
+        """Returns 500 when cached result fails Pydantic validation."""
+        client, _ = authed_client
+
+        mock_resolve.return_value = "main"
+
+        mock_redis = AsyncMock()
+        mock_redis.get.return_value = b'{"broken": true}'
+        mock_redis_fn.return_value = mock_redis
+
+        response = client.get(f"/api/v1/projects/{PROJECT_ID}/quality/duplicates/latest")
+        assert response.status_code == 500
+        assert "corrupt" in response.json()["detail"].lower()
 
     @patch("ontokit.api.routes.quality._get_redis")
     @patch("ontokit.api.routes.quality.resolve_branch", new_callable=AsyncMock)

--- a/tests/unit/test_quality_routes.py
+++ b/tests/unit/test_quality_routes.py
@@ -130,6 +130,25 @@ class TestTriggerConsistencyCheck:
         response = client.post(f"/api/v1/projects/{PROJECT_ID}/quality/check")
         assert response.status_code == 500
 
+    @patch("ontokit.api.routes.quality.get_arq_pool", new_callable=AsyncMock)
+    @patch("ontokit.api.routes.quality.resolve_branch", new_callable=AsyncMock)
+    @patch("ontokit.api.routes.quality.verify_project_access", new_callable=AsyncMock)
+    def test_trigger_check_pool_exception(
+        self,
+        mock_access: AsyncMock,  # noqa: ARG002
+        mock_resolve: AsyncMock,
+        mock_pool_fn: AsyncMock,
+        authed_client: tuple[TestClient, AsyncMock],
+    ) -> None:
+        """Returns 500 when ARQ pool raises an exception."""
+        client, _ = authed_client
+
+        mock_resolve.return_value = "main"
+        mock_pool_fn.side_effect = RuntimeError("Redis unavailable")
+
+        response = client.post(f"/api/v1/projects/{PROJECT_ID}/quality/check")
+        assert response.status_code == 500
+
 
 class TestGetQualityJobResult:
     """Tests for GET /api/v1/projects/{id}/quality/jobs/{job_id}."""
@@ -183,6 +202,113 @@ class TestGetQualityJobResult:
         response = client.get(f"/api/v1/projects/{PROJECT_ID}/quality/jobs/{JOB_ID}")
         assert response.status_code == 404
         assert "not found" in response.json()["detail"].lower()
+
+    @patch("ontokit.api.routes.quality._get_redis")
+    @patch("ontokit.api.routes.quality.verify_project_access", new_callable=AsyncMock)
+    def test_get_job_result_redis_failure(
+        self,
+        mock_access: AsyncMock,  # noqa: ARG002
+        mock_redis_fn: MagicMock,
+        authed_client: tuple[TestClient, AsyncMock],
+    ) -> None:
+        """Returns 404 when Redis raises an exception."""
+        client, _ = authed_client
+
+        mock_redis_fn.side_effect = RuntimeError("Redis down")
+
+        response = client.get(f"/api/v1/projects/{PROJECT_ID}/quality/jobs/{JOB_ID}")
+        assert response.status_code == 404
+
+
+class TestGetConsistencyIssues:
+    """Tests for GET /api/v1/projects/{id}/quality/issues."""
+
+    @patch("ontokit.api.routes.quality._get_redis")
+    @patch("ontokit.api.routes.quality.resolve_branch", new_callable=AsyncMock)
+    @patch("ontokit.api.routes.quality.verify_project_access", new_callable=AsyncMock)
+    def test_get_issues_cached(
+        self,
+        mock_access: AsyncMock,  # noqa: ARG002
+        mock_resolve: AsyncMock,
+        mock_redis_fn: MagicMock,
+        authed_client: tuple[TestClient, AsyncMock],
+    ) -> None:
+        """Returns cached consistency issues from Redis."""
+        client, _ = authed_client
+
+        mock_resolve.return_value = "main"
+        cached_data = json.dumps(
+            {
+                "project_id": PROJECT_ID,
+                "branch": "main",
+                "issues": [
+                    {
+                        "rule_id": "missing_label",
+                        "severity": "warning",
+                        "entity_iri": "http://ex.org/A",
+                        "entity_type": "class",
+                        "message": "Missing label",
+                    }
+                ],
+                "checked_at": datetime.now(UTC).isoformat(),
+                "duration_ms": 10.0,
+            }
+        )
+
+        mock_redis = AsyncMock()
+        mock_redis.get.return_value = cached_data
+        mock_redis_fn.return_value = mock_redis
+
+        response = client.get(f"/api/v1/projects/{PROJECT_ID}/quality/issues")
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["issues"]) == 1
+
+    @patch("ontokit.api.routes.quality._get_redis")
+    @patch("ontokit.api.routes.quality.resolve_branch", new_callable=AsyncMock)
+    @patch("ontokit.api.routes.quality.verify_project_access", new_callable=AsyncMock)
+    def test_get_issues_empty_when_no_cache(
+        self,
+        mock_access: AsyncMock,  # noqa: ARG002
+        mock_resolve: AsyncMock,
+        mock_redis_fn: MagicMock,
+        authed_client: tuple[TestClient, AsyncMock],
+    ) -> None:
+        """Returns empty result when no cached data exists."""
+        client, _ = authed_client
+
+        mock_resolve.return_value = "main"
+
+        mock_redis = AsyncMock()
+        mock_redis.get.return_value = None
+        mock_redis_fn.return_value = mock_redis
+
+        response = client.get(f"/api/v1/projects/{PROJECT_ID}/quality/issues")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["issues"] == []
+        assert data["branch"] == "main"
+
+    @patch("ontokit.api.routes.quality._get_redis")
+    @patch("ontokit.api.routes.quality.resolve_branch", new_callable=AsyncMock)
+    @patch("ontokit.api.routes.quality.verify_project_access", new_callable=AsyncMock)
+    def test_get_issues_redis_failure_returns_empty(
+        self,
+        mock_access: AsyncMock,  # noqa: ARG002
+        mock_resolve: AsyncMock,
+        mock_redis_fn: MagicMock,
+        authed_client: tuple[TestClient, AsyncMock],
+    ) -> None:
+        """Returns empty result when Redis raises an exception."""
+        client, _ = authed_client
+
+        mock_resolve.return_value = "main"
+        mock_redis_fn.side_effect = RuntimeError("Redis down")
+
+        response = client.get(f"/api/v1/projects/{PROJECT_ID}/quality/issues")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["issues"] == []
 
 
 class TestDetectDuplicates:
@@ -246,6 +372,47 @@ class TestDetectDuplicates:
         call_args = mock_pool.enqueue_job.call_args[0]
         assert call_args[3] == 0.9  # threshold is the 4th positional arg
 
+    @patch("ontokit.api.routes.quality.get_arq_pool", new_callable=AsyncMock)
+    @patch("ontokit.api.routes.quality.resolve_branch", new_callable=AsyncMock)
+    @patch("ontokit.api.routes.quality.verify_project_access", new_callable=AsyncMock)
+    def test_detect_duplicates_enqueue_failure(
+        self,
+        mock_access: AsyncMock,  # noqa: ARG002
+        mock_resolve: AsyncMock,
+        mock_pool_fn: AsyncMock,
+        authed_client: tuple[TestClient, AsyncMock],
+    ) -> None:
+        """Returns 500 when ARQ job enqueue returns None."""
+        client, _ = authed_client
+
+        mock_resolve.return_value = "main"
+
+        mock_pool = AsyncMock()
+        mock_pool.enqueue_job.return_value = None
+        mock_pool_fn.return_value = mock_pool
+
+        response = client.post(f"/api/v1/projects/{PROJECT_ID}/quality/duplicates")
+        assert response.status_code == 500
+
+    @patch("ontokit.api.routes.quality.get_arq_pool", new_callable=AsyncMock)
+    @patch("ontokit.api.routes.quality.resolve_branch", new_callable=AsyncMock)
+    @patch("ontokit.api.routes.quality.verify_project_access", new_callable=AsyncMock)
+    def test_detect_duplicates_pool_exception(
+        self,
+        mock_access: AsyncMock,  # noqa: ARG002
+        mock_resolve: AsyncMock,
+        mock_pool_fn: AsyncMock,
+        authed_client: tuple[TestClient, AsyncMock],
+    ) -> None:
+        """Returns 500 when ARQ pool raises an exception."""
+        client, _ = authed_client
+
+        mock_resolve.return_value = "main"
+        mock_pool_fn.side_effect = RuntimeError("Redis unavailable")
+
+        response = client.post(f"/api/v1/projects/{PROJECT_ID}/quality/duplicates")
+        assert response.status_code == 500
+
 
 class TestGetDuplicateJobResult:
     """Tests for GET /api/v1/projects/{id}/quality/duplicates/jobs/{job_id}."""
@@ -293,6 +460,22 @@ class TestGetDuplicateJobResult:
         mock_redis = AsyncMock()
         mock_redis.get.return_value = None
         mock_redis_fn.return_value = mock_redis
+
+        response = client.get(f"/api/v1/projects/{PROJECT_ID}/quality/duplicates/jobs/{JOB_ID}")
+        assert response.status_code == 404
+
+    @patch("ontokit.api.routes.quality._get_redis")
+    @patch("ontokit.api.routes.quality.verify_project_access", new_callable=AsyncMock)
+    def test_get_job_result_redis_failure(
+        self,
+        mock_access: AsyncMock,  # noqa: ARG002
+        mock_redis_fn: MagicMock,
+        authed_client: tuple[TestClient, AsyncMock],
+    ) -> None:
+        """Returns 404 when Redis raises an exception."""
+        client, _ = authed_client
+
+        mock_redis_fn.side_effect = RuntimeError("Redis down")
 
         response = client.get(f"/api/v1/projects/{PROJECT_ID}/quality/duplicates/jobs/{JOB_ID}")
         assert response.status_code == 404
@@ -360,6 +543,27 @@ class TestGetLatestDuplicates:
         mock_redis = AsyncMock()
         mock_redis.get.return_value = None
         mock_redis_fn.return_value = mock_redis
+
+        response = client.get(f"/api/v1/projects/{PROJECT_ID}/quality/duplicates/latest")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["clusters"] == []
+
+    @patch("ontokit.api.routes.quality._get_redis")
+    @patch("ontokit.api.routes.quality.resolve_branch", new_callable=AsyncMock)
+    @patch("ontokit.api.routes.quality.verify_project_access", new_callable=AsyncMock)
+    def test_get_latest_redis_failure_returns_empty(
+        self,
+        mock_access: AsyncMock,  # noqa: ARG002
+        mock_resolve: AsyncMock,
+        mock_redis_fn: MagicMock,
+        authed_client: tuple[TestClient, AsyncMock],
+    ) -> None:
+        """Returns empty result when Redis raises an exception."""
+        client, _ = authed_client
+
+        mock_resolve.return_value = "main"
+        mock_redis_fn.side_effect = RuntimeError("Redis down")
 
         response = client.get(f"/api/v1/projects/{PROJECT_ID}/quality/duplicates/latest")
         assert response.status_code == 200

--- a/tests/unit/test_quality_routes.py
+++ b/tests/unit/test_quality_routes.py
@@ -79,6 +79,7 @@ class TestGetEntityReferences:
 class TestTriggerConsistencyCheck:
     """Tests for POST /api/v1/projects/{id}/quality/check."""
 
+    @patch("ontokit.api.routes.quality._get_redis")
     @patch("ontokit.api.routes.quality.get_arq_pool", new_callable=AsyncMock)
     @patch("ontokit.api.routes.quality.resolve_branch", new_callable=AsyncMock)
     @patch("ontokit.api.routes.quality.verify_project_access", new_callable=AsyncMock)
@@ -87,9 +88,10 @@ class TestTriggerConsistencyCheck:
         mock_access: AsyncMock,  # noqa: ARG002
         mock_resolve: AsyncMock,
         mock_pool_fn: AsyncMock,
+        mock_redis_fn: MagicMock,
         authed_client: tuple[TestClient, AsyncMock],
     ) -> None:
-        """Consistency check enqueues a job and returns job_id."""
+        """Consistency check enqueues a job, sets pending key, and returns job_id."""
         client, _ = authed_client
 
         mock_resolve.return_value = "main"
@@ -98,6 +100,9 @@ class TestTriggerConsistencyCheck:
         mock_pool = AsyncMock()
         mock_pool.enqueue_job.return_value = mock_job
         mock_pool_fn.return_value = mock_pool
+
+        mock_redis = AsyncMock()
+        mock_redis_fn.return_value = mock_redis
 
         response = client.post(f"/api/v1/projects/{PROJECT_ID}/quality/check")
         assert response.status_code == 200
@@ -109,6 +114,11 @@ class TestTriggerConsistencyCheck:
         assert call_args[0] == "run_consistency_check_task"
         # The job_id returned to the client must match what was enqueued
         assert data["job_id"] == call_args[3]
+        # Pending status key must be set in Redis
+        mock_redis.set.assert_called_once()
+        set_args = mock_redis.set.call_args
+        assert "quality_job_status" in set_args[0][0]
+        assert set_args[0][1] == "pending"
 
     @patch("ontokit.api.routes.quality.get_arq_pool", new_callable=AsyncMock)
     @patch("ontokit.api.routes.quality.resolve_branch", new_callable=AsyncMock)
@@ -188,17 +198,40 @@ class TestGetQualityJobResult:
 
     @patch("ontokit.api.routes.quality._get_redis")
     @patch("ontokit.api.routes.quality.verify_project_access", new_callable=AsyncMock)
+    def test_get_job_result_pending(
+        self,
+        mock_access: AsyncMock,  # noqa: ARG002
+        mock_redis_fn: MagicMock,
+        authed_client: tuple[TestClient, AsyncMock],
+    ) -> None:
+        """Returns 202 when job result is not ready but status key exists."""
+        client, _ = authed_client
+
+        mock_redis = AsyncMock()
+        # First call: result key → None; second call: status key → "pending"
+        mock_redis.get.side_effect = [None, b"pending"]
+        mock_redis_fn.return_value = mock_redis
+
+        response = client.get(f"/api/v1/projects/{PROJECT_ID}/quality/jobs/{JOB_ID}")
+        assert response.status_code == 202
+        data = response.json()
+        assert data["status"] == "pending"
+        assert data["job_id"] == JOB_ID
+
+    @patch("ontokit.api.routes.quality._get_redis")
+    @patch("ontokit.api.routes.quality.verify_project_access", new_callable=AsyncMock)
     def test_get_job_result_not_found(
         self,
         mock_access: AsyncMock,  # noqa: ARG002
         mock_redis_fn: MagicMock,
         authed_client: tuple[TestClient, AsyncMock],
     ) -> None:
-        """Returns 404 when job result is not cached."""
+        """Returns 404 when both result and status keys are absent."""
         client, _ = authed_client
 
         mock_redis = AsyncMock()
-        mock_redis.get.return_value = None
+        # Both result key and status key return None
+        mock_redis.get.side_effect = [None, None]
         mock_redis_fn.return_value = mock_redis
 
         response = client.get(f"/api/v1/projects/{PROJECT_ID}/quality/jobs/{JOB_ID}")
@@ -314,6 +347,7 @@ class TestGetConsistencyIssues:
 class TestDetectDuplicates:
     """Tests for POST /api/v1/projects/{id}/quality/duplicates."""
 
+    @patch("ontokit.api.routes.quality._get_redis")
     @patch("ontokit.api.routes.quality.get_arq_pool", new_callable=AsyncMock)
     @patch("ontokit.api.routes.quality.resolve_branch", new_callable=AsyncMock)
     @patch("ontokit.api.routes.quality.verify_project_access", new_callable=AsyncMock)
@@ -322,6 +356,7 @@ class TestDetectDuplicates:
         mock_access: AsyncMock,  # noqa: ARG002
         mock_resolve: AsyncMock,
         mock_pool_fn: AsyncMock,
+        mock_redis_fn: MagicMock,
         authed_client: tuple[TestClient, AsyncMock],
     ) -> None:
         """Returns job_id when duplicate detection is enqueued."""
@@ -334,6 +369,9 @@ class TestDetectDuplicates:
         mock_pool.enqueue_job.return_value = mock_job
         mock_pool_fn.return_value = mock_pool
 
+        mock_redis = AsyncMock()
+        mock_redis_fn.return_value = mock_redis
+
         response = client.post(f"/api/v1/projects/{PROJECT_ID}/quality/duplicates")
         assert response.status_code == 200
         data = response.json()
@@ -344,7 +382,13 @@ class TestDetectDuplicates:
         assert call_args[0] == "run_duplicate_detection_task"
         # The job_id returned to the client must match what was enqueued
         assert data["job_id"] == call_args[4]
+        # Pending status key must be set in Redis
+        mock_redis.set.assert_called_once()
+        set_args = mock_redis.set.call_args
+        assert "duplicates_job_status" in set_args[0][0]
+        assert set_args[0][1] == "pending"
 
+    @patch("ontokit.api.routes.quality._get_redis")
     @patch("ontokit.api.routes.quality.get_arq_pool", new_callable=AsyncMock)
     @patch("ontokit.api.routes.quality.resolve_branch", new_callable=AsyncMock)
     @patch("ontokit.api.routes.quality.verify_project_access", new_callable=AsyncMock)
@@ -353,6 +397,7 @@ class TestDetectDuplicates:
         mock_access: AsyncMock,  # noqa: ARG002
         mock_resolve: AsyncMock,
         mock_pool_fn: AsyncMock,
+        mock_redis_fn: MagicMock,
         authed_client: tuple[TestClient, AsyncMock],
     ) -> None:
         """Custom threshold parameter is forwarded to the enqueued job."""
@@ -364,6 +409,8 @@ class TestDetectDuplicates:
         mock_pool = AsyncMock()
         mock_pool.enqueue_job.return_value = mock_job
         mock_pool_fn.return_value = mock_pool
+
+        mock_redis_fn.return_value = AsyncMock()
 
         response = client.post(
             f"/api/v1/projects/{PROJECT_ID}/quality/duplicates",
@@ -453,17 +500,38 @@ class TestGetDuplicateJobResult:
 
     @patch("ontokit.api.routes.quality._get_redis")
     @patch("ontokit.api.routes.quality.verify_project_access", new_callable=AsyncMock)
+    def test_get_job_result_pending(
+        self,
+        mock_access: AsyncMock,  # noqa: ARG002
+        mock_redis_fn: MagicMock,
+        authed_client: tuple[TestClient, AsyncMock],
+    ) -> None:
+        """Returns 202 when job result is not ready but status key exists."""
+        client, _ = authed_client
+
+        mock_redis = AsyncMock()
+        mock_redis.get.side_effect = [None, b"pending"]
+        mock_redis_fn.return_value = mock_redis
+
+        response = client.get(f"/api/v1/projects/{PROJECT_ID}/quality/duplicates/jobs/{JOB_ID}")
+        assert response.status_code == 202
+        data = response.json()
+        assert data["status"] == "pending"
+        assert data["job_id"] == JOB_ID
+
+    @patch("ontokit.api.routes.quality._get_redis")
+    @patch("ontokit.api.routes.quality.verify_project_access", new_callable=AsyncMock)
     def test_get_job_result_not_found(
         self,
         mock_access: AsyncMock,  # noqa: ARG002
         mock_redis_fn: MagicMock,
         authed_client: tuple[TestClient, AsyncMock],
     ) -> None:
-        """Returns 404 when duplicate job result is not cached."""
+        """Returns 404 when both result and status keys are absent."""
         client, _ = authed_client
 
         mock_redis = AsyncMock()
-        mock_redis.get.return_value = None
+        mock_redis.get.side_effect = [None, None]
         mock_redis_fn.return_value = mock_redis
 
         response = client.get(f"/api/v1/projects/{PROJECT_ID}/quality/duplicates/jobs/{JOB_ID}")

--- a/tests/unit/test_quality_routes.py
+++ b/tests/unit/test_quality_routes.py
@@ -79,64 +79,56 @@ class TestGetEntityReferences:
 class TestTriggerConsistencyCheck:
     """Tests for POST /api/v1/projects/{id}/quality/check."""
 
-    @patch("ontokit.api.routes.quality._get_redis")
-    @patch("ontokit.api.routes.quality.run_consistency_check")
-    @patch("ontokit.api.routes.quality.load_project_graph", new_callable=AsyncMock)
+    @patch("ontokit.api.routes.quality.get_arq_pool", new_callable=AsyncMock)
+    @patch("ontokit.api.routes.quality.resolve_branch", new_callable=AsyncMock)
     @patch("ontokit.api.routes.quality.verify_project_access", new_callable=AsyncMock)
     def test_trigger_check_success(
         self,
         mock_access: AsyncMock,  # noqa: ARG002
-        mock_load: AsyncMock,
-        mock_check: MagicMock,
-        mock_redis_fn: MagicMock,
+        mock_resolve: AsyncMock,
+        mock_pool_fn: AsyncMock,
         authed_client: tuple[TestClient, AsyncMock],
     ) -> None:
-        """Consistency check returns job_id on success."""
+        """Consistency check enqueues a job and returns job_id."""
         client, _ = authed_client
 
-        mock_graph = MagicMock(spec=Graph)
-        mock_load.return_value = (mock_graph, "main")
+        mock_resolve.return_value = "main"
 
-        mock_result = MagicMock()
-        mock_result.model_dump_json.return_value = '{"issues": []}'
-        mock_check.return_value = mock_result
-
-        mock_redis = AsyncMock()
-        mock_redis_fn.return_value = mock_redis
+        mock_job = MagicMock()
+        mock_pool = AsyncMock()
+        mock_pool.enqueue_job.return_value = mock_job
+        mock_pool_fn.return_value = mock_pool
 
         response = client.post(f"/api/v1/projects/{PROJECT_ID}/quality/check")
         assert response.status_code == 200
         data = response.json()
         assert "job_id" in data
         assert len(data["job_id"]) > 0
+        mock_pool.enqueue_job.assert_called_once()
+        call_args = mock_pool.enqueue_job.call_args[0]
+        assert call_args[0] == "run_consistency_check_task"
 
-    @patch("ontokit.api.routes.quality._get_redis")
-    @patch("ontokit.api.routes.quality.run_consistency_check")
-    @patch("ontokit.api.routes.quality.load_project_graph", new_callable=AsyncMock)
+    @patch("ontokit.api.routes.quality.get_arq_pool", new_callable=AsyncMock)
+    @patch("ontokit.api.routes.quality.resolve_branch", new_callable=AsyncMock)
     @patch("ontokit.api.routes.quality.verify_project_access", new_callable=AsyncMock)
-    def test_trigger_check_redis_failure_still_succeeds(
+    def test_trigger_check_enqueue_failure(
         self,
         mock_access: AsyncMock,  # noqa: ARG002
-        mock_load: AsyncMock,
-        mock_check: MagicMock,
-        mock_redis_fn: MagicMock,
+        mock_resolve: AsyncMock,
+        mock_pool_fn: AsyncMock,
         authed_client: tuple[TestClient, AsyncMock],
     ) -> None:
-        """Consistency check succeeds even when Redis caching fails."""
+        """Returns 500 when ARQ job enqueue returns None."""
         client, _ = authed_client
 
-        mock_graph = MagicMock(spec=Graph)
-        mock_load.return_value = (mock_graph, "main")
+        mock_resolve.return_value = "main"
 
-        mock_result = MagicMock()
-        mock_result.model_dump_json.return_value = '{"issues": []}'
-        mock_check.return_value = mock_result
-
-        mock_redis_fn.side_effect = RuntimeError("Redis unavailable")
+        mock_pool = AsyncMock()
+        mock_pool.enqueue_job.return_value = None
+        mock_pool_fn.return_value = mock_pool
 
         response = client.post(f"/api/v1/projects/{PROJECT_ID}/quality/check")
-        # Should still return 200 since Redis failure is caught with warning
-        assert response.status_code == 200
+        assert response.status_code == 500
 
 
 class TestGetQualityJobResult:
@@ -196,57 +188,180 @@ class TestGetQualityJobResult:
 class TestDetectDuplicates:
     """Tests for POST /api/v1/projects/{id}/quality/duplicates."""
 
-    @patch("ontokit.api.routes.quality.find_duplicates")
-    @patch("ontokit.api.routes.quality.load_project_graph", new_callable=AsyncMock)
+    @patch("ontokit.api.routes.quality.get_arq_pool", new_callable=AsyncMock)
+    @patch("ontokit.api.routes.quality.resolve_branch", new_callable=AsyncMock)
     @patch("ontokit.api.routes.quality.verify_project_access", new_callable=AsyncMock)
     def test_detect_duplicates_success(
         self,
         mock_access: AsyncMock,  # noqa: ARG002
-        mock_load: AsyncMock,
-        mock_find: MagicMock,
+        mock_resolve: AsyncMock,
+        mock_pool_fn: AsyncMock,
         authed_client: tuple[TestClient, AsyncMock],
     ) -> None:
-        """Returns duplicate detection results."""
+        """Returns job_id when duplicate detection is enqueued."""
         client, _ = authed_client
 
-        mock_graph = MagicMock(spec=Graph)
-        mock_load.return_value = (mock_graph, "main")
-        mock_find.return_value = {
-            "clusters": [],
-            "threshold": 0.85,
-            "checked_at": datetime.now(UTC).isoformat(),
-        }
+        mock_resolve.return_value = "main"
+
+        mock_job = MagicMock()
+        mock_pool = AsyncMock()
+        mock_pool.enqueue_job.return_value = mock_job
+        mock_pool_fn.return_value = mock_pool
 
         response = client.post(f"/api/v1/projects/{PROJECT_ID}/quality/duplicates")
         assert response.status_code == 200
         data = response.json()
-        assert data["clusters"] == []
-        assert data["threshold"] == 0.85
+        assert "job_id" in data
+        assert len(data["job_id"]) > 0
+        mock_pool.enqueue_job.assert_called_once()
+        call_args = mock_pool.enqueue_job.call_args[0]
+        assert call_args[0] == "run_duplicate_detection_task"
 
-    @patch("ontokit.api.routes.quality.find_duplicates")
-    @patch("ontokit.api.routes.quality.load_project_graph", new_callable=AsyncMock)
+    @patch("ontokit.api.routes.quality.get_arq_pool", new_callable=AsyncMock)
+    @patch("ontokit.api.routes.quality.resolve_branch", new_callable=AsyncMock)
     @patch("ontokit.api.routes.quality.verify_project_access", new_callable=AsyncMock)
     def test_detect_duplicates_custom_threshold(
         self,
         mock_access: AsyncMock,  # noqa: ARG002
-        mock_load: AsyncMock,
-        mock_find: MagicMock,
+        mock_resolve: AsyncMock,
+        mock_pool_fn: AsyncMock,
         authed_client: tuple[TestClient, AsyncMock],
     ) -> None:
-        """Custom threshold parameter is forwarded to find_duplicates."""
+        """Custom threshold parameter is forwarded to the enqueued job."""
         client, _ = authed_client
 
-        mock_graph = MagicMock(spec=Graph)
-        mock_load.return_value = (mock_graph, "main")
-        mock_find.return_value = {
-            "clusters": [],
-            "threshold": 0.9,
-            "checked_at": datetime.now(UTC).isoformat(),
-        }
+        mock_resolve.return_value = "main"
+
+        mock_job = MagicMock()
+        mock_pool = AsyncMock()
+        mock_pool.enqueue_job.return_value = mock_job
+        mock_pool_fn.return_value = mock_pool
 
         response = client.post(
             f"/api/v1/projects/{PROJECT_ID}/quality/duplicates",
             params={"threshold": 0.9},
         )
         assert response.status_code == 200
-        mock_find.assert_called_once_with(mock_graph, 0.9)
+        # Verify threshold was passed to enqueue_job
+        call_args = mock_pool.enqueue_job.call_args[0]
+        assert call_args[3] == 0.9  # threshold is the 4th positional arg
+
+
+class TestGetDuplicateJobResult:
+    """Tests for GET /api/v1/projects/{id}/quality/duplicates/jobs/{job_id}."""
+
+    @patch("ontokit.api.routes.quality._get_redis")
+    @patch("ontokit.api.routes.quality.verify_project_access", new_callable=AsyncMock)
+    def test_get_job_result_cached(
+        self,
+        mock_access: AsyncMock,  # noqa: ARG002
+        mock_redis_fn: MagicMock,
+        authed_client: tuple[TestClient, AsyncMock],
+    ) -> None:
+        """Returns cached duplicate result when available in Redis."""
+        client, _ = authed_client
+
+        cached_data = json.dumps(
+            {
+                "clusters": [],
+                "threshold": 0.85,
+                "checked_at": datetime.now(UTC).isoformat(),
+            }
+        )
+
+        mock_redis = AsyncMock()
+        mock_redis.get.return_value = cached_data
+        mock_redis_fn.return_value = mock_redis
+
+        response = client.get(f"/api/v1/projects/{PROJECT_ID}/quality/duplicates/jobs/{JOB_ID}")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["clusters"] == []
+        assert data["threshold"] == 0.85
+
+    @patch("ontokit.api.routes.quality._get_redis")
+    @patch("ontokit.api.routes.quality.verify_project_access", new_callable=AsyncMock)
+    def test_get_job_result_not_found(
+        self,
+        mock_access: AsyncMock,  # noqa: ARG002
+        mock_redis_fn: MagicMock,
+        authed_client: tuple[TestClient, AsyncMock],
+    ) -> None:
+        """Returns 404 when duplicate job result is not cached."""
+        client, _ = authed_client
+
+        mock_redis = AsyncMock()
+        mock_redis.get.return_value = None
+        mock_redis_fn.return_value = mock_redis
+
+        response = client.get(f"/api/v1/projects/{PROJECT_ID}/quality/duplicates/jobs/{JOB_ID}")
+        assert response.status_code == 404
+
+
+class TestGetLatestDuplicates:
+    """Tests for GET /api/v1/projects/{id}/quality/duplicates/latest."""
+
+    @patch("ontokit.api.routes.quality._get_redis")
+    @patch("ontokit.api.routes.quality.resolve_branch", new_callable=AsyncMock)
+    @patch("ontokit.api.routes.quality.verify_project_access", new_callable=AsyncMock)
+    def test_get_latest_cached(
+        self,
+        mock_access: AsyncMock,  # noqa: ARG002
+        mock_resolve: AsyncMock,
+        mock_redis_fn: MagicMock,
+        authed_client: tuple[TestClient, AsyncMock],
+    ) -> None:
+        """Returns cached duplicate results."""
+        client, _ = authed_client
+
+        mock_resolve.return_value = "main"
+
+        cached_data = json.dumps(
+            {
+                "clusters": [
+                    {
+                        "entities": [
+                            {"iri": "http://ex.org/A", "label": "Thing A", "entity_type": "class"},
+                            {"iri": "http://ex.org/B", "label": "Thing B", "entity_type": "class"},
+                        ],
+                        "similarity": 0.92,
+                    }
+                ],
+                "threshold": 0.85,
+                "checked_at": datetime.now(UTC).isoformat(),
+            }
+        )
+
+        mock_redis = AsyncMock()
+        mock_redis.get.return_value = cached_data
+        mock_redis_fn.return_value = mock_redis
+
+        response = client.get(f"/api/v1/projects/{PROJECT_ID}/quality/duplicates/latest")
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["clusters"]) == 1
+        assert data["clusters"][0]["similarity"] == 0.92
+
+    @patch("ontokit.api.routes.quality._get_redis")
+    @patch("ontokit.api.routes.quality.resolve_branch", new_callable=AsyncMock)
+    @patch("ontokit.api.routes.quality.verify_project_access", new_callable=AsyncMock)
+    def test_get_latest_empty(
+        self,
+        mock_access: AsyncMock,  # noqa: ARG002
+        mock_resolve: AsyncMock,
+        mock_redis_fn: MagicMock,
+        authed_client: tuple[TestClient, AsyncMock],
+    ) -> None:
+        """Returns empty result when no cached data exists."""
+        client, _ = authed_client
+
+        mock_resolve.return_value = "main"
+
+        mock_redis = AsyncMock()
+        mock_redis.get.return_value = None
+        mock_redis_fn.return_value = mock_redis
+
+        response = client.get(f"/api/v1/projects/{PROJECT_ID}/quality/duplicates/latest")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["clusters"] == []

--- a/tests/unit/test_quality_worker.py
+++ b/tests/unit/test_quality_worker.py
@@ -122,9 +122,10 @@ class TestRunConsistencyCheckTask:
 
     @pytest.mark.asyncio
     async def test_project_no_ontology(self) -> None:
-        """Raises ValueError when project has no ontology file."""
+        """Raises ValueError when project has no ontology file and no integration."""
         project = MagicMock()
         project.source_file_path = None
+        project.github_integration = None
         ctx = _make_ctx(project=project)
 
         with pytest.raises(ValueError, match="no ontology file"):
@@ -252,9 +253,10 @@ class TestRunDuplicateDetectionTask:
 
     @pytest.mark.asyncio
     async def test_project_no_ontology(self) -> None:
-        """Raises ValueError when project has no ontology file."""
+        """Raises ValueError when project has no ontology file and no integration."""
         project = MagicMock()
         project.source_file_path = None
+        project.github_integration = None
         ctx = _make_ctx(project=project)
 
         with pytest.raises(ValueError, match="no ontology file"):

--- a/tests/unit/test_quality_worker.py
+++ b/tests/unit/test_quality_worker.py
@@ -39,6 +39,7 @@ class TestRunConsistencyCheckTask:
 
     @pytest.mark.asyncio
     @patch("ontokit.services.consistency_service.run_consistency_check")
+    @patch("ontokit.worker._sync_load_from_git")
     @patch("ontokit.worker.get_ontology_service")
     @patch("ontokit.worker.get_storage_service")
     @patch("ontokit.worker.BareGitRepositoryService")
@@ -46,7 +47,8 @@ class TestRunConsistencyCheckTask:
         self,
         mock_git_cls: MagicMock,
         mock_storage_fn: MagicMock,  # noqa: ARG002
-        mock_ontology_fn: MagicMock,
+        mock_ontology_fn: MagicMock,  # noqa: ARG002
+        mock_sync_load: MagicMock,
         mock_check: MagicMock,
     ) -> None:
         """Runs consistency check via git and caches result."""
@@ -56,9 +58,7 @@ class TestRunConsistencyCheckTask:
         mock_git.repository_exists.return_value = True
         mock_git_cls.return_value = mock_git
 
-        mock_ontology = MagicMock()
-        mock_ontology.load_from_git = AsyncMock(return_value=MagicMock(spec=Graph))
-        mock_ontology_fn.return_value = mock_ontology
+        mock_sync_load.return_value = MagicMock(spec=Graph)
 
         mock_result = MagicMock()
         mock_result.issues = [MagicMock(), MagicMock()]
@@ -133,6 +133,7 @@ class TestRunConsistencyCheckTask:
 
     @pytest.mark.asyncio
     @patch("ontokit.services.consistency_service.run_consistency_check")
+    @patch("ontokit.worker._sync_load_from_git")
     @patch("ontokit.worker.get_ontology_service")
     @patch("ontokit.worker.get_storage_service")
     @patch("ontokit.worker.BareGitRepositoryService")
@@ -140,7 +141,8 @@ class TestRunConsistencyCheckTask:
         self,
         mock_git_cls: MagicMock,
         mock_storage_fn: MagicMock,  # noqa: ARG002
-        mock_ontology_fn: MagicMock,
+        mock_ontology_fn: MagicMock,  # noqa: ARG002
+        mock_sync_load: MagicMock,
         mock_check: MagicMock,
     ) -> None:
         """Caches only by branch key when no job_id is provided."""
@@ -150,9 +152,7 @@ class TestRunConsistencyCheckTask:
         mock_git.repository_exists.return_value = True
         mock_git_cls.return_value = mock_git
 
-        mock_ontology = MagicMock()
-        mock_ontology.load_from_git = AsyncMock(return_value=MagicMock(spec=Graph))
-        mock_ontology_fn.return_value = mock_ontology
+        mock_sync_load.return_value = MagicMock(spec=Graph)
 
         mock_result = MagicMock()
         mock_result.issues = []
@@ -172,6 +172,7 @@ class TestRunDuplicateDetectionTask:
 
     @pytest.mark.asyncio
     @patch("ontokit.services.duplicate_detection_service.find_duplicates")
+    @patch("ontokit.worker._sync_load_from_git")
     @patch("ontokit.worker.get_ontology_service")
     @patch("ontokit.worker.get_storage_service")
     @patch("ontokit.worker.BareGitRepositoryService")
@@ -179,7 +180,8 @@ class TestRunDuplicateDetectionTask:
         self,
         mock_git_cls: MagicMock,
         mock_storage_fn: MagicMock,  # noqa: ARG002
-        mock_ontology_fn: MagicMock,
+        mock_ontology_fn: MagicMock,  # noqa: ARG002
+        mock_sync_load: MagicMock,
         mock_find: MagicMock,
     ) -> None:
         """Runs duplicate detection via git and caches result."""
@@ -189,9 +191,7 @@ class TestRunDuplicateDetectionTask:
         mock_git.repository_exists.return_value = True
         mock_git_cls.return_value = mock_git
 
-        mock_ontology = MagicMock()
-        mock_ontology.load_from_git = AsyncMock(return_value=MagicMock(spec=Graph))
-        mock_ontology_fn.return_value = mock_ontology
+        mock_sync_load.return_value = MagicMock(spec=Graph)
 
         mock_result = MagicMock()
         mock_result.clusters = [MagicMock()]
@@ -264,6 +264,7 @@ class TestRunDuplicateDetectionTask:
 
     @pytest.mark.asyncio
     @patch("ontokit.services.duplicate_detection_service.find_duplicates")
+    @patch("ontokit.worker._sync_load_from_git")
     @patch("ontokit.worker.get_ontology_service")
     @patch("ontokit.worker.get_storage_service")
     @patch("ontokit.worker.BareGitRepositoryService")
@@ -271,7 +272,8 @@ class TestRunDuplicateDetectionTask:
         self,
         mock_git_cls: MagicMock,
         mock_storage_fn: MagicMock,  # noqa: ARG002
-        mock_ontology_fn: MagicMock,
+        mock_ontology_fn: MagicMock,  # noqa: ARG002
+        mock_sync_load: MagicMock,
         mock_find: MagicMock,
     ) -> None:
         """Custom threshold is forwarded to find_duplicates."""
@@ -281,9 +283,7 @@ class TestRunDuplicateDetectionTask:
         mock_git.repository_exists.return_value = True
         mock_git_cls.return_value = mock_git
 
-        mock_ontology = MagicMock()
-        mock_ontology.load_from_git = AsyncMock(return_value=MagicMock(spec=Graph))
-        mock_ontology_fn.return_value = mock_ontology
+        mock_sync_load.return_value = MagicMock(spec=Graph)
 
         mock_result = MagicMock()
         mock_result.clusters = []

--- a/tests/unit/test_quality_worker.py
+++ b/tests/unit/test_quality_worker.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import UUID
 
@@ -13,6 +14,26 @@ from ontokit.worker import run_consistency_check_task, run_duplicate_detection_t
 PROJECT_ID = "12345678-1234-5678-1234-567812345678"
 PROJECT_UUID = UUID(PROJECT_ID)
 JOB_ID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+
+class _InlineExecutor:
+    """A fake executor that runs callables inline (no subprocess)."""
+
+    def __enter__(self) -> _InlineExecutor:
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        pass
+
+    def submit(self, fn: Any, *args: Any) -> Any:
+        from concurrent.futures import Future
+
+        f: Future[object] = Future()
+        try:
+            f.set_result(fn(*args))
+        except Exception as e:
+            f.set_exception(e)
+        return f
 
 
 def _make_ctx(
@@ -39,16 +60,12 @@ class TestRunConsistencyCheckTask:
 
     @pytest.mark.asyncio
     @patch("ontokit.services.consistency_service.run_consistency_check")
-    @patch("ontokit.worker._sync_load_from_git")
-    @patch("ontokit.worker.get_ontology_service")
-    @patch("ontokit.worker.get_storage_service")
+    @patch("ontokit.worker._parse_rdf")
     @patch("ontokit.worker.BareGitRepositoryService")
     async def test_success_with_git(
         self,
         mock_git_cls: MagicMock,
-        mock_storage_fn: MagicMock,  # noqa: ARG002
-        mock_ontology_fn: MagicMock,  # noqa: ARG002
-        mock_sync_load: MagicMock,
+        mock_parse: MagicMock,
         mock_check: MagicMock,
     ) -> None:
         """Runs consistency check via git and caches result."""
@@ -56,16 +73,18 @@ class TestRunConsistencyCheckTask:
 
         mock_git = MagicMock()
         mock_git.repository_exists.return_value = True
+        mock_git.get_file_from_branch.return_value = b"<turtle content>"
         mock_git_cls.return_value = mock_git
 
-        mock_sync_load.return_value = MagicMock(spec=Graph)
+        mock_parse.return_value = MagicMock(spec=Graph)
 
         mock_result = MagicMock()
         mock_result.issues = [MagicMock(), MagicMock()]
         mock_result.model_dump_json.return_value = '{"issues": [{}, {}]}'
         mock_check.return_value = mock_result
 
-        result = await run_consistency_check_task(ctx, PROJECT_ID, "main", JOB_ID)
+        with patch("concurrent.futures.ProcessPoolExecutor", return_value=_InlineExecutor()):
+            result = await run_consistency_check_task(ctx, PROJECT_ID, "main", JOB_ID)
 
         assert result["status"] == "completed"
         assert result["issues_found"] == 2
@@ -77,14 +96,12 @@ class TestRunConsistencyCheckTask:
         assert redis.publish.await_count == 2  # started + complete
 
     @pytest.mark.asyncio
-    @patch("ontokit.worker.get_ontology_service")
     @patch("ontokit.worker.get_storage_service")
     @patch("ontokit.worker.BareGitRepositoryService")
     async def test_success_with_storage_fallback(
         self,
         mock_git_cls: MagicMock,
-        mock_storage_fn: MagicMock,  # noqa: ARG002
-        mock_ontology_fn: MagicMock,
+        mock_storage_fn: MagicMock,
     ) -> None:
         """Falls back to storage when git repo doesn't exist."""
         ctx = _make_ctx()
@@ -93,21 +110,26 @@ class TestRunConsistencyCheckTask:
         mock_git.repository_exists.return_value = False
         mock_git_cls.return_value = mock_git
 
-        mock_ontology = MagicMock()
-        mock_ontology.load_from_storage = AsyncMock(return_value=MagicMock(spec=Graph))
-        mock_ontology_fn.return_value = mock_ontology
+        mock_storage = AsyncMock()
+        mock_storage.download_file.return_value = b"<turtle content>"
+        mock_storage_fn.return_value = mock_storage
 
         mock_result = MagicMock()
         mock_result.issues = []
         mock_result.model_dump_json.return_value = '{"issues": []}'
 
-        with patch(
-            "ontokit.services.consistency_service.run_consistency_check", return_value=mock_result
+        with (
+            patch("ontokit.worker._parse_rdf", return_value=MagicMock(spec=Graph)),
+            patch(
+                "ontokit.services.consistency_service.run_consistency_check",
+                return_value=mock_result,
+            ),
+            patch("concurrent.futures.ProcessPoolExecutor", return_value=_InlineExecutor()),
         ):
             result = await run_consistency_check_task(ctx, PROJECT_ID, "main", JOB_ID)
 
         assert result["status"] == "completed"
-        mock_ontology.load_from_storage.assert_awaited_once()
+        mock_storage.download_file.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_project_not_found(self) -> None:
@@ -133,16 +155,12 @@ class TestRunConsistencyCheckTask:
 
     @pytest.mark.asyncio
     @patch("ontokit.services.consistency_service.run_consistency_check")
-    @patch("ontokit.worker._sync_load_from_git")
-    @patch("ontokit.worker.get_ontology_service")
-    @patch("ontokit.worker.get_storage_service")
+    @patch("ontokit.worker._parse_rdf")
     @patch("ontokit.worker.BareGitRepositoryService")
     async def test_without_job_id(
         self,
         mock_git_cls: MagicMock,
-        mock_storage_fn: MagicMock,  # noqa: ARG002
-        mock_ontology_fn: MagicMock,  # noqa: ARG002
-        mock_sync_load: MagicMock,
+        mock_parse: MagicMock,
         mock_check: MagicMock,
     ) -> None:
         """Caches only by branch key when no job_id is provided."""
@@ -150,16 +168,18 @@ class TestRunConsistencyCheckTask:
 
         mock_git = MagicMock()
         mock_git.repository_exists.return_value = True
+        mock_git.get_file_from_branch.return_value = b"<turtle content>"
         mock_git_cls.return_value = mock_git
 
-        mock_sync_load.return_value = MagicMock(spec=Graph)
+        mock_parse.return_value = MagicMock(spec=Graph)
 
         mock_result = MagicMock()
         mock_result.issues = []
         mock_result.model_dump_json.return_value = '{"issues": []}'
         mock_check.return_value = mock_result
 
-        result = await run_consistency_check_task(ctx, PROJECT_ID, "main", None)
+        with patch("concurrent.futures.ProcessPoolExecutor", return_value=_InlineExecutor()):
+            result = await run_consistency_check_task(ctx, PROJECT_ID, "main", None)
 
         assert result["status"] == "completed"
         # Only cache_key set (no job_key)
@@ -172,16 +192,12 @@ class TestRunDuplicateDetectionTask:
 
     @pytest.mark.asyncio
     @patch("ontokit.services.duplicate_detection_service.find_duplicates")
-    @patch("ontokit.worker._sync_load_from_git")
-    @patch("ontokit.worker.get_ontology_service")
-    @patch("ontokit.worker.get_storage_service")
+    @patch("ontokit.worker._parse_rdf")
     @patch("ontokit.worker.BareGitRepositoryService")
     async def test_success_with_git(
         self,
         mock_git_cls: MagicMock,
-        mock_storage_fn: MagicMock,  # noqa: ARG002
-        mock_ontology_fn: MagicMock,  # noqa: ARG002
-        mock_sync_load: MagicMock,
+        mock_parse: MagicMock,
         mock_find: MagicMock,
     ) -> None:
         """Runs duplicate detection via git and caches result."""
@@ -189,16 +205,18 @@ class TestRunDuplicateDetectionTask:
 
         mock_git = MagicMock()
         mock_git.repository_exists.return_value = True
+        mock_git.get_file_from_branch.return_value = b"<turtle content>"
         mock_git_cls.return_value = mock_git
 
-        mock_sync_load.return_value = MagicMock(spec=Graph)
+        mock_parse.return_value = MagicMock(spec=Graph)
 
         mock_result = MagicMock()
         mock_result.clusters = [MagicMock()]
         mock_result.model_dump_json.return_value = '{"clusters": [{}]}'
         mock_find.return_value = mock_result
 
-        result = await run_duplicate_detection_task(ctx, PROJECT_ID, "main", 0.85, JOB_ID)
+        with patch("concurrent.futures.ProcessPoolExecutor", return_value=_InlineExecutor()):
+            result = await run_duplicate_detection_task(ctx, PROJECT_ID, "main", 0.85, JOB_ID)
 
         assert result["status"] == "completed"
         assert result["clusters_found"] == 1
@@ -209,14 +227,12 @@ class TestRunDuplicateDetectionTask:
         assert redis.publish.await_count == 2
 
     @pytest.mark.asyncio
-    @patch("ontokit.worker.get_ontology_service")
     @patch("ontokit.worker.get_storage_service")
     @patch("ontokit.worker.BareGitRepositoryService")
     async def test_success_with_storage_fallback(
         self,
         mock_git_cls: MagicMock,
-        mock_storage_fn: MagicMock,  # noqa: ARG002
-        mock_ontology_fn: MagicMock,
+        mock_storage_fn: MagicMock,
     ) -> None:
         """Falls back to storage when git repo doesn't exist."""
         ctx = _make_ctx()
@@ -225,21 +241,26 @@ class TestRunDuplicateDetectionTask:
         mock_git.repository_exists.return_value = False
         mock_git_cls.return_value = mock_git
 
-        mock_ontology = MagicMock()
-        mock_ontology.load_from_storage = AsyncMock(return_value=MagicMock(spec=Graph))
-        mock_ontology_fn.return_value = mock_ontology
+        mock_storage = AsyncMock()
+        mock_storage.download_file.return_value = b"<turtle content>"
+        mock_storage_fn.return_value = mock_storage
 
         mock_result = MagicMock()
         mock_result.clusters = []
         mock_result.model_dump_json.return_value = '{"clusters": []}'
 
-        with patch(
-            "ontokit.services.duplicate_detection_service.find_duplicates", return_value=mock_result
+        with (
+            patch("ontokit.worker._parse_rdf", return_value=MagicMock(spec=Graph)),
+            patch(
+                "ontokit.services.duplicate_detection_service.find_duplicates",
+                return_value=mock_result,
+            ),
+            patch("concurrent.futures.ProcessPoolExecutor", return_value=_InlineExecutor()),
         ):
             result = await run_duplicate_detection_task(ctx, PROJECT_ID, "main", 0.85, JOB_ID)
 
         assert result["status"] == "completed"
-        mock_ontology.load_from_storage.assert_awaited_once()
+        mock_storage.download_file.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_project_not_found(self) -> None:
@@ -264,16 +285,12 @@ class TestRunDuplicateDetectionTask:
 
     @pytest.mark.asyncio
     @patch("ontokit.services.duplicate_detection_service.find_duplicates")
-    @patch("ontokit.worker._sync_load_from_git")
-    @patch("ontokit.worker.get_ontology_service")
-    @patch("ontokit.worker.get_storage_service")
+    @patch("ontokit.worker._parse_rdf")
     @patch("ontokit.worker.BareGitRepositoryService")
     async def test_custom_threshold(
         self,
         mock_git_cls: MagicMock,
-        mock_storage_fn: MagicMock,  # noqa: ARG002
-        mock_ontology_fn: MagicMock,  # noqa: ARG002
-        mock_sync_load: MagicMock,
+        mock_parse: MagicMock,
         mock_find: MagicMock,
     ) -> None:
         """Custom threshold is forwarded to find_duplicates."""
@@ -281,16 +298,18 @@ class TestRunDuplicateDetectionTask:
 
         mock_git = MagicMock()
         mock_git.repository_exists.return_value = True
+        mock_git.get_file_from_branch.return_value = b"<turtle content>"
         mock_git_cls.return_value = mock_git
 
-        mock_sync_load.return_value = MagicMock(spec=Graph)
+        mock_parse.return_value = MagicMock(spec=Graph)
 
         mock_result = MagicMock()
         mock_result.clusters = []
         mock_result.model_dump_json.return_value = '{"clusters": []}'
         mock_find.return_value = mock_result
 
-        await run_duplicate_detection_task(ctx, PROJECT_ID, "main", 0.95, JOB_ID)
+        with patch("concurrent.futures.ProcessPoolExecutor", return_value=_InlineExecutor()):
+            await run_duplicate_detection_task(ctx, PROJECT_ID, "main", 0.95, JOB_ID)
 
         mock_find.assert_called_once()
         call_args = mock_find.call_args[0]

--- a/tests/unit/test_quality_worker.py
+++ b/tests/unit/test_quality_worker.py
@@ -1,0 +1,295 @@
+"""Tests for quality-related ARQ worker tasks."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID
+
+import pytest
+from rdflib import Graph
+
+from ontokit.worker import run_consistency_check_task, run_duplicate_detection_task
+
+PROJECT_ID = "12345678-1234-5678-1234-567812345678"
+PROJECT_UUID = UUID(PROJECT_ID)
+JOB_ID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+
+def _make_ctx(
+    project: MagicMock | None = None,
+    project_exists: bool = True,
+) -> dict[str, AsyncMock]:
+    """Build a mock ARQ ctx with db and redis."""
+    db = AsyncMock()
+    redis = AsyncMock()
+
+    if project_exists and project is None:
+        project = MagicMock()
+        project.source_file_path = "ontokit/test.ttl"
+
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = project if project_exists else None
+    db.execute = AsyncMock(return_value=mock_result)
+
+    return {"db": db, "redis": redis}
+
+
+class TestRunConsistencyCheckTask:
+    """Tests for run_consistency_check_task."""
+
+    @pytest.mark.asyncio
+    @patch("ontokit.services.consistency_service.run_consistency_check")
+    @patch("ontokit.worker.get_ontology_service")
+    @patch("ontokit.worker.get_storage_service")
+    @patch("ontokit.worker.BareGitRepositoryService")
+    async def test_success_with_git(
+        self,
+        mock_git_cls: MagicMock,
+        mock_storage_fn: MagicMock,  # noqa: ARG002
+        mock_ontology_fn: MagicMock,
+        mock_check: MagicMock,
+    ) -> None:
+        """Runs consistency check via git and caches result."""
+        ctx = _make_ctx()
+
+        mock_git = MagicMock()
+        mock_git.repository_exists.return_value = True
+        mock_git_cls.return_value = mock_git
+
+        mock_ontology = MagicMock()
+        mock_ontology.load_from_git = AsyncMock(return_value=MagicMock(spec=Graph))
+        mock_ontology_fn.return_value = mock_ontology
+
+        mock_result = MagicMock()
+        mock_result.issues = [MagicMock(), MagicMock()]
+        mock_result.model_dump_json.return_value = '{"issues": [{}, {}]}'
+        mock_check.return_value = mock_result
+
+        result = await run_consistency_check_task(ctx, PROJECT_ID, "main", JOB_ID)
+
+        assert result["status"] == "completed"
+        assert result["issues_found"] == 2
+        assert result["job_id"] == JOB_ID
+
+        # Verify Redis caching
+        redis = ctx["redis"]
+        assert redis.set.await_count == 2  # cache_key + job_key
+        assert redis.publish.await_count == 2  # started + complete
+
+    @pytest.mark.asyncio
+    @patch("ontokit.worker.get_ontology_service")
+    @patch("ontokit.worker.get_storage_service")
+    @patch("ontokit.worker.BareGitRepositoryService")
+    async def test_success_with_storage_fallback(
+        self,
+        mock_git_cls: MagicMock,
+        mock_storage_fn: MagicMock,  # noqa: ARG002
+        mock_ontology_fn: MagicMock,
+    ) -> None:
+        """Falls back to storage when git repo doesn't exist."""
+        ctx = _make_ctx()
+
+        mock_git = MagicMock()
+        mock_git.repository_exists.return_value = False
+        mock_git_cls.return_value = mock_git
+
+        mock_ontology = MagicMock()
+        mock_ontology.load_from_storage = AsyncMock(return_value=MagicMock(spec=Graph))
+        mock_ontology_fn.return_value = mock_ontology
+
+        mock_result = MagicMock()
+        mock_result.issues = []
+        mock_result.model_dump_json.return_value = '{"issues": []}'
+
+        with patch(
+            "ontokit.services.consistency_service.run_consistency_check", return_value=mock_result
+        ):
+            result = await run_consistency_check_task(ctx, PROJECT_ID, "main", JOB_ID)
+
+        assert result["status"] == "completed"
+        mock_ontology.load_from_storage.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_project_not_found(self) -> None:
+        """Raises ValueError when project doesn't exist."""
+        ctx = _make_ctx(project_exists=False)
+
+        with pytest.raises(ValueError, match="not found"):
+            await run_consistency_check_task(ctx, PROJECT_ID, "main", JOB_ID)
+
+        # Verify failure notification was published
+        ctx["redis"].publish.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_project_no_ontology(self) -> None:
+        """Raises ValueError when project has no ontology file."""
+        project = MagicMock()
+        project.source_file_path = None
+        ctx = _make_ctx(project=project)
+
+        with pytest.raises(ValueError, match="no ontology file"):
+            await run_consistency_check_task(ctx, PROJECT_ID, "main", JOB_ID)
+
+    @pytest.mark.asyncio
+    @patch("ontokit.services.consistency_service.run_consistency_check")
+    @patch("ontokit.worker.get_ontology_service")
+    @patch("ontokit.worker.get_storage_service")
+    @patch("ontokit.worker.BareGitRepositoryService")
+    async def test_without_job_id(
+        self,
+        mock_git_cls: MagicMock,
+        mock_storage_fn: MagicMock,  # noqa: ARG002
+        mock_ontology_fn: MagicMock,
+        mock_check: MagicMock,
+    ) -> None:
+        """Caches only by branch key when no job_id is provided."""
+        ctx = _make_ctx()
+
+        mock_git = MagicMock()
+        mock_git.repository_exists.return_value = True
+        mock_git_cls.return_value = mock_git
+
+        mock_ontology = MagicMock()
+        mock_ontology.load_from_git = AsyncMock(return_value=MagicMock(spec=Graph))
+        mock_ontology_fn.return_value = mock_ontology
+
+        mock_result = MagicMock()
+        mock_result.issues = []
+        mock_result.model_dump_json.return_value = '{"issues": []}'
+        mock_check.return_value = mock_result
+
+        result = await run_consistency_check_task(ctx, PROJECT_ID, "main", None)
+
+        assert result["status"] == "completed"
+        # Only cache_key set (no job_key)
+        redis = ctx["redis"]
+        assert redis.set.await_count == 1
+
+
+class TestRunDuplicateDetectionTask:
+    """Tests for run_duplicate_detection_task."""
+
+    @pytest.mark.asyncio
+    @patch("ontokit.services.duplicate_detection_service.find_duplicates")
+    @patch("ontokit.worker.get_ontology_service")
+    @patch("ontokit.worker.get_storage_service")
+    @patch("ontokit.worker.BareGitRepositoryService")
+    async def test_success_with_git(
+        self,
+        mock_git_cls: MagicMock,
+        mock_storage_fn: MagicMock,  # noqa: ARG002
+        mock_ontology_fn: MagicMock,
+        mock_find: MagicMock,
+    ) -> None:
+        """Runs duplicate detection via git and caches result."""
+        ctx = _make_ctx()
+
+        mock_git = MagicMock()
+        mock_git.repository_exists.return_value = True
+        mock_git_cls.return_value = mock_git
+
+        mock_ontology = MagicMock()
+        mock_ontology.load_from_git = AsyncMock(return_value=MagicMock(spec=Graph))
+        mock_ontology_fn.return_value = mock_ontology
+
+        mock_result = MagicMock()
+        mock_result.clusters = [MagicMock()]
+        mock_result.model_dump_json.return_value = '{"clusters": [{}]}'
+        mock_find.return_value = mock_result
+
+        result = await run_duplicate_detection_task(ctx, PROJECT_ID, "main", 0.85, JOB_ID)
+
+        assert result["status"] == "completed"
+        assert result["clusters_found"] == 1
+        assert result["job_id"] == JOB_ID
+
+        redis = ctx["redis"]
+        assert redis.set.await_count == 2
+        assert redis.publish.await_count == 2
+
+    @pytest.mark.asyncio
+    @patch("ontokit.worker.get_ontology_service")
+    @patch("ontokit.worker.get_storage_service")
+    @patch("ontokit.worker.BareGitRepositoryService")
+    async def test_success_with_storage_fallback(
+        self,
+        mock_git_cls: MagicMock,
+        mock_storage_fn: MagicMock,  # noqa: ARG002
+        mock_ontology_fn: MagicMock,
+    ) -> None:
+        """Falls back to storage when git repo doesn't exist."""
+        ctx = _make_ctx()
+
+        mock_git = MagicMock()
+        mock_git.repository_exists.return_value = False
+        mock_git_cls.return_value = mock_git
+
+        mock_ontology = MagicMock()
+        mock_ontology.load_from_storage = AsyncMock(return_value=MagicMock(spec=Graph))
+        mock_ontology_fn.return_value = mock_ontology
+
+        mock_result = MagicMock()
+        mock_result.clusters = []
+        mock_result.model_dump_json.return_value = '{"clusters": []}'
+
+        with patch(
+            "ontokit.services.duplicate_detection_service.find_duplicates", return_value=mock_result
+        ):
+            result = await run_duplicate_detection_task(ctx, PROJECT_ID, "main", 0.85, JOB_ID)
+
+        assert result["status"] == "completed"
+        mock_ontology.load_from_storage.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_project_not_found(self) -> None:
+        """Raises ValueError when project doesn't exist."""
+        ctx = _make_ctx(project_exists=False)
+
+        with pytest.raises(ValueError, match="not found"):
+            await run_duplicate_detection_task(ctx, PROJECT_ID, "main", 0.85, JOB_ID)
+
+        ctx["redis"].publish.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_project_no_ontology(self) -> None:
+        """Raises ValueError when project has no ontology file."""
+        project = MagicMock()
+        project.source_file_path = None
+        ctx = _make_ctx(project=project)
+
+        with pytest.raises(ValueError, match="no ontology file"):
+            await run_duplicate_detection_task(ctx, PROJECT_ID, "main", 0.85, JOB_ID)
+
+    @pytest.mark.asyncio
+    @patch("ontokit.services.duplicate_detection_service.find_duplicates")
+    @patch("ontokit.worker.get_ontology_service")
+    @patch("ontokit.worker.get_storage_service")
+    @patch("ontokit.worker.BareGitRepositoryService")
+    async def test_custom_threshold(
+        self,
+        mock_git_cls: MagicMock,
+        mock_storage_fn: MagicMock,  # noqa: ARG002
+        mock_ontology_fn: MagicMock,
+        mock_find: MagicMock,
+    ) -> None:
+        """Custom threshold is forwarded to find_duplicates."""
+        ctx = _make_ctx()
+
+        mock_git = MagicMock()
+        mock_git.repository_exists.return_value = True
+        mock_git_cls.return_value = mock_git
+
+        mock_ontology = MagicMock()
+        mock_ontology.load_from_git = AsyncMock(return_value=MagicMock(spec=Graph))
+        mock_ontology_fn.return_value = mock_ontology
+
+        mock_result = MagicMock()
+        mock_result.clusters = []
+        mock_result.model_dump_json.return_value = '{"clusters": []}'
+        mock_find.return_value = mock_result
+
+        await run_duplicate_detection_task(ctx, PROJECT_ID, "main", 0.95, JOB_ID)
+
+        mock_find.assert_called_once()
+        call_args = mock_find.call_args[0]
+        assert call_args[1] == 0.95

--- a/tests/unit/test_quality_worker.py
+++ b/tests/unit/test_quality_worker.py
@@ -191,32 +191,22 @@ class TestRunDuplicateDetectionTask:
     """Tests for run_duplicate_detection_task."""
 
     @pytest.mark.asyncio
-    @patch("ontokit.services.duplicate_detection_service.find_duplicates")
-    @patch("ontokit.worker._parse_rdf")
-    @patch("ontokit.worker.BareGitRepositoryService")
-    async def test_success_with_git(
+    @patch(
+        "ontokit.services.duplicate_detection_service.find_duplicates_sql", new_callable=AsyncMock
+    )
+    async def test_success(
         self,
-        mock_git_cls: MagicMock,
-        mock_parse: MagicMock,
-        mock_find: MagicMock,
+        mock_find: AsyncMock,
     ) -> None:
-        """Runs duplicate detection via git and caches result."""
+        """Runs SQL-based duplicate detection and caches result."""
         ctx = _make_ctx()
-
-        mock_git = MagicMock()
-        mock_git.repository_exists.return_value = True
-        mock_git.get_file_from_branch.return_value = b"<turtle content>"
-        mock_git_cls.return_value = mock_git
-
-        mock_parse.return_value = MagicMock(spec=Graph)
 
         mock_result = MagicMock()
         mock_result.clusters = [MagicMock()]
         mock_result.model_dump_json.return_value = '{"clusters": [{}]}'
         mock_find.return_value = mock_result
 
-        with patch("concurrent.futures.ProcessPoolExecutor", return_value=_InlineExecutor()):
-            result = await run_duplicate_detection_task(ctx, PROJECT_ID, "main", 0.85, JOB_ID)
+        result = await run_duplicate_detection_task(ctx, PROJECT_ID, "main", 0.85, JOB_ID)
 
         assert result["status"] == "completed"
         assert result["clusters_found"] == 1
@@ -227,90 +217,23 @@ class TestRunDuplicateDetectionTask:
         assert redis.publish.await_count == 2
 
     @pytest.mark.asyncio
-    @patch("ontokit.worker.get_storage_service")
-    @patch("ontokit.worker.BareGitRepositoryService")
-    async def test_success_with_storage_fallback(
-        self,
-        mock_git_cls: MagicMock,
-        mock_storage_fn: MagicMock,
-    ) -> None:
-        """Falls back to storage when git repo doesn't exist."""
-        ctx = _make_ctx()
-
-        mock_git = MagicMock()
-        mock_git.repository_exists.return_value = False
-        mock_git_cls.return_value = mock_git
-
-        mock_storage = AsyncMock()
-        mock_storage.download_file.return_value = b"<turtle content>"
-        mock_storage_fn.return_value = mock_storage
-
-        mock_result = MagicMock()
-        mock_result.clusters = []
-        mock_result.model_dump_json.return_value = '{"clusters": []}'
-
-        with (
-            patch("ontokit.worker._parse_rdf", return_value=MagicMock(spec=Graph)),
-            patch(
-                "ontokit.services.duplicate_detection_service.find_duplicates",
-                return_value=mock_result,
-            ),
-            patch("concurrent.futures.ProcessPoolExecutor", return_value=_InlineExecutor()),
-        ):
-            result = await run_duplicate_detection_task(ctx, PROJECT_ID, "main", 0.85, JOB_ID)
-
-        assert result["status"] == "completed"
-        mock_storage.download_file.assert_awaited_once()
-
-    @pytest.mark.asyncio
-    async def test_project_not_found(self) -> None:
-        """Raises ValueError when project doesn't exist."""
-        ctx = _make_ctx(project_exists=False)
-
-        with pytest.raises(ValueError, match="not found"):
-            await run_duplicate_detection_task(ctx, PROJECT_ID, "main", 0.85, JOB_ID)
-
-        ctx["redis"].publish.assert_awaited()
-
-    @pytest.mark.asyncio
-    async def test_project_no_ontology(self) -> None:
-        """Raises ValueError when project has no ontology file and no integration."""
-        project = MagicMock()
-        project.source_file_path = None
-        project.github_integration = None
-        ctx = _make_ctx(project=project)
-
-        with pytest.raises(ValueError, match="no ontology file"):
-            await run_duplicate_detection_task(ctx, PROJECT_ID, "main", 0.85, JOB_ID)
-
-    @pytest.mark.asyncio
-    @patch("ontokit.services.duplicate_detection_service.find_duplicates")
-    @patch("ontokit.worker._parse_rdf")
-    @patch("ontokit.worker.BareGitRepositoryService")
+    @patch(
+        "ontokit.services.duplicate_detection_service.find_duplicates_sql", new_callable=AsyncMock
+    )
     async def test_custom_threshold(
         self,
-        mock_git_cls: MagicMock,
-        mock_parse: MagicMock,
-        mock_find: MagicMock,
+        mock_find: AsyncMock,
     ) -> None:
-        """Custom threshold is forwarded to find_duplicates."""
+        """Custom threshold is forwarded to find_duplicates_sql."""
         ctx = _make_ctx()
-
-        mock_git = MagicMock()
-        mock_git.repository_exists.return_value = True
-        mock_git.get_file_from_branch.return_value = b"<turtle content>"
-        mock_git_cls.return_value = mock_git
-
-        mock_parse.return_value = MagicMock(spec=Graph)
 
         mock_result = MagicMock()
         mock_result.clusters = []
         mock_result.model_dump_json.return_value = '{"clusters": []}'
         mock_find.return_value = mock_result
 
-        with patch("concurrent.futures.ProcessPoolExecutor", return_value=_InlineExecutor()):
-            await run_duplicate_detection_task(ctx, PROJECT_ID, "main", 0.95, JOB_ID)
+        await run_duplicate_detection_task(ctx, PROJECT_ID, "main", 0.95, JOB_ID)
 
         mock_find.assert_called_once()
-        call_args = mock_find.call_args[0]
-        assert call_args[1] == 0.95
+        call_args = mock_find.call_args
+        assert call_args[0][3] == 0.95  # threshold is the 4th positional arg

--- a/tests/unit/test_quality_ws.py
+++ b/tests/unit/test_quality_ws.py
@@ -1,0 +1,140 @@
+"""Tests for quality WebSocket endpoint message forwarding."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import AsyncMock, Mock, patch
+from uuid import UUID
+
+import pytest
+from fastapi import WebSocket
+from starlette.websockets import WebSocketDisconnect
+
+from ontokit.api.routes.quality import quality_websocket
+
+PROJECT_ID = "12345678-1234-5678-1234-567812345678"
+PROJECT_UUID = UUID(PROJECT_ID)
+
+
+def _mock_pubsub(messages: list[Any]) -> tuple[AsyncMock, AsyncMock]:
+    call_count = 0
+
+    async def fake_get_message(
+        ignore_subscribe_messages: bool = True,  # noqa: ARG001
+        timeout: float = 0.1,  # noqa: ARG001
+    ) -> dict[str, Any] | None:
+        nonlocal call_count
+        call_count += 1
+        if call_count <= len(messages):
+            msg = messages[call_count - 1]
+            data = json.dumps(msg) if isinstance(msg, dict) else msg
+            return {"type": "message", "data": data}
+        return None
+
+    mock_pubsub = AsyncMock()
+    mock_pubsub.get_message = fake_get_message
+    mock_pool = AsyncMock()
+    mock_pool.pubsub = Mock(return_value=mock_pubsub)
+    return mock_pool, mock_pubsub
+
+
+class TestQualityWebSocketAuth:
+    """Tests for quality_websocket authentication."""
+
+    @pytest.mark.asyncio
+    async def test_auth_failure_returns_early(self) -> None:
+        """Returns without subscribing when authenticate_ws returns False."""
+        ws = AsyncMock(spec=WebSocket)
+
+        with patch("ontokit.api.utils.ws_auth.authenticate_ws", AsyncMock(return_value=False)):
+            await quality_websocket(ws, PROJECT_UUID, token="t")
+
+        ws.send_json.assert_not_awaited()
+
+
+class TestQualityWebSocketMessages:
+    """Tests for quality_websocket message forwarding."""
+
+    @pytest.mark.asyncio
+    async def test_forwards_matching_consistency_message(self) -> None:
+        ws = AsyncMock(spec=WebSocket)
+        ws.receive_text = AsyncMock(side_effect=WebSocketDisconnect(code=1000))
+
+        msg = {"type": "consistency_complete", "project_id": PROJECT_ID, "job_id": "j1"}
+        mock_pool, mock_pubsub = _mock_pubsub([msg])
+
+        with (
+            patch("ontokit.api.utils.ws_auth.authenticate_ws", AsyncMock(return_value=True)),
+            patch("ontokit.api.routes.quality.get_arq_pool", return_value=mock_pool),
+        ):
+            await quality_websocket(ws, PROJECT_UUID, token="t")
+
+        ws.send_json.assert_awaited_once_with(msg)
+        mock_pubsub.unsubscribe.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_forwards_matching_duplicates_message(self) -> None:
+        ws = AsyncMock(spec=WebSocket)
+        ws.receive_text = AsyncMock(side_effect=WebSocketDisconnect(code=1000))
+
+        msg = {"type": "duplicates_complete", "project_id": PROJECT_ID, "job_id": "j2"}
+        mock_pool, mock_pubsub = _mock_pubsub([msg])
+
+        with (
+            patch("ontokit.api.utils.ws_auth.authenticate_ws", AsyncMock(return_value=True)),
+            patch("ontokit.api.routes.quality.get_arq_pool", return_value=mock_pool),
+        ):
+            await quality_websocket(ws, PROJECT_UUID, token="t")
+
+        ws.send_json.assert_awaited_once_with(msg)
+        mock_pubsub.unsubscribe.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_skips_messages_for_other_projects(self) -> None:
+        ws = AsyncMock(spec=WebSocket)
+        ws.receive_text = AsyncMock(side_effect=WebSocketDisconnect(code=1000))
+
+        other_msg = {"type": "consistency_complete", "project_id": "other-project"}
+        mock_pool, _ = _mock_pubsub([other_msg])
+
+        with (
+            patch("ontokit.api.utils.ws_auth.authenticate_ws", AsyncMock(return_value=True)),
+            patch("ontokit.api.routes.quality.get_arq_pool", return_value=mock_pool),
+        ):
+            await quality_websocket(ws, PROJECT_UUID, token="t")
+
+        ws.send_json.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_handles_malformed_json(self) -> None:
+        ws = AsyncMock(spec=WebSocket)
+        ws.receive_text = AsyncMock(side_effect=[TimeoutError, WebSocketDisconnect(code=1000)])
+
+        valid_msg = {"type": "duplicates_started", "project_id": PROJECT_ID}
+        mock_pool, _ = _mock_pubsub(["not valid json{{{", valid_msg])
+
+        with (
+            patch("ontokit.api.utils.ws_auth.authenticate_ws", AsyncMock(return_value=True)),
+            patch("ontokit.api.routes.quality.get_arq_pool", return_value=mock_pool),
+        ):
+            await quality_websocket(ws, PROJECT_UUID, token="t")
+
+        ws.send_json.assert_awaited_once_with(valid_msg)
+
+    @pytest.mark.asyncio
+    async def test_cleans_up_on_exception(self) -> None:
+        ws = AsyncMock(spec=WebSocket)
+
+        mock_pubsub = AsyncMock()
+        mock_pubsub.get_message = AsyncMock(side_effect=RuntimeError("Redis down"))
+        mock_pool = AsyncMock()
+        mock_pool.pubsub = Mock(return_value=mock_pubsub)
+
+        with (
+            patch("ontokit.api.utils.ws_auth.authenticate_ws", AsyncMock(return_value=True)),
+            patch("ontokit.api.routes.quality.get_arq_pool", return_value=mock_pool),
+        ):
+            await quality_websocket(ws, PROJECT_UUID, token="t")
+
+        mock_pubsub.unsubscribe.assert_awaited()


### PR DESCRIPTION
## Summary

- Moves consistency check and duplicate detection from inline sync execution to ARQ background worker tasks, preventing event loop blocking that caused the API to become unresponsive for large ontologies
- Adds `QUALITY_UPDATES_CHANNEL` Redis pub/sub, WebSocket endpoint (`/quality/ws`), and polling endpoints for async result retrieval
- **Breaking**: `POST /quality/duplicates` now returns `{job_id}` instead of the full result (frontend update needed)

## Test plan

- [x] All 1386 existing tests pass
- [x] ruff check, ruff format, mypy all clean
- [ ] Manual test: trigger consistency check, verify job completes via WebSocket/polling
- [ ] Manual test: trigger duplicate detection, verify results cached and retrievable
- [ ] Frontend update to consume new async duplicates API (separate PR on ontokit-web)

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Quality checks and duplicate detection run as background jobs and return job IDs.
  * Real-time WebSocket for project-specific quality update notifications.
  * New pub/sub channel for quality updates.

* **API Changes**
  * Duplicate-detection trigger returns a job ID; new job-status/result and "latest" endpoints added.
  * Job endpoints return 202 pending, 200 success, 404 not-found, or 500 failure as appropriate.

* **Bug Fixes**
  * Corrupt cached results are detected and surfaced as errors (500).

* **Tests**
  * Expanded unit tests for background tasks, caching, WebSocket flows, and error paths.

* **Documentation**
  * Added post-merge cleanup guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->