### PR TITLE
Potential fix for code scanning alert no. 16: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-target-guard.yml
+++ b/.github/workflows/pr-target-guard.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches: [main]
 
+permissions: {}
+
 jobs:
   check-source-branch:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/CatholicOS/ontokit-api/security/code-scanning/16](https://github.com/CatholicOS/ontokit-api/security/code-scanning/16)

Add an explicit `permissions` block to the workflow so token scope is constrained regardless of repository/org defaults.

Best fix here (without changing functionality): set top-level permissions to `{}` because this workflow only checks branch names and prints errors; it does not require any token scopes. This is stricter than `contents: read` and still compatible with current behavior.

Change required:
- File: `.github/workflows/pr-target-guard.yml`
- Insert `permissions: {}` at workflow root (after `on:` block and before `jobs:` is clean and conventional).
- No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
