### PR TITLE
feat: per-project lint rule configuration

### DIFF
--- a/alembic/versions/47cc27515626_add_subject_type_to_lint_issues.py
+++ b/alembic/versions/47cc27515626_add_subject_type_to_lint_issues.py
@@ -1,0 +1,24 @@
+"""add subject_type to lint_issues
+
+Revision ID: 47cc27515626
+Revises: 94afeba9ab5c
+Create Date: 2026-04-21
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "47cc27515626"
+down_revision = "94afeba9ab5c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("lint_issues", sa.Column("subject_type", sa.String(length=50), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("lint_issues", "subject_type")

--- a/alembic/versions/47cc27515626_add_subject_type_to_lint_issues.py
+++ b/alembic/versions/47cc27515626_add_subject_type_to_lint_issues.py
@@ -2,7 +2,7 @@
 
 Revision ID: 47cc27515626
 Revises: 94afeba9ab5c
-Create Date: 2026-04-21
+Create Date: 2026-04-21 12:34:26.000000
 """
 
 import sqlalchemy as sa
@@ -18,7 +18,13 @@ depends_on = None
 
 def upgrade() -> None:
     op.add_column("lint_issues", sa.Column("subject_type", sa.String(length=50), nullable=True))
+    op.create_check_constraint(
+        "ck_lint_issues_subject_type",
+        "lint_issues",
+        "subject_type IS NULL OR subject_type IN ('class', 'property', 'individual', 'other')",
+    )
 
 
 def downgrade() -> None:
+    op.drop_constraint("ck_lint_issues_subject_type", "lint_issues", type_="check")
     op.drop_column("lint_issues", "subject_type")

--- a/alembic/versions/94afeba9ab5c_add_project_lint_configs.py
+++ b/alembic/versions/94afeba9ab5c_add_project_lint_configs.py
@@ -2,7 +2,7 @@
 
 Revision ID: 94afeba9ab5c
 Revises: r1s2t3u4v5w6
-Create Date: 2026-04-20
+Create Date: 2026-04-20 23:22:25.000000
 """
 
 import sqlalchemy as sa

--- a/alembic/versions/94afeba9ab5c_add_project_lint_configs.py
+++ b/alembic/versions/94afeba9ab5c_add_project_lint_configs.py
@@ -1,6 +1,6 @@
 """add project lint configs
 
-Revision ID: a1b2c3d4e5f6
+Revision ID: 94afeba9ab5c
 Revises: r1s2t3u4v5w6
 Create Date: 2026-04-20
 """
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision = "a1b2c3d4e5f6"
+revision = "94afeba9ab5c"
 down_revision = "r1s2t3u4v5w6"
 branch_labels = None
 depends_on = None

--- a/alembic/versions/a1b2c3d4e5f6_add_project_lint_configs.py
+++ b/alembic/versions/a1b2c3d4e5f6_add_project_lint_configs.py
@@ -1,0 +1,49 @@
+"""add project lint configs
+
+Revision ID: a1b2c3d4e5f6
+Revises: r1s2t3u4v5w6
+Create Date: 2026-04-20
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a1b2c3d4e5f6"
+down_revision = "r1s2t3u4v5w6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "project_lint_configs",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("project_id", sa.Uuid(), nullable=False),
+        sa.Column("lint_level", sa.Integer(), nullable=True),
+        sa.Column("enabled_rules", sa.String(length=2000), nullable=True),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["project_id"],
+            ["projects.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("project_id"),
+    )
+    op.create_index(
+        "ix_project_lint_configs_project_id",
+        "project_lint_configs",
+        ["project_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_project_lint_configs_project_id", table_name="project_lint_configs")
+    op.drop_table("project_lint_configs")

--- a/alembic/versions/a1b2c3d4e5f6_add_project_lint_configs.py
+++ b/alembic/versions/a1b2c3d4e5f6_add_project_lint_configs.py
@@ -37,13 +37,7 @@ def upgrade() -> None:
         sa.PrimaryKeyConstraint("id"),
         sa.UniqueConstraint("project_id"),
     )
-    op.create_index(
-        "ix_project_lint_configs_project_id",
-        "project_lint_configs",
-        ["project_id"],
-    )
 
 
 def downgrade() -> None:
-    op.drop_index("ix_project_lint_configs_project_id", table_name="project_lint_configs")
     op.drop_table("project_lint_configs")

--- a/alembic/versions/a1b2c3d4e5f6_add_project_lint_configs.py
+++ b/alembic/versions/a1b2c3d4e5f6_add_project_lint_configs.py
@@ -34,6 +34,7 @@ def upgrade() -> None:
             ["projects.id"],
             ondelete="CASCADE",
         ),
+        sa.CheckConstraint("lint_level BETWEEN 1 AND 5", name="ck_lint_level_range"),
         sa.PrimaryKeyConstraint("id"),
         sa.UniqueConstraint("project_id"),
     )

--- a/ontokit/api/routes/lint.py
+++ b/ontokit/api/routes/lint.py
@@ -9,7 +9,7 @@ from typing import Annotated, cast
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, WebSocket, WebSocketDisconnect, status
-from sqlalchemy import case, func, select
+from sqlalchemy import case, delete, func, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -477,6 +477,27 @@ async def dismiss_issue(
 
     # Mark as resolved
     issue.resolved_at = datetime.now(UTC)
+    await db.commit()
+
+
+@router.delete(
+    "/{project_id}/lint/results",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def clear_lint_results(
+    project_id: UUID,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    user: RequiredUser,
+) -> None:
+    """
+    Clear all lint results (runs and issues) for a project.
+
+    Requires authentication and admin/owner access.
+    """
+    await verify_project_access(project_id, db, user, require_manage=True)
+
+    # Delete all lint runs (issues cascade-delete via relationship)
+    await db.execute(delete(LintRun).where(LintRun.project_id == project_id))
     await db.commit()
 
 

--- a/ontokit/api/routes/lint.py
+++ b/ontokit/api/routes/lint.py
@@ -17,11 +17,16 @@ from ontokit.core.auth import CurrentUser, OptionalUser, RequiredUser
 from ontokit.core.constants import LINT_UPDATES_CHANNEL
 from ontokit.core.database import get_db
 from ontokit.models.lint import LintIssue, LintRun, LintRunStatus
+from ontokit.models.lint_config import ProjectLintConfig
 from ontokit.models.project import Project
 from ontokit.schemas.lint import (
+    LintConfigResponse,
+    LintConfigUpdate,
     LintIssueListResponse,
     LintIssueResponse,
     LintIssueTypeValue,
+    LintLevelInfo,
+    LintLevelsResponse,
     LintRuleInfo,
     LintRulesResponse,
     LintRunDetailResponse,
@@ -31,7 +36,7 @@ from ontokit.schemas.lint import (
     LintSummaryResponse,
     LintTriggerResponse,
 )
-from ontokit.services.linter import get_available_rules
+from ontokit.services.linter import ALL_RULE_IDS, LINT_LEVELS, get_available_rules
 from ontokit.services.project_service import get_project_service
 
 logger = logging.getLogger(__name__)
@@ -44,6 +49,7 @@ async def verify_project_access(
     db: AsyncSession,
     user: CurrentUser | None,
     require_write: bool = False,
+    require_manage: bool = False,
 ) -> Project:
     """
     Verify user has access to the project.
@@ -53,6 +59,7 @@ async def verify_project_access(
         db: Database session
         user: Current user (from auth)
         require_write: If True, require editor/admin/owner access
+        require_manage: If True, require admin/owner access
 
     Returns:
         The Project model if access is granted
@@ -74,6 +81,12 @@ async def verify_project_access(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Project not found",
+        )
+
+    if require_manage and project_response.user_role not in ("owner", "admin"):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin access required",
         )
 
     if require_write and project_response.user_role not in ("owner", "admin", "editor"):
@@ -464,6 +477,141 @@ async def dismiss_issue(
     # Mark as resolved
     issue.resolved_at = datetime.now(UTC)
     await db.commit()
+
+
+@router.get("/{project_id}/lint/config", response_model=LintConfigResponse)
+async def get_lint_config(
+    project_id: UUID,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    user: OptionalUser,
+) -> LintConfigResponse:
+    """
+    Get the current lint configuration for a project.
+
+    Returns the lint level and/or enabled rules, plus the effective set of
+    rules that will be checked on the next lint run.
+    """
+    await verify_project_access(project_id, db, user)
+
+    result = await db.execute(
+        select(ProjectLintConfig).where(ProjectLintConfig.project_id == project_id)
+    )
+    config = result.scalar_one_or_none()
+
+    if config is None:
+        return LintConfigResponse(
+            project_id=project_id,
+            effective_rules=sorted(ALL_RULE_IDS),
+        )
+
+    effective = config.get_enabled_rule_ids()
+    enabled_list = (
+        sorted(r.strip() for r in config.enabled_rules.split(",") if r.strip())
+        if config.enabled_rules
+        else None
+    )
+
+    return LintConfigResponse(
+        project_id=project_id,
+        lint_level=config.lint_level,
+        enabled_rules=enabled_list,
+        effective_rules=sorted(effective) if effective is not None else sorted(ALL_RULE_IDS),
+        updated_at=config.updated_at,
+    )
+
+
+@router.put("/{project_id}/lint/config", response_model=LintConfigResponse)
+async def update_lint_config(
+    project_id: UUID,
+    body: LintConfigUpdate,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    user: RequiredUser,
+) -> LintConfigResponse:
+    """
+    Update lint configuration for a project.
+
+    Requires owner or admin role.
+
+    Set ``lint_level`` to use a preset level (1-5).
+    Set ``enabled_rules`` to configure individual rules.
+    Set both to ``null`` to reset to default (all rules).
+    """
+    await verify_project_access(project_id, db, user, require_manage=True)
+
+    # Validate rule IDs if provided
+    if body.enabled_rules is not None:
+        invalid = set(body.enabled_rules) - ALL_RULE_IDS
+        if invalid:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=f"Unknown rule IDs: {', '.join(sorted(invalid))}",
+            )
+
+    result = await db.execute(
+        select(ProjectLintConfig).where(ProjectLintConfig.project_id == project_id)
+    )
+    config = result.scalar_one_or_none()
+
+    enabled_rules_str = (
+        ",".join(sorted(body.enabled_rules)) if body.enabled_rules is not None else None
+    )
+
+    if config is None:
+        config = ProjectLintConfig(
+            project_id=project_id,
+            lint_level=body.lint_level,
+            enabled_rules=enabled_rules_str,
+        )
+        db.add(config)
+    else:
+        config.lint_level = body.lint_level
+        config.enabled_rules = enabled_rules_str
+
+    await db.commit()
+    await db.refresh(config)
+
+    effective = config.get_enabled_rule_ids()
+    enabled_list = (
+        sorted(r.strip() for r in config.enabled_rules.split(",") if r.strip())
+        if config.enabled_rules
+        else None
+    )
+
+    return LintConfigResponse(
+        project_id=project_id,
+        lint_level=config.lint_level,
+        enabled_rules=enabled_list,
+        effective_rules=sorted(effective) if effective is not None else sorted(ALL_RULE_IDS),
+        updated_at=config.updated_at,
+    )
+
+
+@router.get("/lint/levels", response_model=LintLevelsResponse)
+async def get_lint_levels() -> LintLevelsResponse:
+    """
+    Get the list of available progressive lint levels.
+
+    Each level includes all rules from the previous level plus additional rules.
+    """
+    level_names = {
+        1: ("Critical", "Structural errors that break ontology validity"),
+        2: ("Structural", "Orphan classes, duplicates, and disjointness violations"),
+        3: ("Labels", "Missing, empty, and duplicate label checks"),
+        4: ("Quality", "Comments and per-language label checks"),
+        5: ("All", "All available rules including domain/range and cardinality"),
+    }
+
+    return LintLevelsResponse(
+        levels=[
+            LintLevelInfo(
+                level=lvl,
+                name=level_names[lvl][0],
+                description=level_names[lvl][1],
+                rule_ids=sorted(rules),
+            )
+            for lvl, rules in sorted(LINT_LEVELS.items())
+        ]
+    )
 
 
 @router.get("/lint/rules", response_model=LintRulesResponse)

--- a/ontokit/api/routes/lint.py
+++ b/ontokit/api/routes/lint.py
@@ -758,4 +758,5 @@ async def lint_websocket(
         if pubsub:
             with contextlib.suppress(Exception):
                 await pubsub.unsubscribe(LINT_UPDATES_CHANNEL)
+            with contextlib.suppress(Exception):
                 await pubsub.aclose()  # type: ignore[no-untyped-call]

--- a/ontokit/api/routes/lint.py
+++ b/ontokit/api/routes/lint.py
@@ -559,6 +559,7 @@ async def update_lint_config(
         set_={
             "lint_level": body.lint_level,
             "enabled_rules": enabled_rules_str,
+            "updated_at": func.now(),
         },
     )
     await db.execute(stmt)

--- a/ontokit/api/routes/lint.py
+++ b/ontokit/api/routes/lint.py
@@ -641,6 +641,7 @@ async def get_lint_rules() -> LintRulesResponse:
                 name=rule.name,
                 description=rule.description,
                 severity=cast("LintIssueTypeValue", rule.severity),
+                scope=rule.scope,
             )
             for rule in rules
         ]

--- a/ontokit/api/routes/lint.py
+++ b/ontokit/api/routes/lint.py
@@ -561,9 +561,9 @@ async def update_lint_config(
 
     Requires owner or admin role.
 
-    Set ``lint_level`` to use a preset level (1-5).
-    Set ``enabled_rules`` to configure individual rules (empty list disables all).
-    Set both to ``null`` to reset to default (all rules).
+    ``lint_level`` and ``enabled_rules`` are mutually exclusive: set exactly one
+    or set both to ``null`` to reset to all rules. Pass ``enabled_rules=[]`` to
+    explicitly disable every rule.
     """
     await verify_project_access(project_id, db, user, require_manage=True)
 
@@ -572,28 +572,34 @@ async def update_lint_config(
     if body.enabled_rules is not None:
         enabled_rules_str = ",".join(sorted(body.enabled_rules))
 
-    # Upsert to handle concurrent first-time PUTs safely
-    stmt = pg_insert(ProjectLintConfig).values(
-        project_id=project_id,
-        lint_level=body.lint_level,
-        enabled_rules=enabled_rules_str,
+    # Upsert to handle concurrent first-time PUTs safely; RETURNING gives
+    # us the persisted row in the same round trip. Wrapping in select(...).from_statement(...)
+    # with populate_existing materializes the returned row as an ORM instance.
+    insert_stmt = (
+        pg_insert(ProjectLintConfig)
+        .values(
+            project_id=project_id,
+            lint_level=body.lint_level,
+            enabled_rules=enabled_rules_str,
+        )
+        .on_conflict_do_update(
+            index_elements=[ProjectLintConfig.project_id],
+            set_={
+                "lint_level": body.lint_level,
+                "enabled_rules": enabled_rules_str,
+                "updated_at": func.now(),
+            },
+        )
+        .returning(ProjectLintConfig)
     )
-    stmt = stmt.on_conflict_do_update(
-        index_elements=[ProjectLintConfig.project_id],
-        set_={
-            "lint_level": body.lint_level,
-            "enabled_rules": enabled_rules_str,
-            "updated_at": func.now(),
-        },
+    orm_stmt = (
+        select(ProjectLintConfig)
+        .from_statement(insert_stmt)
+        .execution_options(populate_existing=True)
     )
-    await db.execute(stmt)
-    await db.commit()
-
-    # Re-fetch the config to return the updated state
-    result = await db.execute(
-        select(ProjectLintConfig).where(ProjectLintConfig.project_id == project_id)
-    )
+    result = await db.execute(orm_stmt)
     config = result.scalar_one()
+    await db.commit()
     return _serialize_lint_config(project_id, config)
 
 

--- a/ontokit/api/routes/lint.py
+++ b/ontokit/api/routes/lint.py
@@ -766,5 +766,10 @@ async def lint_websocket(
         if pubsub:
             with contextlib.suppress(Exception):
                 await pubsub.unsubscribe(LINT_UPDATES_CHANNEL)
-            with contextlib.suppress(Exception):
-                await pubsub.aclose()  # type: ignore[no-untyped-call]
+            # aclose() can hang on a half-open connection; bound it so a stuck
+            # Redis socket does not leak the request task.
+            with contextlib.suppress(Exception, TimeoutError):
+                await asyncio.wait_for(
+                    pubsub.aclose(),  # type: ignore[no-untyped-call]
+                    timeout=5.0,
+                )

--- a/ontokit/api/routes/lint.py
+++ b/ontokit/api/routes/lint.py
@@ -598,7 +598,7 @@ _LEVEL_METADATA: dict[int, tuple[str, str]] = {
     1: ("Critical", "Undefined parents, circular hierarchies, undefined prefixes"),
     2: ("Consistency", "Orphan classes, duplicate triples, and disjointness violations"),
     3: ("Labels", "Missing, empty, and duplicate label checks"),
-    4: ("Quality", "Comments and per-language label checks"),
+    4: ("Quality", "Comments, per-language label checks, and redundant regional variants"),
     5: ("All", "All available rules including domain/range and cardinality"),
 }
 

--- a/ontokit/api/routes/lint.py
+++ b/ontokit/api/routes/lint.py
@@ -10,6 +10,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, WebSocket, WebSocketDisconnect, status
 from sqlalchemy import case, func, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ontokit.api.utils.redis import get_arq_pool
@@ -479,6 +480,30 @@ async def dismiss_issue(
     await db.commit()
 
 
+def _serialize_lint_config(
+    project_id: UUID, config: ProjectLintConfig | None
+) -> LintConfigResponse:
+    """Build a LintConfigResponse from a ProjectLintConfig (or None for defaults)."""
+    if config is None:
+        return LintConfigResponse(
+            project_id=project_id,
+            effective_rules=sorted(ALL_RULE_IDS),
+        )
+
+    effective = config.get_enabled_rule_ids()
+    enabled_list: list[str] | None = None
+    if config.enabled_rules is not None:
+        enabled_list = sorted(r.strip() for r in config.enabled_rules.split(",") if r.strip())
+
+    return LintConfigResponse(
+        project_id=project_id,
+        lint_level=config.lint_level,
+        enabled_rules=enabled_list,
+        effective_rules=sorted(effective) if effective is not None else sorted(ALL_RULE_IDS),
+        updated_at=config.updated_at,
+    )
+
+
 @router.get("/{project_id}/lint/config", response_model=LintConfigResponse)
 async def get_lint_config(
     project_id: UUID,
@@ -497,27 +522,7 @@ async def get_lint_config(
         select(ProjectLintConfig).where(ProjectLintConfig.project_id == project_id)
     )
     config = result.scalar_one_or_none()
-
-    if config is None:
-        return LintConfigResponse(
-            project_id=project_id,
-            effective_rules=sorted(ALL_RULE_IDS),
-        )
-
-    effective = config.get_enabled_rule_ids()
-    enabled_list = (
-        sorted(r.strip() for r in config.enabled_rules.split(",") if r.strip())
-        if config.enabled_rules
-        else None
-    )
-
-    return LintConfigResponse(
-        project_id=project_id,
-        lint_level=config.lint_level,
-        enabled_rules=enabled_list,
-        effective_rules=sorted(effective) if effective is not None else sorted(ALL_RULE_IDS),
-        updated_at=config.updated_at,
-    )
+    return _serialize_lint_config(project_id, config)
 
 
 @router.put("/{project_id}/lint/config", response_model=LintConfigResponse)
@@ -533,57 +538,49 @@ async def update_lint_config(
     Requires owner or admin role.
 
     Set ``lint_level`` to use a preset level (1-5).
-    Set ``enabled_rules`` to configure individual rules.
+    Set ``enabled_rules`` to configure individual rules (empty list disables all).
     Set both to ``null`` to reset to default (all rules).
     """
     await verify_project_access(project_id, db, user, require_manage=True)
 
-    # Validate rule IDs if provided
+    # enabled_rules=[] is stored as "" to distinguish from None (unset)
+    enabled_rules_str: str | None = None
     if body.enabled_rules is not None:
-        invalid = set(body.enabled_rules) - ALL_RULE_IDS
-        if invalid:
-            raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                detail=f"Unknown rule IDs: {', '.join(sorted(invalid))}",
-            )
+        enabled_rules_str = ",".join(sorted(body.enabled_rules))
 
+    # Upsert to handle concurrent first-time PUTs safely
+    stmt = pg_insert(ProjectLintConfig).values(
+        project_id=project_id,
+        lint_level=body.lint_level,
+        enabled_rules=enabled_rules_str,
+    )
+    stmt = stmt.on_conflict_do_update(
+        index_elements=[ProjectLintConfig.project_id],
+        set_={
+            "lint_level": body.lint_level,
+            "enabled_rules": enabled_rules_str,
+        },
+    )
+    await db.execute(stmt)
+    await db.commit()
+
+    # Re-fetch the config to return the updated state
     result = await db.execute(
         select(ProjectLintConfig).where(ProjectLintConfig.project_id == project_id)
     )
-    config = result.scalar_one_or_none()
+    config = result.scalar_one()
+    return _serialize_lint_config(project_id, config)
 
-    enabled_rules_str = (
-        ",".join(sorted(body.enabled_rules)) if body.enabled_rules is not None else None
-    )
 
-    if config is None:
-        config = ProjectLintConfig(
-            project_id=project_id,
-            lint_level=body.lint_level,
-            enabled_rules=enabled_rules_str,
-        )
-        db.add(config)
-    else:
-        config.lint_level = body.lint_level
-        config.enabled_rules = enabled_rules_str
+_LEVEL_METADATA: dict[int, tuple[str, str]] = {
+    1: ("Critical", "Structural errors that break ontology validity"),
+    2: ("Structural", "Orphan classes, duplicates, and disjointness violations"),
+    3: ("Labels", "Missing, empty, and duplicate label checks"),
+    4: ("Quality", "Comments and per-language label checks"),
+    5: ("All", "All available rules including domain/range and cardinality"),
+}
 
-    await db.commit()
-    await db.refresh(config)
-
-    effective = config.get_enabled_rule_ids()
-    enabled_list = (
-        sorted(r.strip() for r in config.enabled_rules.split(",") if r.strip())
-        if config.enabled_rules
-        else None
-    )
-
-    return LintConfigResponse(
-        project_id=project_id,
-        lint_level=config.lint_level,
-        enabled_rules=enabled_list,
-        effective_rules=sorted(effective) if effective is not None else sorted(ALL_RULE_IDS),
-        updated_at=config.updated_at,
-    )
+_LEVEL_FALLBACK: tuple[str, str] = ("Unknown", "Unknown level")
 
 
 @router.get("/lint/levels", response_model=LintLevelsResponse)
@@ -593,20 +590,12 @@ async def get_lint_levels() -> LintLevelsResponse:
 
     Each level includes all rules from the previous level plus additional rules.
     """
-    level_names = {
-        1: ("Critical", "Structural errors that break ontology validity"),
-        2: ("Structural", "Orphan classes, duplicates, and disjointness violations"),
-        3: ("Labels", "Missing, empty, and duplicate label checks"),
-        4: ("Quality", "Comments and per-language label checks"),
-        5: ("All", "All available rules including domain/range and cardinality"),
-    }
-
     return LintLevelsResponse(
         levels=[
             LintLevelInfo(
                 level=lvl,
-                name=level_names.get(lvl, ("Unknown", ""))[0],
-                description=level_names.get(lvl, ("", "Unknown level"))[1],
+                name=_LEVEL_METADATA.get(lvl, _LEVEL_FALLBACK)[0],
+                description=_LEVEL_METADATA.get(lvl, _LEVEL_FALLBACK)[1],
                 rule_ids=sorted(rules),
             )
             for lvl, rules in sorted(LINT_LEVELS.items())

--- a/ontokit/api/routes/lint.py
+++ b/ontokit/api/routes/lint.py
@@ -36,6 +36,7 @@ from ontokit.schemas.lint import (
     LintRunStatusValue,
     LintSummaryResponse,
     LintTriggerResponse,
+    SubjectTypeValue,
 )
 from ontokit.services.linter import ALL_RULE_IDS, LINT_LEVELS, get_available_rules
 from ontokit.services.project_service import get_project_service
@@ -333,6 +334,7 @@ async def get_lint_run(
                 rule_id=issue.rule_id,
                 message=issue.message,
                 subject_iri=issue.subject_iri,
+                subject_type=cast("SubjectTypeValue | None", issue.subject_type),
                 details=issue.details,
                 created_at=issue.created_at,
                 resolved_at=issue.resolved_at,
@@ -425,6 +427,7 @@ async def get_lint_issues(
                 rule_id=issue.rule_id,
                 message=issue.message,
                 subject_iri=issue.subject_iri,
+                subject_type=cast("SubjectTypeValue | None", issue.subject_type),
                 details=issue.details,
                 created_at=issue.created_at,
                 resolved_at=issue.resolved_at,

--- a/ontokit/api/routes/lint.py
+++ b/ontokit/api/routes/lint.py
@@ -17,6 +17,7 @@ from ontokit.api.utils.redis import get_arq_pool
 from ontokit.core.auth import CurrentUser, OptionalUser, RequiredUser
 from ontokit.core.constants import LINT_UPDATES_CHANNEL
 from ontokit.core.database import get_db
+from ontokit.git.bare_repository import BareGitRepositoryService
 from ontokit.models.lint import LintIssue, LintRun, LintRunStatus
 from ontokit.models.lint_config import ProjectLintConfig
 from ontokit.models.project import Project
@@ -120,7 +121,12 @@ async def trigger_lint(
     """
     project = await verify_project_access(project_id, db, user)
 
-    if not project.source_file_path:
+    # Allow git-only projects: the worker resolves the ontology from the bare
+    # repository when source_file_path is absent. Mirror the worker's loading
+    # logic so the only requests rejected here are those the worker itself
+    # would have to fail.
+    git_service = BareGitRepositoryService()
+    if not project.source_file_path and not git_service.repository_exists(project_id):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Project has no ontology file to lint",
@@ -493,14 +499,21 @@ async def clear_lint_results(
     user: RequiredUser,
 ) -> None:
     """
-    Clear all lint results (runs and issues) for a project.
+    Clear terminal lint results (runs and issues) for a project.
 
-    Requires authentication and admin/owner access.
+    Only completed and failed runs are removed; in-flight runs (pending or
+    running) are preserved so the worker can finish updating them. Requires
+    authentication and admin/owner access.
     """
     await verify_project_access(project_id, db, user, require_manage=True)
 
-    # Delete all lint runs (issues cascade-delete via relationship)
-    await db.execute(delete(LintRun).where(LintRun.project_id == project_id))
+    # Delete only terminal runs; pending/running stay so the worker can finish
+    # updating them (issues cascade-delete via relationship).
+    await db.execute(
+        delete(LintRun)
+        .where(LintRun.project_id == project_id)
+        .where(LintRun.status.in_([LintRunStatus.COMPLETED.value, LintRunStatus.FAILED.value]))
+    )
     await db.commit()
 
 

--- a/ontokit/api/routes/lint.py
+++ b/ontokit/api/routes/lint.py
@@ -758,3 +758,4 @@ async def lint_websocket(
         if pubsub:
             with contextlib.suppress(Exception):
                 await pubsub.unsubscribe(LINT_UPDATES_CHANNEL)
+                await pubsub.aclose()  # type: ignore[no-untyped-call]

--- a/ontokit/api/routes/lint.py
+++ b/ontokit/api/routes/lint.py
@@ -605,8 +605,8 @@ async def get_lint_levels() -> LintLevelsResponse:
         levels=[
             LintLevelInfo(
                 level=lvl,
-                name=level_names[lvl][0],
-                description=level_names[lvl][1],
+                name=level_names.get(lvl, ("Unknown", ""))[0],
+                description=level_names.get(lvl, ("", "Unknown level"))[1],
                 rule_ids=sorted(rules),
             )
             for lvl, rules in sorted(LINT_LEVELS.items())

--- a/ontokit/api/routes/lint.py
+++ b/ontokit/api/routes/lint.py
@@ -595,8 +595,8 @@ async def update_lint_config(
 
 
 _LEVEL_METADATA: dict[int, tuple[str, str]] = {
-    1: ("Critical", "Structural errors that break ontology validity"),
-    2: ("Structural", "Orphan classes, duplicates, and disjointness violations"),
+    1: ("Critical", "Undefined parents, circular hierarchies, undefined prefixes"),
+    2: ("Consistency", "Orphan classes, duplicate triples, and disjointness violations"),
     3: ("Labels", "Missing, empty, and duplicate label checks"),
     4: ("Quality", "Comments and per-language label checks"),
     5: ("All", "All available rules including domain/range and cardinality"),

--- a/ontokit/api/routes/lint.py
+++ b/ontokit/api/routes/lint.py
@@ -38,7 +38,7 @@ from ontokit.schemas.lint import (
     LintTriggerResponse,
     SubjectTypeValue,
 )
-from ontokit.services.linter import ALL_RULE_IDS, LINT_LEVELS, get_available_rules
+from ontokit.services.linter import ALL_RULE_IDS, LINT_LEVEL_DEFINITIONS, get_available_rules
 from ontokit.services.project_service import get_project_service
 
 logger = logging.getLogger(__name__)
@@ -597,17 +597,6 @@ async def update_lint_config(
     return _serialize_lint_config(project_id, config)
 
 
-_LEVEL_METADATA: dict[int, tuple[str, str]] = {
-    1: ("Critical", "Undefined parents, circular hierarchies, undefined prefixes"),
-    2: ("Consistency", "Orphan classes, duplicate triples, and disjointness violations"),
-    3: ("Labels", "Missing, empty, and duplicate label checks"),
-    4: ("Quality", "Comments, per-language label checks, and redundant regional variants"),
-    5: ("All", "All available rules including domain/range and cardinality"),
-}
-
-_LEVEL_FALLBACK: tuple[str, str] = ("Unknown", "Unknown level")
-
-
 @router.get("/lint/levels", response_model=LintLevelsResponse)
 async def get_lint_levels() -> LintLevelsResponse:
     """
@@ -619,11 +608,11 @@ async def get_lint_levels() -> LintLevelsResponse:
         levels=[
             LintLevelInfo(
                 level=lvl,
-                name=_LEVEL_METADATA.get(lvl, _LEVEL_FALLBACK)[0],
-                description=_LEVEL_METADATA.get(lvl, _LEVEL_FALLBACK)[1],
-                rule_ids=sorted(rules),
+                name=defn.name,
+                description=defn.description,
+                rule_ids=sorted(defn.rules),
             )
-            for lvl, rules in sorted(LINT_LEVELS.items())
+            for lvl, defn in sorted(LINT_LEVEL_DEFINITIONS.items())
         ]
     )
 

--- a/ontokit/api/routes/projects.py
+++ b/ontokit/api/routes/projects.py
@@ -1589,3 +1589,4 @@ async def ontology_index_websocket(
         if pubsub:
             with contextlib.suppress(Exception):
                 await pubsub.unsubscribe(ONTOLOGY_INDEX_UPDATES_CHANNEL)
+                await pubsub.aclose()  # type: ignore[no-untyped-call]

--- a/ontokit/api/routes/projects.py
+++ b/ontokit/api/routes/projects.py
@@ -1589,4 +1589,5 @@ async def ontology_index_websocket(
         if pubsub:
             with contextlib.suppress(Exception):
                 await pubsub.unsubscribe(ONTOLOGY_INDEX_UPDATES_CHANNEL)
+            with contextlib.suppress(Exception):
                 await pubsub.aclose()  # type: ignore[no-untyped-call]

--- a/ontokit/api/routes/quality.py
+++ b/ontokit/api/routes/quality.py
@@ -406,4 +406,5 @@ async def quality_websocket(
         if pubsub:
             with contextlib.suppress(Exception):
                 await pubsub.unsubscribe(QUALITY_UPDATES_CHANNEL)
+            with contextlib.suppress(Exception):
                 await pubsub.aclose()  # type: ignore[no-untyped-call]

--- a/ontokit/models/__init__.py
+++ b/ontokit/models/__init__.py
@@ -10,6 +10,7 @@ from ontokit.models.lint import (
     LintRun,
     LintRunStatus,
 )
+from ontokit.models.lint_config import ProjectLintConfig
 from ontokit.models.normalization import NormalizationRun
 from ontokit.models.notification import Notification
 from ontokit.models.ontology_index import (
@@ -51,6 +52,7 @@ __all__ = [
     "LintIssueType",
     "LintRun",
     "LintRunStatus",
+    "ProjectLintConfig",
     "NormalizationRun",
     "Notification",
     "OntologyIndexStatus",

--- a/ontokit/models/lint.py
+++ b/ontokit/models/lint.py
@@ -66,6 +66,7 @@ class LintIssue(Base):
     rule_id: Mapped[str] = mapped_column(String(100), nullable=False)
     message: Mapped[str] = mapped_column(Text, nullable=False)
     subject_iri: Mapped[str | None] = mapped_column(String(2000), nullable=True)
+    subject_type: Mapped[str | None] = mapped_column(String(50), nullable=True)
     details: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     resolved_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/ontokit/models/lint.py
+++ b/ontokit/models/lint.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 
-from sqlalchemy import JSON, DateTime, ForeignKey, Integer, String, Text, func
+from sqlalchemy import JSON, CheckConstraint, DateTime, ForeignKey, Integer, String, Text, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 if TYPE_CHECKING:
@@ -58,6 +58,12 @@ class LintIssue(Base):
     """Lint issue model for storing individual issues found during linting."""
 
     __tablename__ = "lint_issues"
+    __table_args__ = (
+        CheckConstraint(
+            "subject_type IS NULL OR subject_type IN ('class', 'property', 'individual', 'other')",
+            name="ck_lint_issues_subject_type",
+        ),
+    )
 
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
     run_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("lint_runs.id", ondelete="CASCADE"))

--- a/ontokit/models/lint_config.py
+++ b/ontokit/models/lint_config.py
@@ -1,6 +1,7 @@
 """Per-project lint configuration model."""
 
 import uuid
+from collections.abc import Set as AbstractSet
 from datetime import datetime
 from typing import TYPE_CHECKING
 
@@ -18,7 +19,8 @@ class ProjectLintConfig(Base):
 
     Stores which lint rules are enabled for a project, either via an explicit
     comma-separated list of rule IDs or via a preset lint level (1-5).
-    When ``lint_level`` is set, it takes precedence over ``enabled_rules``.
+    ``lint_level`` and ``enabled_rules`` are mutually exclusive — see the
+    ``enforce_xor`` validator on ``LintConfigUpdate``.
     """
 
     __tablename__ = "project_lint_configs"
@@ -43,13 +45,13 @@ class ProjectLintConfig(Base):
     def __repr__(self) -> str:
         return f"<ProjectLintConfig(project_id={self.project_id}, lint_level={self.lint_level})>"
 
-    def get_enabled_rule_ids(self) -> set[str] | None:
+    def get_enabled_rule_ids(self) -> AbstractSet[str] | None:
         """Resolve the effective set of enabled rule IDs.
 
         Returns:
             - ``None`` when no configuration has been set (meaning all rules)
-            - An empty ``set()`` when rules are explicitly set to none
-            - A non-empty ``set`` of specific rule IDs otherwise
+            - An empty set when rules are explicitly set to none
+            - A non-empty set of specific rule IDs otherwise
         """
         from ontokit.services.linter import ALL_RULE_IDS, get_rules_for_level
 

--- a/ontokit/models/lint_config.py
+++ b/ontokit/models/lint_config.py
@@ -45,13 +45,17 @@ class ProjectLintConfig(Base):
     def get_enabled_rule_ids(self) -> set[str] | None:
         """Resolve the effective set of enabled rule IDs.
 
-        Returns ``None`` when no configuration has been set (meaning all rules).
+        Returns:
+            - ``None`` when no configuration has been set (meaning all rules)
+            - An empty ``set()`` when rules are explicitly set to none
+            - A non-empty ``set`` of specific rule IDs otherwise
         """
         from ontokit.services.linter import ALL_RULE_IDS, get_rules_for_level
 
         if self.lint_level is not None:
             return get_rules_for_level(self.lint_level)
-        if self.enabled_rules is not None and self.enabled_rules.strip():
+        if self.enabled_rules is not None:
+            # Empty string means explicitly "no rules"; non-empty is parsed
             ids = {r.strip() for r in self.enabled_rules.split(",") if r.strip()}
             return ids & ALL_RULE_IDS
         return None

--- a/ontokit/models/lint_config.py
+++ b/ontokit/models/lint_config.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import DateTime, ForeignKey, Integer, String, func
+from sqlalchemy import CheckConstraint, DateTime, ForeignKey, Integer, String, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 if TYPE_CHECKING:
@@ -22,6 +22,7 @@ class ProjectLintConfig(Base):
     """
 
     __tablename__ = "project_lint_configs"
+    __table_args__ = (CheckConstraint("lint_level BETWEEN 1 AND 5", name="ck_lint_level_range"),)
 
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
     project_id: Mapped[uuid.UUID] = mapped_column(

--- a/ontokit/models/lint_config.py
+++ b/ontokit/models/lint_config.py
@@ -51,7 +51,7 @@ class ProjectLintConfig(Base):
 
         if self.lint_level is not None:
             return get_rules_for_level(self.lint_level)
-        if self.enabled_rules is not None:
+        if self.enabled_rules is not None and self.enabled_rules.strip():
             ids = {r.strip() for r in self.enabled_rules.split(",") if r.strip()}
             return ids & ALL_RULE_IDS
         return None

--- a/ontokit/models/lint_config.py
+++ b/ontokit/models/lint_config.py
@@ -1,0 +1,57 @@
+"""Per-project lint configuration model."""
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import DateTime, ForeignKey, Integer, String, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+if TYPE_CHECKING:
+    from ontokit.models.project import Project
+
+from ontokit.core.database import Base
+
+
+class ProjectLintConfig(Base):
+    """Per-project lint rule configuration.
+
+    Stores which lint rules are enabled for a project, either via an explicit
+    comma-separated list of rule IDs or via a preset lint level (1-5).
+    When ``lint_level`` is set, it takes precedence over ``enabled_rules``.
+    """
+
+    __tablename__ = "project_lint_configs"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    project_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("projects.id", ondelete="CASCADE"),
+        unique=True,
+    )
+    lint_level: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    enabled_rules: Mapped[str | None] = mapped_column(String(2000), nullable=True)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    # Relationships
+    project: Mapped["Project"] = relationship(back_populates="lint_config")
+
+    def __repr__(self) -> str:
+        return f"<ProjectLintConfig(project_id={self.project_id}, lint_level={self.lint_level})>"
+
+    def get_enabled_rule_ids(self) -> set[str] | None:
+        """Resolve the effective set of enabled rule IDs.
+
+        Returns ``None`` when no configuration has been set (meaning all rules).
+        """
+        from ontokit.services.linter import ALL_RULE_IDS, get_rules_for_level
+
+        if self.lint_level is not None:
+            return get_rules_for_level(self.lint_level)
+        if self.enabled_rules is not None:
+            ids = {r.strip() for r in self.enabled_rules.split(",") if r.strip()}
+            return ids & ALL_RULE_IDS
+        return None

--- a/ontokit/models/project.py
+++ b/ontokit/models/project.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 if TYPE_CHECKING:
     from ontokit.models.join_request import JoinRequest
     from ontokit.models.lint import LintRun
+    from ontokit.models.lint_config import ProjectLintConfig
     from ontokit.models.normalization import NormalizationRun
     from ontokit.models.pull_request import GitHubIntegration, PullRequest
     from ontokit.models.suggestion_session import SuggestionSession
@@ -70,6 +71,9 @@ class Project(Base):
     )
     suggestion_sessions: Mapped[list["SuggestionSession"]] = relationship(
         back_populates="project", cascade="all, delete-orphan"
+    )
+    lint_config: Mapped["ProjectLintConfig | None"] = relationship(
+        back_populates="project", cascade="all, delete-orphan", uselist=False
     )
 
     def __repr__(self) -> str:

--- a/ontokit/schemas/lint.py
+++ b/ontokit/schemas/lint.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 # Type definitions
 LintIssueTypeValue = Literal["error", "warning", "info"]
 LintRunStatusValue = Literal["pending", "running", "completed", "failed"]
+SubjectTypeValue = Literal["class", "property", "individual", "other"]
 
 
 class LintIssueBase(BaseModel):
@@ -18,6 +19,7 @@ class LintIssueBase(BaseModel):
     rule_id: str = Field(..., min_length=1, max_length=100)
     message: str
     subject_iri: str | None = None
+    subject_type: SubjectTypeValue | None = None
     details: dict[str, Any] | None = None
 
 

--- a/ontokit/schemas/lint.py
+++ b/ontokit/schemas/lint.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from typing import Any, Literal
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 # Type definitions
 LintIssueTypeValue = Literal["error", "warning", "info"]
@@ -162,10 +162,11 @@ class LintConfigResponse(BaseModel):
 class LintConfigUpdate(BaseModel):
     """Request body for updating lint configuration.
 
+    ``lint_level`` and ``enabled_rules`` are mutually exclusive — see ``enforce_xor``.
+
     Set ``lint_level`` to use a preset level (1-5).
     Set ``enabled_rules`` to configure individual rules (can be empty list to disable all).
     Set both to ``None`` to reset to default (all rules).
-    When ``lint_level`` is set, it takes precedence over ``enabled_rules``.
     """
 
     lint_level: int | None = Field(default=None, ge=1, le=5)
@@ -184,3 +185,16 @@ class LintConfigUpdate(BaseModel):
             msg = f"Unknown rule IDs: {', '.join(sorted(invalid))}"
             raise ValueError(msg)
         return v
+
+    @model_validator(mode="after")
+    def enforce_xor(self) -> "LintConfigUpdate":
+        """Reject contradictory bodies that set both a preset level and a custom
+        rule list. Presets are immutable, so the two modes are mutually exclusive
+        and the UI never sends both. Accepting both would persist a self-
+        contradictory row whose response lies about effective rules."""
+        if self.lint_level is not None and self.enabled_rules is not None:
+            msg = (
+                "lint_level and enabled_rules are mutually exclusive — choose preset OR custom mode"
+            )
+            raise ValueError(msg)
+        return self

--- a/ontokit/schemas/lint.py
+++ b/ontokit/schemas/lint.py
@@ -118,6 +118,9 @@ class LintRuleInfo(BaseModel):
     name: str
     description: str
     severity: LintIssueTypeValue
+    scope: list[str] = Field(
+        description="Entity types this rule applies to: class, property, individual",
+    )
 
 
 class LintRulesResponse(BaseModel):

--- a/ontokit/schemas/lint.py
+++ b/ontokit/schemas/lint.py
@@ -122,3 +122,46 @@ class LintRulesResponse(BaseModel):
     """List of available lint rules."""
 
     rules: list[LintRuleInfo]
+
+
+# ---------------------------------------------------------------------------
+# Per-project lint configuration
+# ---------------------------------------------------------------------------
+
+
+class LintLevelInfo(BaseModel):
+    """Information about a progressive lint level."""
+
+    level: int
+    name: str
+    description: str
+    rule_ids: list[str]
+
+
+class LintLevelsResponse(BaseModel):
+    """List of available lint levels."""
+
+    levels: list[LintLevelInfo]
+
+
+class LintConfigResponse(BaseModel):
+    """Current lint configuration for a project."""
+
+    project_id: UUID
+    lint_level: int | None = None
+    enabled_rules: list[str] | None = None
+    effective_rules: list[str]
+    updated_at: datetime | None = None
+
+
+class LintConfigUpdate(BaseModel):
+    """Request body for updating lint configuration.
+
+    Set ``lint_level`` to use a preset level (1-5).
+    Set ``enabled_rules`` to configure individual rules.
+    Set both to ``None`` to reset to default (all rules).
+    When ``lint_level`` is set, it takes precedence over ``enabled_rules``.
+    """
+
+    lint_level: int | None = Field(default=None, ge=1, le=5)
+    enabled_rules: list[str] | None = None

--- a/ontokit/schemas/lint.py
+++ b/ontokit/schemas/lint.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from typing import Any, Literal
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 # Type definitions
 LintIssueTypeValue = Literal["error", "warning", "info"]
@@ -158,10 +158,24 @@ class LintConfigUpdate(BaseModel):
     """Request body for updating lint configuration.
 
     Set ``lint_level`` to use a preset level (1-5).
-    Set ``enabled_rules`` to configure individual rules.
+    Set ``enabled_rules`` to configure individual rules (can be empty list to disable all).
     Set both to ``None`` to reset to default (all rules).
     When ``lint_level`` is set, it takes precedence over ``enabled_rules``.
     """
 
     lint_level: int | None = Field(default=None, ge=1, le=5)
     enabled_rules: list[str] | None = None
+
+    @field_validator("enabled_rules")
+    @classmethod
+    def validate_rule_ids(cls, v: list[str] | None) -> list[str] | None:
+        """Reject unknown rule IDs at schema level."""
+        if v is None:
+            return v
+        from ontokit.services.linter import ALL_RULE_IDS
+
+        invalid = set(v) - ALL_RULE_IDS
+        if invalid:
+            msg = f"Unknown rule IDs: {', '.join(sorted(invalid))}"
+            raise ValueError(msg)
+        return v

--- a/ontokit/services/linter.py
+++ b/ontokit/services/linter.py
@@ -594,11 +594,12 @@ class OntologyLinter:
         issues = []
 
         # Group triples by subject
+        # Use o.n3() to preserve language tags and datatypes in comparisons
         subject_triples: dict[str, list[tuple[str, str]]] = defaultdict(list)
 
         for s, p, o in graph:
             if isinstance(s, URIRef):
-                po_key = (str(p), str(o))
+                po_key = (str(p), o.n3())
                 subject_triples[str(s)].append(po_key)
 
         # Find duplicates within each subject

--- a/ontokit/services/linter.py
+++ b/ontokit/services/linter.py
@@ -33,7 +33,11 @@ class LintRuleInfo:
     name: str
     description: str
     severity: str
+    scope: list[str] = field(default_factory=lambda: ["class"])
 
+
+# Scope constants for rule applicability
+_ALL = ["class", "property", "individual"]
 
 # Available lint rules with their metadata
 LINT_RULES: list[LintRuleInfo] = [
@@ -42,108 +46,126 @@ LINT_RULES: list[LintRuleInfo] = [
         name="Missing Label",
         description="Resources should have at least one rdfs:label annotation",
         severity=LintIssueType.WARNING.value,
+        scope=_ALL,
     ),
     LintRuleInfo(
         rule_id="missing-comment",
         name="Missing Comment",
         description="Resources should have a description via rdfs:comment",
         severity=LintIssueType.INFO.value,
+        scope=_ALL,
     ),
     LintRuleInfo(
         rule_id="orphan-class",
         name="Orphan Class",
         description="Classes with no parent (other than owl:Thing) and no children may be misplaced",
         severity=LintIssueType.WARNING.value,
+        scope=["class"],
     ),
     LintRuleInfo(
         rule_id="undefined-parent",
         name="Undefined Parent",
         description="Class references a parent that is not defined in the ontology",
         severity=LintIssueType.ERROR.value,
+        scope=["class"],
     ),
     LintRuleInfo(
         rule_id="circular-hierarchy",
         name="Circular Hierarchy",
         description="Circular inheritance detected in class hierarchy",
         severity=LintIssueType.ERROR.value,
+        scope=["class"],
     ),
     LintRuleInfo(
         rule_id="empty-label",
         name="Empty Label",
         description="Resource has a label that is an empty string",
         severity=LintIssueType.WARNING.value,
+        scope=_ALL,
     ),
     LintRuleInfo(
         rule_id="duplicate-label",
         name="Duplicate Label",
         description="Multiple resources share the same label, which may cause confusion",
         severity=LintIssueType.WARNING.value,
+        scope=_ALL,
     ),
     LintRuleInfo(
         rule_id="label-per-language",
         name="Duplicate Label Per Language",
         description="Resource has multiple different labels for the same language tag",
         severity=LintIssueType.ERROR.value,
+        scope=_ALL,
     ),
     LintRuleInfo(
         rule_id="undefined-prefix",
         name="Undefined Prefix",
         description="IRI uses a prefix that is not defined in the namespace bindings",
         severity=LintIssueType.ERROR.value,
+        scope=_ALL,
     ),
     LintRuleInfo(
         rule_id="duplicate-triple",
         name="Duplicate Triple",
         description="Same predicate-object pair appears multiple times for the same subject",
         severity=LintIssueType.INFO.value,
+        scope=_ALL,
     ),
     LintRuleInfo(
         rule_id="domain-violation",
         name="Domain Violation",
         description="Property used on a subject that is not in its declared domain",
         severity=LintIssueType.WARNING.value,
+        scope=_ALL,
     ),
     LintRuleInfo(
         rule_id="range-violation",
         name="Range Violation",
         description="Property value is not in the declared range",
         severity=LintIssueType.WARNING.value,
+        scope=_ALL,
     ),
     LintRuleInfo(
         rule_id="cardinality-violation",
         name="Cardinality Violation",
         description="Property usage violates declared cardinality constraints",
         severity=LintIssueType.ERROR.value,
+        scope=["individual"],
     ),
     LintRuleInfo(
         rule_id="disjoint-violation",
         name="Disjoint Class Violation",
         description="Resource is typed with classes declared as disjoint",
         severity=LintIssueType.ERROR.value,
+        scope=["individual"],
     ),
     LintRuleInfo(
         rule_id="inverse-property-inconsistency",
         name="Inverse Property Inconsistency",
         description="Inverse property relationship is not symmetric",
         severity=LintIssueType.WARNING.value,
+        scope=["property"],
     ),
     LintRuleInfo(
         rule_id="missing-english-label",
         name="Missing English Label",
         description="Resource has labels but none in English",
         severity=LintIssueType.WARNING.value,
+        scope=_ALL,
     ),
     LintRuleInfo(
         rule_id="missing-language-tag",
         name="Missing Language Tag",
         description="Label or annotation has no language tag (plain literal or xsd:string)",
         severity=LintIssueType.WARNING.value,
+        scope=_ALL,
     ),
     LintRuleInfo(
         rule_id="redundant-regional-label",
         name="Redundant Regional Label",
         description="Regional language variants have identical values and should use the base tag",
         severity=LintIssueType.INFO.value,
+        scope=_ALL,
     ),
 ]
 

--- a/ontokit/services/linter.py
+++ b/ontokit/services/linter.py
@@ -213,53 +213,53 @@ class OntologyLinter:
         return issues
 
     async def _check_missing_label(self, graph: Graph) -> list[LintResult]:
-        """Find classes without rdfs:label."""
+        """Find resources without rdfs:label."""
         issues = []
 
-        for class_uri in graph.subjects(RDF.type, OWL.Class):
-            if not isinstance(class_uri, URIRef):
+        for subject in set(graph.subjects()):
+            if not isinstance(subject, URIRef):
                 continue
-            if class_uri == OWL.Thing:
+            if subject == OWL.Thing:
                 continue
 
             # Check for any rdfs:label
-            labels = list(graph.objects(class_uri, RDFS.label))
+            labels = list(graph.objects(subject, RDFS.label))
             if not labels:
                 issues.append(
                     LintResult(
                         issue_type=LintIssueType.WARNING.value,
                         rule_id="missing-label",
-                        message="Class has no rdfs:label annotation",
-                        subject_iri=str(class_uri),
-                        details={"local_name": self._get_local_name(class_uri)},
+                        message="Resource has no rdfs:label annotation",
+                        subject_iri=str(subject),
+                        details={"local_name": self._get_local_name(subject)},
                     )
                 )
 
         return issues
 
     async def _check_missing_comment(self, graph: Graph) -> list[LintResult]:
-        """Find classes without rdfs:comment."""
+        """Find resources without rdfs:comment."""
         issues = []
 
-        for class_uri in graph.subjects(RDF.type, OWL.Class):
-            if not isinstance(class_uri, URIRef):
+        for subject in set(graph.subjects()):
+            if not isinstance(subject, URIRef):
                 continue
-            if class_uri == OWL.Thing:
+            if subject == OWL.Thing:
                 continue
 
             # Check for any rdfs:comment
-            comments = list(graph.objects(class_uri, RDFS.comment))
+            comments = list(graph.objects(subject, RDFS.comment))
             if not comments:
                 # Get label for better context
-                label = self._get_label(graph, class_uri)
+                label = self._get_label(graph, subject)
                 issues.append(
                     LintResult(
                         issue_type=LintIssueType.INFO.value,
                         rule_id="missing-comment",
-                        message="Class has no rdfs:comment description",
-                        subject_iri=str(class_uri),
+                        message="Resource has no rdfs:comment description",
+                        subject_iri=str(subject),
                         details={
-                            "local_name": self._get_local_name(class_uri),
+                            "local_name": self._get_local_name(subject),
                             "label": label,
                         },
                     )
@@ -409,17 +409,17 @@ class OntologyLinter:
         return issues
 
     async def _check_empty_label(self, graph: Graph) -> list[LintResult]:
-        """Find classes with empty string labels."""
+        """Find resources with empty string labels."""
         issues = []
 
-        for class_uri in graph.subjects(RDF.type, OWL.Class):
-            if not isinstance(class_uri, URIRef):
+        for subject in set(graph.subjects()):
+            if not isinstance(subject, URIRef):
                 continue
-            if class_uri == OWL.Thing:
+            if subject == OWL.Thing:
                 continue
 
             # Check each label
-            for label in graph.objects(class_uri, RDFS.label):
+            for label in graph.objects(subject, RDFS.label):
                 if isinstance(label, RDFLiteral):
                     label_str = str(label).strip()
                     if not label_str:
@@ -427,10 +427,10 @@ class OntologyLinter:
                             LintResult(
                                 issue_type=LintIssueType.WARNING.value,
                                 rule_id="empty-label",
-                                message="Class has an empty rdfs:label",
-                                subject_iri=str(class_uri),
+                                message="Resource has an empty rdfs:label",
+                                subject_iri=str(subject),
                                 details={
-                                    "local_name": self._get_local_name(class_uri),
+                                    "local_name": self._get_local_name(subject),
                                     "language": label.language,
                                 },
                             )
@@ -439,45 +439,45 @@ class OntologyLinter:
         return issues
 
     async def _check_duplicate_label(self, graph: Graph) -> list[LintResult]:
-        """Find classes that share the same label."""
+        """Find resources that share the same label."""
         issues = []
 
-        # Build map of label → list of class IRIs
-        label_to_classes: dict[str, list[str]] = defaultdict(list)
+        # Build map of label → list of resource IRIs
+        label_to_resources: dict[str, list[str]] = defaultdict(list)
 
-        for class_uri in graph.subjects(RDF.type, OWL.Class):
-            if not isinstance(class_uri, URIRef):
+        for subject in set(graph.subjects()):
+            if not isinstance(subject, URIRef):
                 continue
-            if class_uri == OWL.Thing:
+            if subject == OWL.Thing:
                 continue
 
-            for label in graph.objects(class_uri, RDFS.label):
+            for label in graph.objects(subject, RDFS.label):
                 if isinstance(label, RDFLiteral):
                     label_str = str(label).strip().lower()
                     if label_str:  # Skip empty labels
-                        label_to_classes[label_str].append(str(class_uri))
+                        label_to_resources[label_str].append(str(subject))
 
         # Report duplicates
         reported_iris: set[str] = set()
-        for _label_str, class_iris in label_to_classes.items():
-            if len(class_iris) > 1:
-                for class_iri in class_iris:
-                    if class_iri not in reported_iris:
-                        reported_iris.add(class_iri)
+        for _label_str, resource_iris in label_to_resources.items():
+            if len(resource_iris) > 1:
+                for resource_iri in resource_iris:
+                    if resource_iri not in reported_iris:
+                        reported_iris.add(resource_iri)
                         # Get original (non-lowercased) label
-                        original_label = self._get_label(graph, URIRef(class_iri))
-                        other_classes = [c for c in class_iris if c != class_iri]
+                        original_label = self._get_label(graph, URIRef(resource_iri))
+                        other_resources = [c for c in resource_iris if c != resource_iri]
                         issues.append(
                             LintResult(
                                 issue_type=LintIssueType.WARNING.value,
                                 rule_id="duplicate-label",
-                                message=f"Label '{original_label}' is shared with {len(other_classes)} other class(es)",
-                                subject_iri=class_iri,
+                                message=f"Label '{original_label}' is shared with {len(other_resources)} other resource(s)",
+                                subject_iri=resource_iri,
                                 details={
-                                    "local_name": self._get_local_name(URIRef(class_iri)),
+                                    "local_name": self._get_local_name(URIRef(resource_iri)),
                                     "label": original_label,
-                                    "duplicate_iris": other_classes[:5],  # Limit to 5
-                                    "total_duplicates": len(other_classes),
+                                    "duplicate_iris": other_resources[:5],  # Limit to 5
+                                    "total_duplicates": len(other_resources),
                                 },
                             )
                         )
@@ -503,17 +503,17 @@ class OntologyLinter:
             (SKOS.prefLabel, "skos:prefLabel"),
         ]
 
-        for class_uri in graph.subjects(RDF.type, OWL.Class):
-            if not isinstance(class_uri, URIRef):
+        for subject in set(graph.subjects()):
+            if not isinstance(subject, URIRef):
                 continue
-            if class_uri == OWL.Thing:
+            if subject == OWL.Thing:
                 continue
 
             for predicate, pred_name in label_predicates:
                 # Collect labels by language for this specific predicate
                 labels_by_lang: dict[str | None, list[str]] = defaultdict(list)
 
-                for label in graph.objects(class_uri, predicate):
+                for label in graph.objects(subject, predicate):
                     if isinstance(label, RDFLiteral):
                         labels_by_lang[label.language].append(str(label))
 
@@ -530,9 +530,9 @@ class OntologyLinter:
                                     f"Multiple different {pred_name} values "
                                     f"for language '{lang_str}'"
                                 ),
-                                subject_iri=str(class_uri),
+                                subject_iri=str(subject),
                                 details={
-                                    "local_name": self._get_local_name(class_uri),
+                                    "local_name": self._get_local_name(subject),
                                     "predicate": pred_name,
                                     "language": lang_str,
                                     "labels": unique_values,
@@ -950,23 +950,23 @@ class OntologyLinter:
         issues = []
         SKOS = Namespace("http://www.w3.org/2004/02/skos/core#")
 
-        for class_uri in graph.subjects(RDF.type, OWL.Class):
-            if not isinstance(class_uri, URIRef):
+        for subject in set(graph.subjects()):
+            if not isinstance(subject, URIRef):
                 continue
-            if class_uri == OWL.Thing:
+            if subject == OWL.Thing:
                 continue
 
             # Collect all labels
             all_labels = []
             has_english = False
 
-            for label in graph.objects(class_uri, RDFS.label):
+            for label in graph.objects(subject, RDFS.label):
                 if isinstance(label, RDFLiteral):
                     all_labels.append(label)
                     if label.language and label.language.lower().startswith("en"):
                         has_english = True
 
-            for label in graph.objects(class_uri, SKOS.prefLabel):
+            for label in graph.objects(subject, SKOS.prefLabel):
                 if isinstance(label, RDFLiteral):
                     all_labels.append(label)
                     if label.language and label.language.lower().startswith("en"):
@@ -980,9 +980,9 @@ class OntologyLinter:
                         issue_type=LintIssueType.WARNING.value,
                         rule_id="missing-english-label",
                         message=f"No English label defined (has labels in: {', '.join(languages)})",
-                        subject_iri=str(class_uri),
+                        subject_iri=str(subject),
                         details={
-                            "local_name": self._get_local_name(class_uri),
+                            "local_name": self._get_local_name(subject),
                             "available_languages": languages,
                         },
                     )

--- a/ontokit/services/linter.py
+++ b/ontokit/services/linter.py
@@ -478,12 +478,19 @@ class OntologyLinter:
 
     async def _check_label_per_language(self, graph: Graph) -> list[LintResult]:
         """
-        Find resources with multiple different labels for the same language.
+        Find resources with multiple different labels for the same predicate and language.
 
-        Adapted from skos-ttl-editor's labelCheck.
+        Each label predicate (rdfs:label, skos:prefLabel, skos:altLabel) is checked
+        independently — having different values across different predicates is valid.
         """
         issues = []
         SKOS = Namespace("http://www.w3.org/2004/02/skos/core#")
+
+        label_predicates = [
+            (RDFS.label, "rdfs:label"),
+            (SKOS.prefLabel, "skos:prefLabel"),
+            (SKOS.altLabel, "skos:altLabel"),
+        ]
 
         for class_uri in graph.subjects(RDF.type, OWL.Class):
             if not isinstance(class_uri, URIRef):
@@ -491,39 +498,36 @@ class OntologyLinter:
             if class_uri == OWL.Thing:
                 continue
 
-            # Collect all labels with their language tags
-            labels_by_lang: dict[str | None, list[str]] = defaultdict(list)
+            for predicate, pred_name in label_predicates:
+                # Collect labels by language for this specific predicate
+                labels_by_lang: dict[str | None, list[str]] = defaultdict(list)
 
-            # Check rdfs:label
-            for label in graph.objects(class_uri, RDFS.label):
-                if isinstance(label, RDFLiteral):
-                    lang = label.language
-                    labels_by_lang[lang].append(str(label))
+                for label in graph.objects(class_uri, predicate):
+                    if isinstance(label, RDFLiteral):
+                        labels_by_lang[label.language].append(str(label))
 
-            # Check skos:prefLabel
-            for label in graph.objects(class_uri, SKOS.prefLabel):
-                if isinstance(label, RDFLiteral):
-                    lang = label.language
-                    labels_by_lang[lang].append(str(label))
-
-            # Check for multiple different labels per language
-            for lang, label_values in labels_by_lang.items():
-                unique_values = list(set(label_values))
-                if len(unique_values) > 1:
-                    lang_str = lang or "no language tag"
-                    issues.append(
-                        LintResult(
-                            issue_type=LintIssueType.ERROR.value,
-                            rule_id="label-per-language",
-                            message=f"Multiple different labels for language '{lang_str}'",
-                            subject_iri=str(class_uri),
-                            details={
-                                "local_name": self._get_local_name(class_uri),
-                                "language": lang_str,
-                                "labels": unique_values,
-                            },
+                # Check for multiple different labels per language within this predicate
+                for lang, label_values in labels_by_lang.items():
+                    unique_values = list(set(label_values))
+                    if len(unique_values) > 1:
+                        lang_str = lang or "no language tag"
+                        issues.append(
+                            LintResult(
+                                issue_type=LintIssueType.ERROR.value,
+                                rule_id="label-per-language",
+                                message=(
+                                    f"Multiple different {pred_name} values "
+                                    f"for language '{lang_str}'"
+                                ),
+                                subject_iri=str(class_uri),
+                                details={
+                                    "local_name": self._get_local_name(class_uri),
+                                    "predicate": pred_name,
+                                    "language": lang_str,
+                                    "labels": unique_values,
+                                },
+                            )
                         )
-                    )
 
         return issues
 

--- a/ontokit/services/linter.py
+++ b/ontokit/services/linter.py
@@ -148,7 +148,10 @@ LINT_RULES: list[LintRuleInfo] = [
         name="Inverse Property Inconsistency",
         description="Inverse property relationship is not symmetric",
         severity=LintIssueType.WARNING.value,
-        scope=["property"],
+        # The flagged subject is the asserter of the property usage (typically
+        # an individual), not a property — keep scope aligned with what the
+        # rule actually reports.
+        scope=["individual"],
     ),
     LintRuleInfo(
         rule_id="missing-english-label",
@@ -1015,7 +1018,7 @@ class OntologyLinter:
                                 rule_id="inverse-property-inconsistency",
                                 message="Missing inverse property assertion",
                                 subject_iri=str(s),
-                                subject_type="property",
+                                subject_type=self._determine_entity_type(graph, s),
                                 details={
                                     "property": prop_str,
                                     "object": str(o),

--- a/ontokit/services/linter.py
+++ b/ontokit/services/linter.py
@@ -1090,9 +1090,6 @@ class OntologyLinter:
         """
         issues = []
 
-        DC = Namespace("http://purl.org/dc/elements/1.1/")
-        DCTERMS = Namespace("http://purl.org/dc/terms/")
-
         predicates = [
             (RDFS.label, "rdfs:label"),
             (RDFS.comment, "rdfs:comment"),

--- a/ontokit/services/linter.py
+++ b/ontokit/services/linter.py
@@ -8,7 +8,7 @@ from uuid import UUID
 
 from rdflib import Graph, Namespace, URIRef
 from rdflib import Literal as RDFLiteral
-from rdflib.namespace import OWL, RDF, RDFS, XSD
+from rdflib.namespace import OWL, RDF, RDFS, SKOS, XSD
 
 from ontokit.models.lint import LintIssueType
 
@@ -21,6 +21,7 @@ class LintResult:
     rule_id: str
     message: str
     subject_iri: str | None = None
+    subject_type: str | None = None  # "class", "property", "individual", "other"
     details: dict[str, Any] | None = None
 
 
@@ -170,22 +171,22 @@ _LEVEL_4_RULES: set[str] = _LEVEL_3_RULES | {
 }
 _LEVEL_5_RULES: set[str] = {r.rule_id for r in LINT_RULES}
 
-LINT_LEVELS: dict[int, set[str]] = {
-    1: _LEVEL_1_RULES,
-    2: _LEVEL_2_RULES,
-    3: _LEVEL_3_RULES,
-    4: _LEVEL_4_RULES,
-    5: _LEVEL_5_RULES,
+LINT_LEVELS: dict[int, frozenset[str]] = {
+    1: frozenset(_LEVEL_1_RULES),
+    2: frozenset(_LEVEL_2_RULES),
+    3: frozenset(_LEVEL_3_RULES),
+    4: frozenset(_LEVEL_4_RULES),
+    5: frozenset(_LEVEL_5_RULES),
 }
 
-ALL_RULE_IDS: set[str] = _LEVEL_5_RULES
+ALL_RULE_IDS: frozenset[str] = LINT_LEVELS[5]
 
 
 def get_rules_for_level(level: int) -> set[str]:
     """Return the set of rule IDs enabled at a given lint level (1-5)."""
     if level < 1 or level > 5:
         raise ValueError(f"Lint level must be between 1 and 5, got {level}")
-    return LINT_LEVELS[level].copy()
+    return set(LINT_LEVELS[level])
 
 
 @dataclass
@@ -240,6 +241,7 @@ class OntologyLinter:
                         rule_id="missing-label",
                         message="Resource has no rdfs:label annotation",
                         subject_iri=str(subject),
+                        subject_type=self._determine_entity_type(graph, subject),
                         details={"local_name": self._get_local_name(subject)},
                     )
                 )
@@ -267,6 +269,7 @@ class OntologyLinter:
                         rule_id="missing-comment",
                         message="Resource has no rdfs:comment description",
                         subject_iri=str(subject),
+                        subject_type=self._determine_entity_type(graph, subject),
                         details={
                             "local_name": self._get_local_name(subject),
                             "label": label,
@@ -307,6 +310,7 @@ class OntologyLinter:
                         rule_id="orphan-class",
                         message="Class has no parent classes and no children",
                         subject_iri=str(class_uri),
+                        subject_type="class",
                         details={
                             "local_name": self._get_local_name(class_uri),
                             "label": label,
@@ -345,6 +349,7 @@ class OntologyLinter:
                             rule_id="undefined-parent",
                             message="References undefined parent class",
                             subject_iri=str(class_uri),
+                            subject_type="class",
                             details={
                                 "local_name": self._get_local_name(class_uri),
                                 "label": label,
@@ -408,6 +413,7 @@ class OntologyLinter:
                             rule_id="circular-hierarchy",
                             message=f"Circular inheritance: {' → '.join(cycle_labels)} → {cycle_labels[0]}",
                             subject_iri=cycle[0],
+                            subject_type="class",
                             details={
                                 "cycle_iris": cycle,
                                 "cycle_labels": cycle_labels,
@@ -438,6 +444,7 @@ class OntologyLinter:
                                 rule_id="empty-label",
                                 message="Resource has an empty rdfs:label",
                                 subject_iri=str(subject),
+                                subject_type="class",
                                 details={
                                     "local_name": self._get_local_name(subject),
                                     "language": label.language,
@@ -482,6 +489,7 @@ class OntologyLinter:
                                 rule_id="duplicate-label",
                                 message=f"Label '{original_label}' is shared with {len(other_resources)} other resource(s)",
                                 subject_iri=resource_iri,
+                                subject_type="class",
                                 details={
                                     "local_name": self._get_local_name(URIRef(resource_iri)),
                                     "label": original_label,
@@ -505,7 +513,6 @@ class OntologyLinter:
         multiple values per language is their intended usage (synonyms, variants).
         """
         issues = []
-        SKOS = Namespace("http://www.w3.org/2004/02/skos/core#")
 
         label_predicates = [
             (RDFS.label, "rdfs:label"),
@@ -540,6 +547,7 @@ class OntologyLinter:
                                     f"for language '{lang_str}'"
                                 ),
                                 subject_iri=str(subject),
+                                subject_type="class",
                                 details={
                                     "local_name": self._get_local_name(subject),
                                     "predicate": pred_name,
@@ -586,6 +594,7 @@ class OntologyLinter:
                                 rule_id="undefined-prefix",
                                 message=f"Prefix '{prefix}' is not defined",
                                 subject_iri=iri,
+                                subject_type="other",
                                 details={
                                     "prefix": prefix,
                                     "iri": iri,
@@ -626,6 +635,7 @@ class OntologyLinter:
                             rule_id="duplicate-triple",
                             message=f"Duplicate triple: predicate-object pair appears {count} times",
                             subject_iri=subject_iri,
+                            subject_type=self._determine_entity_type(graph, URIRef(subject_iri)),
                             details={
                                 "predicate": po[0],
                                 "object": po[1],
@@ -688,6 +698,7 @@ class OntologyLinter:
                             rule_id="domain-violation",
                             message="Property used on subject not in declared domain",
                             subject_iri=str(s),
+                            subject_type=self._determine_entity_type(graph, URIRef(str(s))),
                             details={
                                 "property": prop_str,
                                 "expected_domains": list(domains),
@@ -742,6 +753,7 @@ class OntologyLinter:
                             rule_id="range-violation",
                             message="Property value not in declared range",
                             subject_iri=str(s),
+                            subject_type=self._determine_entity_type(graph, URIRef(str(s))),
                             details={
                                 "property": prop_str,
                                 "object": str(o),
@@ -804,6 +816,7 @@ class OntologyLinter:
                                 rule_id="cardinality-violation",
                                 message=f"Cardinality violation: expected exactly {exact_cardinality}, found {value_count}",
                                 subject_iri=str(instance),
+                                subject_type="individual",
                                 details={
                                     "property": str(on_property),
                                     "expected": exact_cardinality,
@@ -819,6 +832,7 @@ class OntologyLinter:
                                 rule_id="cardinality-violation",
                                 message=f"Cardinality violation: max {max_cardinality}, found {value_count}",
                                 subject_iri=str(instance),
+                                subject_type="individual",
                                 details={
                                     "property": str(on_property),
                                     "max": max_cardinality,
@@ -834,6 +848,7 @@ class OntologyLinter:
                                 rule_id="cardinality-violation",
                                 message=f"Cardinality violation: min {min_cardinality}, found {value_count}",
                                 subject_iri=str(instance),
+                                subject_type="individual",
                                 details={
                                     "property": str(on_property),
                                     "min": min_cardinality,
@@ -890,6 +905,7 @@ class OntologyLinter:
                                 rule_id="disjoint-violation",
                                 message="Resource is typed with disjoint classes",
                                 subject_iri=str(instance),
+                                subject_type="individual",
                                 details={
                                     "class1": t1,
                                     "class2": t2,
@@ -939,6 +955,7 @@ class OntologyLinter:
                                 rule_id="inverse-property-inconsistency",
                                 message="Missing inverse property assertion",
                                 subject_iri=str(s),
+                                subject_type="property",
                                 details={
                                     "property": prop_str,
                                     "object": str(o),
@@ -957,7 +974,6 @@ class OntologyLinter:
         Adapted from skos-ttl-editor's labelCheck warning.
         """
         issues = []
-        SKOS = Namespace("http://www.w3.org/2004/02/skos/core#")
 
         for subject in set(graph.subjects()):
             if not isinstance(subject, URIRef):
@@ -990,6 +1006,7 @@ class OntologyLinter:
                         rule_id="missing-english-label",
                         message=f"No English label defined (has labels in: {', '.join(languages)})",
                         subject_iri=str(subject),
+                        subject_type="class",
                         details={
                             "local_name": self._get_local_name(subject),
                             "available_languages": languages,
@@ -1005,7 +1022,7 @@ class OntologyLinter:
         instead of language-tagged literals.
         """
         issues = []
-        SKOS = Namespace("http://www.w3.org/2004/02/skos/core#")
+
         DC = Namespace("http://purl.org/dc/elements/1.1/")
         DCTERMS = Namespace("http://purl.org/dc/terms/")
 
@@ -1050,6 +1067,7 @@ class OntologyLinter:
                                 rule_id="missing-language-tag",
                                 message=(f"{pred_name} has no language tag{datatype_note}"),
                                 subject_iri=str(subject),
+                                subject_type=self._determine_entity_type(graph, subject),
                                 details={
                                     "local_name": self._get_local_name(subject),
                                     "predicate": pred_name,
@@ -1068,7 +1086,7 @@ class OntologyLinter:
         adds no value and the base tag (@es) should be used instead.
         """
         issues = []
-        SKOS = Namespace("http://www.w3.org/2004/02/skos/core#")
+
         DC = Namespace("http://purl.org/dc/elements/1.1/")
         DCTERMS = Namespace("http://purl.org/dc/terms/")
 
@@ -1105,8 +1123,6 @@ class OntologyLinter:
                     if not isinstance(obj, RDFLiteral) or obj.language is None:
                         continue
                     lang = obj.language.lower()
-                    if "-" not in lang:
-                        continue  # Not a regional variant
                     base_lang = lang.split("-")[0]
                     regional_groups[(base_lang, str(obj))].append(lang)
 
@@ -1125,6 +1141,7 @@ class OntologyLinter:
                                 f"{tag_list} — consider using @{base_lang} instead"
                             ),
                             subject_iri=str(subject),
+                            subject_type=self._determine_entity_type(graph, subject),
                             details={
                                 "local_name": self._get_local_name(subject),
                                 "predicate": pred_name,
@@ -1136,6 +1153,26 @@ class OntologyLinter:
                     )
 
         return issues
+
+    @staticmethod
+    def _determine_entity_type(graph: Graph, uri: URIRef) -> str:
+        """Return 'class', 'property', 'individual', or 'other' for a URI."""
+        types = set(graph.objects(uri, RDF.type))
+        if OWL.Class in types or RDFS.Class in types:
+            return "class"
+        if any(
+            t in types
+            for t in (
+                OWL.ObjectProperty,
+                OWL.DatatypeProperty,
+                OWL.AnnotationProperty,
+                RDF.Property,
+            )
+        ):
+            return "property"
+        if types:
+            return "individual"
+        return "other"
 
     @staticmethod
     def _get_local_name(uri: URIRef) -> str:

--- a/ontokit/services/linter.py
+++ b/ontokit/services/linter.py
@@ -137,47 +137,31 @@ LINT_RULES: list[LintRuleInfo] = [
 # Map rule IDs to their info
 LINT_RULES_MAP: dict[str, LintRuleInfo] = {rule.rule_id: rule for rule in LINT_RULES}
 
-# Progressive lint levels — each level includes all rules from previous levels
+# Progressive lint levels — each level cumulatively includes the previous
+_LEVEL_1_RULES: set[str] = {"undefined-parent", "circular-hierarchy", "undefined-prefix"}
+_LEVEL_2_RULES: set[str] = _LEVEL_1_RULES | {
+    "orphan-class",
+    "duplicate-triple",
+    "disjoint-violation",
+}
+_LEVEL_3_RULES: set[str] = _LEVEL_2_RULES | {
+    "missing-label",
+    "empty-label",
+    "duplicate-label",
+    "missing-english-label",
+}
+_LEVEL_4_RULES: set[str] = _LEVEL_3_RULES | {"missing-comment", "label-per-language"}
+_LEVEL_5_RULES: set[str] = {r.rule_id for r in LINT_RULES}
+
 LINT_LEVELS: dict[int, set[str]] = {
-    1: {"undefined-parent", "circular-hierarchy", "undefined-prefix"},
-    2: {
-        "undefined-parent",
-        "circular-hierarchy",
-        "undefined-prefix",
-        "orphan-class",
-        "duplicate-triple",
-        "disjoint-violation",
-    },
-    3: {
-        "undefined-parent",
-        "circular-hierarchy",
-        "undefined-prefix",
-        "orphan-class",
-        "duplicate-triple",
-        "disjoint-violation",
-        "missing-label",
-        "empty-label",
-        "duplicate-label",
-        "missing-english-label",
-    },
-    4: {
-        "undefined-parent",
-        "circular-hierarchy",
-        "undefined-prefix",
-        "orphan-class",
-        "duplicate-triple",
-        "disjoint-violation",
-        "missing-label",
-        "empty-label",
-        "duplicate-label",
-        "missing-english-label",
-        "missing-comment",
-        "label-per-language",
-    },
-    5: {r.rule_id for r in LINT_RULES},
+    1: _LEVEL_1_RULES,
+    2: _LEVEL_2_RULES,
+    3: _LEVEL_3_RULES,
+    4: _LEVEL_4_RULES,
+    5: _LEVEL_5_RULES,
 }
 
-ALL_RULE_IDS: set[str] = {r.rule_id for r in LINT_RULES}
+ALL_RULE_IDS: set[str] = _LEVEL_5_RULES
 
 
 def get_rules_for_level(level: int) -> set[str]:

--- a/ontokit/services/linter.py
+++ b/ontokit/services/linter.py
@@ -39,13 +39,13 @@ LINT_RULES: list[LintRuleInfo] = [
     LintRuleInfo(
         rule_id="missing-label",
         name="Missing Label",
-        description="Classes should have at least one rdfs:label annotation",
+        description="Resources should have at least one rdfs:label annotation",
         severity=LintIssueType.WARNING.value,
     ),
     LintRuleInfo(
         rule_id="missing-comment",
         name="Missing Comment",
-        description="Classes should have a description via rdfs:comment",
+        description="Resources should have a description via rdfs:comment",
         severity=LintIssueType.INFO.value,
     ),
     LintRuleInfo(
@@ -69,13 +69,13 @@ LINT_RULES: list[LintRuleInfo] = [
     LintRuleInfo(
         rule_id="empty-label",
         name="Empty Label",
-        description="Class has a label that is an empty string",
+        description="Resource has a label that is an empty string",
         severity=LintIssueType.WARNING.value,
     ),
     LintRuleInfo(
         rule_id="duplicate-label",
         name="Duplicate Label",
-        description="Multiple classes share the same label, which may cause confusion",
+        description="Multiple resources share the same label, which may cause confusion",
         severity=LintIssueType.WARNING.value,
     ),
     LintRuleInfo(
@@ -156,9 +156,8 @@ _LEVEL_3_RULES: set[str] = _LEVEL_2_RULES | {
     "duplicate-label",
     "missing-english-label",
     "missing-language-tag",
-    "missing-comment",
 }
-_LEVEL_4_RULES: set[str] = _LEVEL_3_RULES | {"label-per-language"}
+_LEVEL_4_RULES: set[str] = _LEVEL_3_RULES | {"missing-comment", "label-per-language"}
 _LEVEL_5_RULES: set[str] = {r.rule_id for r in LINT_RULES}
 
 LINT_LEVELS: dict[int, set[str]] = {

--- a/ontokit/services/linter.py
+++ b/ontokit/services/linter.py
@@ -487,8 +487,12 @@ class OntologyLinter:
         """
         Find resources with multiple different labels for the same predicate and language.
 
-        Each label predicate (rdfs:label, skos:prefLabel, skos:altLabel) is checked
-        independently — having different values across different predicates is valid.
+        Only checks predicates with cardinality constraints:
+        - rdfs:label: conventionally one per language
+        - skos:prefLabel: at most one per language (SKOS integrity condition S14)
+
+        skos:altLabel and skos:hiddenLabel are explicitly unconstrained —
+        multiple values per language is their intended usage (synonyms, variants).
         """
         issues = []
         SKOS = Namespace("http://www.w3.org/2004/02/skos/core#")
@@ -496,7 +500,6 @@ class OntologyLinter:
         label_predicates = [
             (RDFS.label, "rdfs:label"),
             (SKOS.prefLabel, "skos:prefLabel"),
-            (SKOS.altLabel, "skos:altLabel"),
         ]
 
         for class_uri in graph.subjects(RDF.type, OWL.Class):

--- a/ontokit/services/linter.py
+++ b/ontokit/services/linter.py
@@ -3,7 +3,7 @@
 import contextlib
 from collections import defaultdict
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, NamedTuple
 from uuid import UUID
 
 from rdflib import Graph, Namespace, URIRef
@@ -213,6 +213,43 @@ LINT_LEVELS: dict[int, frozenset[str]] = {
 }
 
 ALL_RULE_IDS: frozenset[str] = LINT_LEVELS[5]
+
+
+class LintLevelDefinition(NamedTuple):
+    """Metadata for a progressive lint level."""
+
+    name: str
+    description: str
+    rules: frozenset[str]
+
+
+LINT_LEVEL_DEFINITIONS: dict[int, LintLevelDefinition] = {
+    1: LintLevelDefinition(
+        "Critical",
+        "Undefined parents, circular hierarchies, undefined prefixes",
+        LINT_LEVELS[1],
+    ),
+    2: LintLevelDefinition(
+        "Consistency",
+        "Orphan classes, duplicate triples, and disjointness violations",
+        LINT_LEVELS[2],
+    ),
+    3: LintLevelDefinition(
+        "Labels",
+        "Missing, empty, and duplicate label checks",
+        LINT_LEVELS[3],
+    ),
+    4: LintLevelDefinition(
+        "Quality",
+        "Comments, per-language label checks, and redundant regional variants",
+        LINT_LEVELS[4],
+    ),
+    5: LintLevelDefinition(
+        "All",
+        "All available rules including domain/range and cardinality",
+        LINT_LEVELS[5],
+    ),
+}
 
 
 def get_rules_for_level(level: int) -> set[str]:

--- a/ontokit/services/linter.py
+++ b/ontokit/services/linter.py
@@ -138,6 +138,12 @@ LINT_RULES: list[LintRuleInfo] = [
         description="Label or annotation has no language tag (plain literal or xsd:string)",
         severity=LintIssueType.WARNING.value,
     ),
+    LintRuleInfo(
+        rule_id="redundant-regional-label",
+        name="Redundant Regional Label",
+        description="Regional language variants have identical values and should use the base tag",
+        severity=LintIssueType.INFO.value,
+    ),
 ]
 
 # Map rule IDs to their info
@@ -157,7 +163,11 @@ _LEVEL_3_RULES: set[str] = _LEVEL_2_RULES | {
     "missing-english-label",
     "missing-language-tag",
 }
-_LEVEL_4_RULES: set[str] = _LEVEL_3_RULES | {"missing-comment", "label-per-language"}
+_LEVEL_4_RULES: set[str] = _LEVEL_3_RULES | {
+    "missing-comment",
+    "label-per-language",
+    "redundant-regional-label",
+}
 _LEVEL_5_RULES: set[str] = {r.rule_id for r in LINT_RULES}
 
 LINT_LEVELS: dict[int, set[str]] = {
@@ -1047,6 +1057,83 @@ class OntologyLinter:
                                 },
                             )
                         )
+
+        return issues
+
+    async def _check_redundant_regional_label(self, graph: Graph) -> list[LintResult]:
+        """
+        Find annotations where regional language variants have identical values.
+
+        When e.g. @es-es and @es-mx carry the same text, the regional qualifier
+        adds no value and the base tag (@es) should be used instead.
+        """
+        issues = []
+        SKOS = Namespace("http://www.w3.org/2004/02/skos/core#")
+        DC = Namespace("http://purl.org/dc/elements/1.1/")
+        DCTERMS = Namespace("http://purl.org/dc/terms/")
+
+        predicates = [
+            (RDFS.label, "rdfs:label"),
+            (RDFS.comment, "rdfs:comment"),
+            (SKOS.prefLabel, "skos:prefLabel"),
+            (SKOS.altLabel, "skos:altLabel"),
+            (SKOS.hiddenLabel, "skos:hiddenLabel"),
+            (SKOS.definition, "skos:definition"),
+            (SKOS.note, "skos:note"),
+            (SKOS.scopeNote, "skos:scopeNote"),
+            (SKOS.historyNote, "skos:historyNote"),
+            (SKOS.editorialNote, "skos:editorialNote"),
+            (SKOS.changeNote, "skos:changeNote"),
+            (SKOS.example, "skos:example"),
+            (DC.title, "dc:title"),
+            (DC.description, "dc:description"),
+            (DCTERMS.title, "dcterms:title"),
+            (DCTERMS.description, "dcterms:description"),
+        ]
+
+        for subject in set(graph.subjects()):
+            if not isinstance(subject, URIRef):
+                continue
+            if subject == OWL.Thing:
+                continue
+
+            for predicate, pred_name in predicates:
+                # Group literals by (base_language, value)
+                regional_groups: dict[tuple[str, str], list[str]] = defaultdict(list)
+
+                for obj in graph.objects(subject, predicate):
+                    if not isinstance(obj, RDFLiteral) or obj.language is None:
+                        continue
+                    lang = obj.language.lower()
+                    if "-" not in lang:
+                        continue  # Not a regional variant
+                    base_lang = lang.split("-")[0]
+                    regional_groups[(base_lang, str(obj))].append(lang)
+
+                for (base_lang, value), tags in regional_groups.items():
+                    if len(tags) < 2:
+                        continue
+                    sorted_tags = sorted(tags)
+                    tag_list = ", ".join(f"@{t}" for t in sorted_tags)
+                    issues.append(
+                        LintResult(
+                            issue_type=LintIssueType.INFO.value,
+                            rule_id="redundant-regional-label",
+                            message=(
+                                f"Redundant regional variants: {pred_name} "
+                                f'"{value[:80]}" has identical values for '
+                                f"{tag_list} — consider using @{base_lang} instead"
+                            ),
+                            subject_iri=str(subject),
+                            details={
+                                "local_name": self._get_local_name(subject),
+                                "predicate": pred_name,
+                                "value": value[:100],
+                                "regional_tags": sorted_tags,
+                                "base_language": base_lang,
+                            },
+                        )
+                    )
 
         return issues
 

--- a/ontokit/services/linter.py
+++ b/ontokit/services/linter.py
@@ -12,6 +12,9 @@ from rdflib.namespace import OWL, RDF, RDFS, SKOS, XSD
 
 from ontokit.models.lint import LintIssueType
 
+DC = Namespace("http://purl.org/dc/elements/1.1/")
+DCTERMS = Namespace("http://purl.org/dc/terms/")
+
 
 @dataclass
 class LintResult:
@@ -224,6 +227,7 @@ class OntologyLinter:
     """Service for checking ontology health and finding issues."""
 
     enabled_rules: set[str] = field(default_factory=lambda: {r.rule_id for r in LINT_RULES})
+    _uri_subjects: set[URIRef] = field(default_factory=set, init=False, repr=False)
 
     def get_enabled_rules(self) -> list[LintRuleInfo]:
         """Get list of enabled lint rules."""
@@ -242,6 +246,11 @@ class OntologyLinter:
         """
         issues: list[LintResult] = []
 
+        # Pre-compute subjects once for all checkers
+        self._uri_subjects: set[URIRef] = {
+            s for s in graph.subjects() if isinstance(s, URIRef) and s != OWL.Thing
+        }
+
         # Run each enabled rule
         for rule_id in self.enabled_rules:
             checker_name = f"_check_{rule_id.replace('-', '_')}"
@@ -256,12 +265,7 @@ class OntologyLinter:
         """Find resources without rdfs:label."""
         issues = []
 
-        for subject in set(graph.subjects()):
-            if not isinstance(subject, URIRef):
-                continue
-            if subject == OWL.Thing:
-                continue
-
+        for subject in self._uri_subjects:
             # Check for any rdfs:label
             labels = list(graph.objects(subject, RDFS.label))
             if not labels:
@@ -282,12 +286,7 @@ class OntologyLinter:
         """Find resources without rdfs:comment."""
         issues = []
 
-        for subject in set(graph.subjects()):
-            if not isinstance(subject, URIRef):
-                continue
-            if subject == OWL.Thing:
-                continue
-
+        for subject in self._uri_subjects:
             # Check for any rdfs:comment
             comments = list(graph.objects(subject, RDFS.comment))
             if not comments:
@@ -457,12 +456,7 @@ class OntologyLinter:
         """Find resources with empty string labels."""
         issues = []
 
-        for subject in set(graph.subjects()):
-            if not isinstance(subject, URIRef):
-                continue
-            if subject == OWL.Thing:
-                continue
-
+        for subject in self._uri_subjects:
             # Check each label
             for label in graph.objects(subject, RDFS.label):
                 if isinstance(label, RDFLiteral):
@@ -474,7 +468,7 @@ class OntologyLinter:
                                 rule_id="empty-label",
                                 message="Resource has an empty rdfs:label",
                                 subject_iri=str(subject),
-                                subject_type="class",
+                                subject_type=self._determine_entity_type(graph, subject),
                                 details={
                                     "local_name": self._get_local_name(subject),
                                     "language": label.language,
@@ -491,12 +485,7 @@ class OntologyLinter:
         # Build map of label → list of resource IRIs
         label_to_resources: dict[str, list[str]] = defaultdict(list)
 
-        for subject in set(graph.subjects()):
-            if not isinstance(subject, URIRef):
-                continue
-            if subject == OWL.Thing:
-                continue
-
+        for subject in self._uri_subjects:
             for label in graph.objects(subject, RDFS.label):
                 if isinstance(label, RDFLiteral):
                     label_str = str(label).strip().lower()
@@ -519,7 +508,9 @@ class OntologyLinter:
                                 rule_id="duplicate-label",
                                 message=f"Label '{original_label}' is shared with {len(other_resources)} other resource(s)",
                                 subject_iri=resource_iri,
-                                subject_type="class",
+                                subject_type=self._determine_entity_type(
+                                    graph, URIRef(resource_iri)
+                                ),
                                 details={
                                     "local_name": self._get_local_name(URIRef(resource_iri)),
                                     "label": original_label,
@@ -549,12 +540,7 @@ class OntologyLinter:
             (SKOS.prefLabel, "skos:prefLabel"),
         ]
 
-        for subject in set(graph.subjects()):
-            if not isinstance(subject, URIRef):
-                continue
-            if subject == OWL.Thing:
-                continue
-
+        for subject in self._uri_subjects:
             for predicate, pred_name in label_predicates:
                 # Collect labels by language for this specific predicate
                 labels_by_lang: dict[str | None, list[str]] = defaultdict(list)
@@ -577,7 +563,7 @@ class OntologyLinter:
                                     f"for language '{lang_str}'"
                                 ),
                                 subject_iri=str(subject),
-                                subject_type="class",
+                                subject_type=self._determine_entity_type(graph, subject),
                                 details={
                                     "local_name": self._get_local_name(subject),
                                     "predicate": pred_name,
@@ -1005,12 +991,7 @@ class OntologyLinter:
         """
         issues = []
 
-        for subject in set(graph.subjects()):
-            if not isinstance(subject, URIRef):
-                continue
-            if subject == OWL.Thing:
-                continue
-
+        for subject in self._uri_subjects:
             # Collect all labels
             all_labels = []
             has_english = False
@@ -1036,7 +1017,7 @@ class OntologyLinter:
                         rule_id="missing-english-label",
                         message=f"No English label defined (has labels in: {', '.join(languages)})",
                         subject_iri=str(subject),
-                        subject_type="class",
+                        subject_type=self._determine_entity_type(graph, subject),
                         details={
                             "local_name": self._get_local_name(subject),
                             "available_languages": languages,
@@ -1052,9 +1033,6 @@ class OntologyLinter:
         instead of language-tagged literals.
         """
         issues = []
-
-        DC = Namespace("http://purl.org/dc/elements/1.1/")
-        DCTERMS = Namespace("http://purl.org/dc/terms/")
 
         # Predicates that should typically have language tags
         lang_predicates = [
@@ -1076,12 +1054,7 @@ class OntologyLinter:
             (DCTERMS.description, "dcterms:description"),
         ]
 
-        for subject in set(graph.subjects()):
-            if not isinstance(subject, URIRef):
-                continue
-            if subject == OWL.Thing:
-                continue
-
+        for subject in self._uri_subjects:
             for predicate, pred_name in lang_predicates:
                 for obj in graph.objects(subject, predicate):
                     if not isinstance(obj, RDFLiteral):
@@ -1139,12 +1112,7 @@ class OntologyLinter:
             (DCTERMS.description, "dcterms:description"),
         ]
 
-        for subject in set(graph.subjects()):
-            if not isinstance(subject, URIRef):
-                continue
-            if subject == OWL.Thing:
-                continue
-
+        for subject in self._uri_subjects:
             for predicate, pred_name in predicates:
                 # Group literals by (base_language, value)
                 regional_groups: dict[tuple[str, str], list[str]] = defaultdict(list)
@@ -1161,6 +1129,13 @@ class OntologyLinter:
                         continue
                     sorted_tags = sorted(tags)
                     tag_list = ", ".join(f"@{t}" for t in sorted_tags)
+                    if base_lang in sorted_tags:
+                        # Base tag already present — suggest removing regional variants
+                        regional_only = [t for t in sorted_tags if t != base_lang]
+                        drop_list = ", ".join(f"@{t}" for t in regional_only)
+                        action = f"consider removing {drop_list}"
+                    else:
+                        action = f"consider using @{base_lang} instead"
                     issues.append(
                         LintResult(
                             issue_type=LintIssueType.INFO.value,
@@ -1168,7 +1143,7 @@ class OntologyLinter:
                             message=(
                                 f"Redundant regional variants: {pred_name} "
                                 f'"{value[:80]}" has identical values for '
-                                f"{tag_list} — consider using @{base_lang} instead"
+                                f"{tag_list} — {action}"
                             ),
                             subject_iri=str(subject),
                             subject_type=self._determine_entity_type(graph, subject),
@@ -1194,29 +1169,24 @@ class OntologyLinter:
         issues: list[LintResult] = []
 
         # Determine the ontology's base namespace from the graph
-        base_ns = None
+        base_ns_candidates: set[str] = set()
         for s in graph.subjects(RDF.type, OWL.Ontology):
             if isinstance(s, URIRef):
-                base_ns = str(s).rstrip("/") + "/"
+                stripped = str(s).rstrip("/#")
+                base_ns_candidates.add(stripped + "#")
+                base_ns_candidates.add(stripped + "/")
                 break
 
-        # If no owl:Ontology found, try to infer from the most common namespace
-        if not base_ns:
-            from collections import Counter
-
-            ns_counts: Counter[str] = Counter()
-            for s in graph.subjects():
-                if isinstance(s, URIRef):
-                    iri = str(s)
-                    if "#" in iri:
-                        ns_counts[iri[: iri.rindex("#") + 1]] += 1
-                    elif "/" in iri:
-                        ns_counts[iri[: iri.rindex("/") + 1]] += 1
-            if ns_counts:
-                base_ns = ns_counts.most_common(1)[0][0]
-
-        if not base_ns:
-            return issues
+        base_ns = None
+        if base_ns_candidates:
+            # Pick the candidate that actually contains subjects
+            for candidate in base_ns_candidates:
+                if any(str(subj).startswith(candidate) for subj in self._uri_subjects):
+                    base_ns = candidate
+                    break
+            # Fallback to first candidate if neither matches
+            if not base_ns:
+                base_ns = next(iter(base_ns_candidates))
 
         # Well-known vocabulary namespaces to skip
         skip_prefixes = {
@@ -1232,9 +1202,26 @@ class OntologyLinter:
             "http://xmlns.com/foaf/0.1/",
         }
 
-        for subject in set(graph.subjects()):
-            if not isinstance(subject, URIRef):
-                continue
+        # If no owl:Ontology found, infer from most common namespace
+        if not base_ns:
+            from collections import Counter
+
+            ns_counts: Counter[str] = Counter()
+            for s in self._uri_subjects:
+                iri = str(s)
+                if any(iri.startswith(p) for p in skip_prefixes):
+                    continue
+                if "#" in iri:
+                    ns_counts[iri[: iri.rindex("#") + 1]] += 1
+                elif "/" in iri:
+                    ns_counts[iri[: iri.rindex("/") + 1]] += 1
+            if ns_counts:
+                base_ns = ns_counts.most_common(1)[0][0]
+
+        if not base_ns:
+            return issues
+
+        for subject in self._uri_subjects:
             iri = str(subject)
 
             # Only check IRIs in the ontology's own namespace

--- a/ontokit/services/linter.py
+++ b/ontokit/services/linter.py
@@ -8,7 +8,7 @@ from uuid import UUID
 
 from rdflib import Graph, Namespace, URIRef
 from rdflib import Literal as RDFLiteral
-from rdflib.namespace import OWL, RDF, RDFS
+from rdflib.namespace import OWL, RDF, RDFS, XSD
 
 from ontokit.models.lint import LintIssueType
 
@@ -132,6 +132,12 @@ LINT_RULES: list[LintRuleInfo] = [
         description="Resource has labels but none in English",
         severity=LintIssueType.WARNING.value,
     ),
+    LintRuleInfo(
+        rule_id="missing-language-tag",
+        name="Missing Language Tag",
+        description="Label or annotation has no language tag (plain literal or xsd:string)",
+        severity=LintIssueType.WARNING.value,
+    ),
 ]
 
 # Map rule IDs to their info
@@ -149,6 +155,7 @@ _LEVEL_3_RULES: set[str] = _LEVEL_2_RULES | {
     "empty-label",
     "duplicate-label",
     "missing-english-label",
+    "missing-language-tag",
 }
 _LEVEL_4_RULES: set[str] = _LEVEL_3_RULES | {"missing-comment", "label-per-language"}
 _LEVEL_5_RULES: set[str] = {r.rule_id for r in LINT_RULES}
@@ -975,6 +982,67 @@ class OntologyLinter:
                         },
                     )
                 )
+
+        return issues
+
+    async def _check_missing_language_tag(self, graph: Graph) -> list[LintResult]:
+        """
+        Find label/annotation predicates with plain literals or xsd:string
+        instead of language-tagged literals.
+        """
+        issues = []
+        SKOS = Namespace("http://www.w3.org/2004/02/skos/core#")
+        DC = Namespace("http://purl.org/dc/elements/1.1/")
+        DCTERMS = Namespace("http://purl.org/dc/terms/")
+
+        # Predicates that should typically have language tags
+        lang_predicates = [
+            (RDFS.label, "rdfs:label"),
+            (RDFS.comment, "rdfs:comment"),
+            (SKOS.prefLabel, "skos:prefLabel"),
+            (SKOS.altLabel, "skos:altLabel"),
+            (SKOS.hiddenLabel, "skos:hiddenLabel"),
+            (SKOS.definition, "skos:definition"),
+            (SKOS.note, "skos:note"),
+            (SKOS.scopeNote, "skos:scopeNote"),
+            (SKOS.historyNote, "skos:historyNote"),
+            (SKOS.editorialNote, "skos:editorialNote"),
+            (SKOS.changeNote, "skos:changeNote"),
+            (SKOS.example, "skos:example"),
+            (DC.title, "dc:title"),
+            (DC.description, "dc:description"),
+            (DCTERMS.title, "dcterms:title"),
+            (DCTERMS.description, "dcterms:description"),
+        ]
+
+        for class_uri in graph.subjects(RDF.type, OWL.Class):
+            if not isinstance(class_uri, URIRef):
+                continue
+            if class_uri == OWL.Thing:
+                continue
+
+            for predicate, pred_name in lang_predicates:
+                for obj in graph.objects(class_uri, predicate):
+                    if not isinstance(obj, RDFLiteral):
+                        continue
+                    # Flag if no language tag: plain literal or explicit xsd:string
+                    if obj.language is None:
+                        datatype_note = ""
+                        if obj.datatype == XSD.string:
+                            datatype_note = " (typed as xsd:string)"
+                        issues.append(
+                            LintResult(
+                                issue_type=LintIssueType.WARNING.value,
+                                rule_id="missing-language-tag",
+                                message=(f"{pred_name} has no language tag{datatype_note}"),
+                                subject_iri=str(class_uri),
+                                details={
+                                    "local_name": self._get_local_name(class_uri),
+                                    "predicate": pred_name,
+                                    "value": str(obj)[:100],
+                                },
+                            )
+                        )
 
         return issues
 

--- a/ontokit/services/linter.py
+++ b/ontokit/services/linter.py
@@ -1020,14 +1020,14 @@ class OntologyLinter:
             (DCTERMS.description, "dcterms:description"),
         ]
 
-        for class_uri in graph.subjects(RDF.type, OWL.Class):
-            if not isinstance(class_uri, URIRef):
+        for subject in set(graph.subjects()):
+            if not isinstance(subject, URIRef):
                 continue
-            if class_uri == OWL.Thing:
+            if subject == OWL.Thing:
                 continue
 
             for predicate, pred_name in lang_predicates:
-                for obj in graph.objects(class_uri, predicate):
+                for obj in graph.objects(subject, predicate):
                     if not isinstance(obj, RDFLiteral):
                         continue
                     # Flag if no language tag: plain literal or explicit xsd:string
@@ -1040,9 +1040,9 @@ class OntologyLinter:
                                 issue_type=LintIssueType.WARNING.value,
                                 rule_id="missing-language-tag",
                                 message=(f"{pred_name} has no language tag{datatype_note}"),
-                                subject_iri=str(class_uri),
+                                subject_iri=str(subject),
                                 details={
-                                    "local_name": self._get_local_name(class_uri),
+                                    "local_name": self._get_local_name(subject),
                                     "predicate": pred_name,
                                     "value": str(obj)[:100],
                                 },

--- a/ontokit/services/linter.py
+++ b/ontokit/services/linter.py
@@ -137,6 +137,55 @@ LINT_RULES: list[LintRuleInfo] = [
 # Map rule IDs to their info
 LINT_RULES_MAP: dict[str, LintRuleInfo] = {rule.rule_id: rule for rule in LINT_RULES}
 
+# Progressive lint levels — each level includes all rules from previous levels
+LINT_LEVELS: dict[int, set[str]] = {
+    1: {"undefined-parent", "circular-hierarchy", "undefined-prefix"},
+    2: {
+        "undefined-parent",
+        "circular-hierarchy",
+        "undefined-prefix",
+        "orphan-class",
+        "duplicate-triple",
+        "disjoint-violation",
+    },
+    3: {
+        "undefined-parent",
+        "circular-hierarchy",
+        "undefined-prefix",
+        "orphan-class",
+        "duplicate-triple",
+        "disjoint-violation",
+        "missing-label",
+        "empty-label",
+        "duplicate-label",
+        "missing-english-label",
+    },
+    4: {
+        "undefined-parent",
+        "circular-hierarchy",
+        "undefined-prefix",
+        "orphan-class",
+        "duplicate-triple",
+        "disjoint-violation",
+        "missing-label",
+        "empty-label",
+        "duplicate-label",
+        "missing-english-label",
+        "missing-comment",
+        "label-per-language",
+    },
+    5: {r.rule_id for r in LINT_RULES},
+}
+
+ALL_RULE_IDS: set[str] = {r.rule_id for r in LINT_RULES}
+
+
+def get_rules_for_level(level: int) -> set[str]:
+    """Return the set of rule IDs enabled at a given lint level (1-5)."""
+    if level < 1 or level > 5:
+        raise ValueError(f"Lint level must be between 1 and 5, got {level}")
+    return LINT_LEVELS[level].copy()
+
 
 @dataclass
 class OntologyLinter:

--- a/ontokit/services/linter.py
+++ b/ontokit/services/linter.py
@@ -156,8 +156,9 @@ _LEVEL_3_RULES: set[str] = _LEVEL_2_RULES | {
     "duplicate-label",
     "missing-english-label",
     "missing-language-tag",
+    "missing-comment",
 }
-_LEVEL_4_RULES: set[str] = _LEVEL_3_RULES | {"missing-comment", "label-per-language"}
+_LEVEL_4_RULES: set[str] = _LEVEL_3_RULES | {"label-per-language"}
 _LEVEL_5_RULES: set[str] = {r.rule_id for r in LINT_RULES}
 
 LINT_LEVELS: dict[int, set[str]] = {

--- a/ontokit/services/linter.py
+++ b/ontokit/services/linter.py
@@ -167,6 +167,13 @@ LINT_RULES: list[LintRuleInfo] = [
         severity=LintIssueType.INFO.value,
         scope=_ALL,
     ),
+    LintRuleInfo(
+        rule_id="missing-type-declaration",
+        name="Missing Type Declaration",
+        description="Resource has no rdf:type declaration (not declared as class, property, or individual)",
+        severity=LintIssueType.WARNING.value,
+        scope=_ALL,
+    ),
 ]
 
 # Map rule IDs to their info
@@ -178,6 +185,7 @@ _LEVEL_2_RULES: set[str] = _LEVEL_1_RULES | {
     "orphan-class",
     "duplicate-triple",
     "disjoint-violation",
+    "missing-type-declaration",
 }
 _LEVEL_3_RULES: set[str] = _LEVEL_2_RULES | {
     "missing-label",
@@ -1173,6 +1181,85 @@ class OntologyLinter:
                             },
                         )
                     )
+
+        return issues
+
+    async def _check_missing_type_declaration(self, graph: Graph) -> list[LintResult]:
+        """
+        Find resources that appear as subjects but have no rdf:type declaration.
+
+        Only checks IRIs in the ontology's own namespace — external vocabulary
+        terms (OWL, RDF, RDFS, XSD, SKOS, DC, etc.) are skipped.
+        """
+        issues: list[LintResult] = []
+
+        # Determine the ontology's base namespace from the graph
+        base_ns = None
+        for s in graph.subjects(RDF.type, OWL.Ontology):
+            if isinstance(s, URIRef):
+                base_ns = str(s).rstrip("/") + "/"
+                break
+
+        # If no owl:Ontology found, try to infer from the most common namespace
+        if not base_ns:
+            from collections import Counter
+
+            ns_counts: Counter[str] = Counter()
+            for s in graph.subjects():
+                if isinstance(s, URIRef):
+                    iri = str(s)
+                    if "#" in iri:
+                        ns_counts[iri[: iri.rindex("#") + 1]] += 1
+                    elif "/" in iri:
+                        ns_counts[iri[: iri.rindex("/") + 1]] += 1
+            if ns_counts:
+                base_ns = ns_counts.most_common(1)[0][0]
+
+        if not base_ns:
+            return issues
+
+        # Well-known vocabulary namespaces to skip
+        skip_prefixes = {
+            str(OWL),
+            str(RDF),
+            str(RDFS),
+            str(XSD),
+            str(SKOS),
+            "http://purl.org/dc/elements/1.1/",
+            "http://purl.org/dc/terms/",
+            "http://www.w3.org/ns/prov#",
+            "http://www.w3.org/2006/time#",
+            "http://xmlns.com/foaf/0.1/",
+        }
+
+        for subject in set(graph.subjects()):
+            if not isinstance(subject, URIRef):
+                continue
+            iri = str(subject)
+
+            # Only check IRIs in the ontology's own namespace
+            if not iri.startswith(base_ns):
+                continue
+
+            # Skip if it's a well-known vocabulary term
+            if any(iri.startswith(prefix) for prefix in skip_prefixes):
+                continue
+
+            # Check for rdf:type
+            types = list(graph.objects(subject, RDF.type))
+            if not types:
+                issues.append(
+                    LintResult(
+                        issue_type=LintIssueType.WARNING.value,
+                        rule_id="missing-type-declaration",
+                        message="Resource has no rdf:type declaration",
+                        subject_iri=iri,
+                        subject_type="other",
+                        details={
+                            "local_name": self._get_local_name(subject),
+                        },
+                    )
+                )
 
         return issues
 

--- a/ontokit/services/linter.py
+++ b/ontokit/services/linter.py
@@ -2,6 +2,7 @@
 
 import contextlib
 from collections import defaultdict
+from collections.abc import Set as AbstractSet
 from dataclasses import dataclass, field
 from typing import Any, NamedTuple
 from uuid import UUID
@@ -36,7 +37,7 @@ class LintRuleInfo:
     name: str
     description: str
     severity: str
-    scope: list[str] = field(default_factory=lambda: ["class"])
+    scope: list[str]
 
 
 # Scope constants for rule applicability
@@ -252,18 +253,20 @@ LINT_LEVEL_DEFINITIONS: dict[int, LintLevelDefinition] = {
 }
 
 
-def get_rules_for_level(level: int) -> set[str]:
-    """Return the set of rule IDs enabled at a given lint level (1-5)."""
+def get_rules_for_level(level: int) -> frozenset[str]:
+    """Return the immutable set of rule IDs enabled at a given lint level (1-5)."""
     if level < 1 or level > 5:
         raise ValueError(f"Lint level must be between 1 and 5, got {level}")
-    return set(LINT_LEVELS[level])
+    return LINT_LEVELS[level]
 
 
 @dataclass
 class OntologyLinter:
     """Service for checking ontology health and finding issues."""
 
-    enabled_rules: set[str] = field(default_factory=lambda: {r.rule_id for r in LINT_RULES})
+    enabled_rules: AbstractSet[str] = field(
+        default_factory=lambda: frozenset(r.rule_id for r in LINT_RULES)
+    )
     _uri_subjects: set[URIRef] = field(default_factory=set, init=False, repr=False)
 
     def get_enabled_rules(self) -> list[LintRuleInfo]:
@@ -584,7 +587,11 @@ class OntologyLinter:
 
                 for label in graph.objects(subject, predicate):
                     if isinstance(label, RDFLiteral):
-                        labels_by_lang[label.language].append(str(label))
+                        # Normalize language tag to lowercase for case-insensitive
+                        # comparison (BCP-47: tags are case-insensitive). Matches the
+                        # normalization used by `redundant-regional-label`.
+                        lang_key = label.language.lower() if label.language else None
+                        labels_by_lang[lang_key].append(str(label))
 
                 # Check for multiple different labels per language within this predicate
                 for lang, label_values in labels_by_lang.items():
@@ -647,7 +654,7 @@ class OntologyLinter:
                                 rule_id="undefined-prefix",
                                 message=f"Prefix '{prefix}' is not defined",
                                 subject_iri=iri,
-                                subject_type="other",
+                                subject_type=self._determine_entity_type(graph, term),
                                 details={
                                     "prefix": prefix,
                                     "iri": iri,
@@ -1321,7 +1328,7 @@ class OntologyLinter:
         return None
 
 
-def get_linter(enabled_rules: set[str] | None = None) -> OntologyLinter:
+def get_linter(enabled_rules: AbstractSet[str] | None = None) -> OntologyLinter:
     """
     Get an ontology linter instance.
 

--- a/ontokit/services/ontology.py
+++ b/ontokit/services/ontology.py
@@ -98,6 +98,7 @@ ANNOTATION_PROPERTIES = {
     # SKOS
     "skos:prefLabel": SKOS.prefLabel,
     "skos:altLabel": SKOS.altLabel,
+    "skos:hiddenLabel": SKOS.hiddenLabel,
     "skos:definition": SKOS.definition,
     "skos:notation": SKOS.notation,
     "skos:example": SKOS.example,

--- a/ontokit/services/ontology.py
+++ b/ontokit/services/ontology.py
@@ -51,6 +51,7 @@ LABEL_PROPERTY_MAP = {
     "rdfs:label": RDFS.label,
     "skos:prefLabel": SKOS.prefLabel,
     "skos:altLabel": SKOS.altLabel,
+    "skos:hiddenLabel": SKOS.hiddenLabel,
     "dcterms:title": URIRef("http://purl.org/dc/terms/title"),
     "dc:title": URIRef("http://purl.org/dc/elements/1.1/title"),
 }

--- a/ontokit/worker.py
+++ b/ontokit/worker.py
@@ -198,6 +198,7 @@ async def run_ontology_index_task(
 async def run_lint_task(
     ctx: dict[str, Any],
     project_id: str,
+    branch: str = "main",
 ) -> dict[str, Any]:
     """
     Background task to lint an ontology project.
@@ -205,6 +206,7 @@ async def run_lint_task(
     Args:
         ctx: ARQ context with db session and services
         project_id: The project UUID to lint
+        branch: The git branch to lint (default: "main")
 
     Returns:
         Dict with run_id and issues_found
@@ -216,15 +218,21 @@ async def run_lint_task(
     run: LintRun | None = None
 
     try:
-        # Verify project exists and get its details
-        result = await db.execute(select(Project).where(Project.id == project_uuid))
+        # Verify project exists (eagerly load github_integration for file path)
+        result = await db.execute(
+            select(Project)
+            .options(selectinload(Project.github_integration))
+            .where(Project.id == project_uuid)
+        )
         project = result.scalar_one_or_none()
 
         if not project:
             raise ValueError(f"Project {project_id} not found")
 
-        if not project.source_file_path:
+        if not project.source_file_path and not project.github_integration:
             raise ValueError(f"Project {project_id} has no ontology file")
+
+        filename = get_git_ontology_path(project)
 
         # Create lint run record
         run = LintRun(
@@ -244,14 +252,19 @@ async def run_lint_task(
             f'{{"type": "lint_started", "project_id": "{project_id}", "run_id": "{run_id}"}}',
         )
 
-        # Load ontology from storage
+        # Load ontology from git or storage
         storage = get_storage_service()
         ontology_service = get_ontology_service(storage)
 
-        graph = await ontology_service.load_from_storage(
-            project_uuid,
-            project.source_file_path,
-        )
+        git_service = BareGitRepositoryService()
+        if git_service.repository_exists(project_uuid):
+            graph = await ontology_service.load_from_git(
+                project_uuid, branch, filename, git_service
+            )
+        elif project.source_file_path:
+            graph = await ontology_service.load_from_storage(project_uuid, project.source_file_path)
+        else:
+            raise ValueError(f"Project {project_id} has no git repository and no storage file")
 
         # Load per-project lint configuration
         config_result = await db.execute(

--- a/ontokit/worker.py
+++ b/ontokit/worker.py
@@ -273,6 +273,7 @@ async def run_lint_task(
                 rule_id=lint_result.rule_id,
                 message=lint_result.message,
                 subject_iri=lint_result.subject_iri,
+                subject_type=lint_result.subject_type,
                 details=lint_result.details,
             )
             db.add(issue)

--- a/ontokit/worker.py
+++ b/ontokit/worker.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+from collections.abc import Set as AbstractSet
 from datetime import UTC, datetime
 from typing import Any
 from uuid import UUID
@@ -263,15 +264,15 @@ async def run_lint_task(
                 project_uuid, branch, filename, git_service
             )
         elif project.source_file_path:
-            graph = await ontology_service.load_from_storage(project_uuid, project.source_file_path)
+            graph = await ontology_service.load_from_storage(
+                project_uuid, project.source_file_path, branch
+            )
         else:
             raise ValueError(f"Project {project_id} has no git repository and no storage file")
 
         # Load per-project lint configuration. Tolerate the table being absent
         # (migration not yet applied) by falling back to all rules; let any
         # other SQL error propagate.
-        from collections.abc import Set as AbstractSet
-
         enabled_rules: AbstractSet[str] | None
         try:
             config_result = await db.execute(

--- a/ontokit/worker.py
+++ b/ontokit/worker.py
@@ -23,6 +23,7 @@ from ontokit.core.constants import (
 from ontokit.core.encryption import decrypt_token
 from ontokit.git.bare_repository import BareGitRepositoryService
 from ontokit.models.lint import LintIssue, LintRun, LintRunStatus
+from ontokit.models.lint_config import ProjectLintConfig
 from ontokit.models.project import Project, get_git_ontology_path
 from ontokit.models.pull_request import GitHubIntegration
 from ontokit.models.user_github_token import UserGitHubToken
@@ -252,8 +253,15 @@ async def run_lint_task(
             project.source_file_path,
         )
 
+        # Load per-project lint configuration
+        config_result = await db.execute(
+            select(ProjectLintConfig).where(ProjectLintConfig.project_id == project_uuid)
+        )
+        lint_config = config_result.scalar_one_or_none()
+        enabled_rules = lint_config.get_enabled_rule_ids() if lint_config else None
+
         # Run linting
-        linter = get_linter()
+        linter = get_linter(enabled_rules=enabled_rules)
         lint_results: list[LintResult] = await linter.lint(graph, project_uuid)
 
         # Save issues to database

--- a/ontokit/worker.py
+++ b/ontokit/worker.py
@@ -268,7 +268,8 @@ async def run_lint_task(
             raise ValueError(f"Project {project_id} has no git repository and no storage file")
 
         # Load per-project lint configuration. Tolerate the table being absent
-        # (migration not yet applied) by falling back to all rules.
+        # (migration not yet applied) by falling back to all rules; let any
+        # other SQL error propagate.
         from collections.abc import Set as AbstractSet
 
         enabled_rules: AbstractSet[str] | None
@@ -278,7 +279,11 @@ async def run_lint_task(
             )
             lint_config = config_result.scalar_one_or_none()
             enabled_rules = lint_config.get_enabled_rule_ids() if lint_config else None
-        except ProgrammingError:
+        except ProgrammingError as e:
+            # 42P01 = undefined_table. Re-raise anything else (syntax errors,
+            # missing columns, permission failures, ...) so we don't mask bugs.
+            if getattr(e.orig, "pgcode", None) != "42P01":
+                raise
             logger.warning(
                 "project_lint_configs table not found; using all lint rules. "
                 "Run `alembic upgrade head` to enable per-project lint configuration."

--- a/ontokit/worker.py
+++ b/ontokit/worker.py
@@ -9,6 +9,7 @@ from uuid import UUID
 from arq import ArqRedis, cron, func
 from arq.connections import RedisSettings
 from sqlalchemy import select
+from sqlalchemy.exc import ProgrammingError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.orm import selectinload
 
@@ -266,12 +267,24 @@ async def run_lint_task(
         else:
             raise ValueError(f"Project {project_id} has no git repository and no storage file")
 
-        # Load per-project lint configuration
-        config_result = await db.execute(
-            select(ProjectLintConfig).where(ProjectLintConfig.project_id == project_uuid)
-        )
-        lint_config = config_result.scalar_one_or_none()
-        enabled_rules = lint_config.get_enabled_rule_ids() if lint_config else None
+        # Load per-project lint configuration. Tolerate the table being absent
+        # (migration not yet applied) by falling back to all rules.
+        from collections.abc import Set as AbstractSet
+
+        enabled_rules: AbstractSet[str] | None
+        try:
+            config_result = await db.execute(
+                select(ProjectLintConfig).where(ProjectLintConfig.project_id == project_uuid)
+            )
+            lint_config = config_result.scalar_one_or_none()
+            enabled_rules = lint_config.get_enabled_rule_ids() if lint_config else None
+        except ProgrammingError:
+            logger.warning(
+                "project_lint_configs table not found; using all lint rules. "
+                "Run `alembic upgrade head` to enable per-project lint configuration."
+            )
+            await db.rollback()
+            enabled_rules = None
 
         # Run linting
         linter = get_linter(enabled_rules=enabled_rules)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,11 @@ ignore = ["E501"]
 [tool.ruff.lint.isort]
 known-first-party = ["ontokit"]
 
+[tool.pyright]
+venvPath = "."
+venv = ".venv"
+pythonVersion = "3.11"
+
 [tool.mypy]
 python_version = "3.11"
 strict = true

--- a/tests/unit/test_lint_config.py
+++ b/tests/unit/test_lint_config.py
@@ -11,6 +11,7 @@ Covers:
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 from uuid import uuid4
 
@@ -146,6 +147,14 @@ class TestProjectLintConfigModel:
         config = self._make_config(enabled_rules="")
         result = config.get_enabled_rule_ids()
         assert result is None
+
+    def test_repr(self) -> None:
+        """__repr__ includes project_id and lint_level."""
+        config = self._make_config(lint_level=3)
+        config.project_id = PROJECT_ID
+        result = ProjectLintConfig.__repr__(config)
+        assert "lint_level=3" in result
+        assert PROJECT_ID in result
 
 
 # ---------------------------------------------------------------------------
@@ -393,6 +402,31 @@ class TestUpdateLintConfig:
         assert data["enabled_rules"] is None
         # Effective rules should be all rules when config is reset
         assert set(data["effective_rules"]) == ALL_RULE_IDS
+
+    @patch("ontokit.api.routes.lint.get_project_service")
+    def test_manage_access_forbidden_for_editor(
+        self,
+        mock_get_svc: MagicMock,
+        authed_client: tuple[TestClient, AsyncMock],
+    ) -> None:
+        """Returns 403 when user has editor role (admin/owner required)."""
+        client, mock_session = authed_client
+
+        mock_svc = AsyncMock()
+        mock_svc.get.return_value = SimpleNamespace(user_role="editor")
+        mock_get_svc.return_value = mock_svc
+
+        mock_project = Mock()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = mock_project
+        mock_session.execute.return_value = mock_result
+
+        response = client.put(
+            f"/api/v1/projects/{PROJECT_ID}/lint/config",
+            json={"lint_level": 1},
+        )
+        assert response.status_code == 403
+        assert "admin access required" in response.json()["detail"].lower()
 
     def test_lint_level_validation_too_low(
         self,

--- a/tests/unit/test_lint_config.py
+++ b/tests/unit/test_lint_config.py
@@ -708,6 +708,31 @@ class TestClearLintResults:
         mock_session.commit.assert_awaited()
 
     @patch("ontokit.api.routes.lint.verify_project_access", new_callable=AsyncMock)
+    def test_clear_excludes_in_progress_runs(
+        self,
+        mock_access: AsyncMock,
+        authed_client: tuple[TestClient, AsyncMock],
+    ) -> None:
+        """The DELETE statement must filter out pending/running runs so the
+        worker can finish updating them."""
+        from ontokit.models.lint import LintRunStatus
+
+        client, mock_session = authed_client
+        mock_access.return_value = Mock()
+
+        response = client.delete(f"/api/v1/projects/{PROJECT_ID}/lint/results")
+        assert response.status_code == 204
+
+        # Inspect the DELETE statement compiled by SQLAlchemy. Only terminal
+        # statuses should appear in the WHERE clause.
+        executed_stmt = mock_session.execute.await_args.args[0]
+        compiled = str(executed_stmt.compile(compile_kwargs={"literal_binds": True})).lower()
+        assert LintRunStatus.COMPLETED.value in compiled
+        assert LintRunStatus.FAILED.value in compiled
+        assert LintRunStatus.PENDING.value not in compiled
+        assert LintRunStatus.RUNNING.value not in compiled
+
+    @patch("ontokit.api.routes.lint.verify_project_access", new_callable=AsyncMock)
     def test_clear_propagates_403_from_auth(
         self,
         mock_access: AsyncMock,

--- a/tests/unit/test_lint_config.py
+++ b/tests/unit/test_lint_config.py
@@ -1,0 +1,490 @@
+"""Tests for per-project lint configuration (issue #26).
+
+Covers:
+- Lint level presets and get_rules_for_level()
+- ProjectLintConfig model logic (get_enabled_rule_ids)
+- GET / PUT /api/v1/projects/{id}/lint/config endpoints
+- GET /api/v1/projects/lint/levels endpoint
+- Worker integration with per-project lint config
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from ontokit.models.lint_config import ProjectLintConfig
+from ontokit.services.linter import (
+    ALL_RULE_IDS,
+    LINT_LEVELS,
+    LINT_RULES,
+    OntologyLinter,
+    get_linter,
+    get_rules_for_level,
+)
+
+PROJECT_ID = "12345678-1234-5678-1234-567812345678"
+
+
+# ---------------------------------------------------------------------------
+# 1. Lint level presets
+# ---------------------------------------------------------------------------
+
+
+class TestLintLevels:
+    """Tests for progressive lint levels defined in linter.py."""
+
+    def test_level_1_critical_rules(self) -> None:
+        """Level 1 contains only critical structural rules."""
+        rules = get_rules_for_level(1)
+        assert rules == {"undefined-parent", "circular-hierarchy", "undefined-prefix"}
+
+    def test_level_2_includes_level_1(self) -> None:
+        """Level 2 is a superset of level 1."""
+        assert get_rules_for_level(1).issubset(get_rules_for_level(2))
+
+    def test_level_3_includes_level_2(self) -> None:
+        """Level 3 is a superset of level 2."""
+        assert get_rules_for_level(2).issubset(get_rules_for_level(3))
+
+    def test_level_4_includes_level_3(self) -> None:
+        """Level 4 is a superset of level 3."""
+        assert get_rules_for_level(3).issubset(get_rules_for_level(4))
+
+    def test_level_5_is_all_rules(self) -> None:
+        """Level 5 contains every defined rule."""
+        assert get_rules_for_level(5) == ALL_RULE_IDS
+
+    def test_all_rule_ids_matches_lint_rules(self) -> None:
+        """ALL_RULE_IDS matches the set of rule_id from LINT_RULES."""
+        assert {r.rule_id for r in LINT_RULES} == ALL_RULE_IDS
+
+    def test_invalid_level_low(self) -> None:
+        """get_rules_for_level raises ValueError for level < 1."""
+        with pytest.raises(ValueError, match="between 1 and 5"):
+            get_rules_for_level(0)
+
+    def test_invalid_level_high(self) -> None:
+        """get_rules_for_level raises ValueError for level > 5."""
+        with pytest.raises(ValueError, match="between 1 and 5"):
+            get_rules_for_level(6)
+
+    def test_get_rules_returns_copy(self) -> None:
+        """get_rules_for_level returns a copy, not the original set."""
+        rules = get_rules_for_level(1)
+        rules.add("fake-rule")
+        assert "fake-rule" not in LINT_LEVELS[1]
+
+    def test_each_level_has_more_rules(self) -> None:
+        """Each successive level has strictly more rules than the previous."""
+        for lvl in range(1, 5):
+            assert len(get_rules_for_level(lvl)) < len(get_rules_for_level(lvl + 1))
+
+
+# ---------------------------------------------------------------------------
+# 2. ProjectLintConfig model logic
+# ---------------------------------------------------------------------------
+
+
+class TestProjectLintConfigModel:
+    """Tests for ProjectLintConfig.get_enabled_rule_ids()."""
+
+    @staticmethod
+    def _make_config(
+        lint_level: int | None = None,
+        enabled_rules: str | None = None,
+    ) -> Mock:
+        """Create a Mock that behaves like ProjectLintConfig for testing logic."""
+        config = Mock(spec=ProjectLintConfig)
+        config.lint_level = lint_level
+        config.enabled_rules = enabled_rules
+        # Use the real implementation
+        config.get_enabled_rule_ids = lambda: ProjectLintConfig.get_enabled_rule_ids(config)
+        return config
+
+    def test_no_config_returns_none(self) -> None:
+        """When neither lint_level nor enabled_rules is set, returns None (= all rules)."""
+        config = self._make_config()
+        assert config.get_enabled_rule_ids() is None
+
+    def test_lint_level_returns_level_rules(self) -> None:
+        """When lint_level is set, returns the rules for that level."""
+        config = self._make_config(lint_level=2)
+        result = config.get_enabled_rule_ids()
+        assert result == get_rules_for_level(2)
+
+    def test_enabled_rules_returns_valid_subset(self) -> None:
+        """When enabled_rules is a comma string, returns the valid rule IDs."""
+        config = self._make_config(enabled_rules="missing-label,orphan-class")
+        result = config.get_enabled_rule_ids()
+        assert result == {"missing-label", "orphan-class"}
+
+    def test_enabled_rules_filters_invalid(self) -> None:
+        """Invalid rule IDs in enabled_rules are filtered out."""
+        config = self._make_config(enabled_rules="missing-label,bogus-rule")
+        result = config.get_enabled_rule_ids()
+        assert result == {"missing-label"}
+
+    def test_lint_level_takes_precedence(self) -> None:
+        """When both lint_level and enabled_rules are set, lint_level wins."""
+        config = self._make_config(lint_level=1, enabled_rules="missing-label")
+        result = config.get_enabled_rule_ids()
+        assert result == get_rules_for_level(1)
+
+    def test_enabled_rules_whitespace_handling(self) -> None:
+        """Extra whitespace in enabled_rules is trimmed correctly."""
+        config = self._make_config(enabled_rules=" missing-label , orphan-class ")
+        result = config.get_enabled_rule_ids()
+        assert result == {"missing-label", "orphan-class"}
+
+    def test_empty_enabled_rules_string(self) -> None:
+        """An empty enabled_rules string returns empty set."""
+        config = self._make_config(enabled_rules="")
+        result = config.get_enabled_rule_ids()
+        assert result == set()
+
+
+# ---------------------------------------------------------------------------
+# 3. GET /api/v1/projects/{id}/lint/config
+# ---------------------------------------------------------------------------
+
+
+class TestGetLintConfig:
+    """Tests for GET /api/v1/projects/{id}/lint/config."""
+
+    @patch("ontokit.api.routes.lint.verify_project_access", new_callable=AsyncMock)
+    def test_no_config_returns_all_rules(
+        self,
+        mock_access: AsyncMock,
+        authed_client: tuple[TestClient, AsyncMock],
+    ) -> None:
+        """When no config exists, returns all rules as effective."""
+        client, mock_session = authed_client
+        mock_access.return_value = Mock()
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        mock_session.execute.return_value = mock_result
+
+        response = client.get(f"/api/v1/projects/{PROJECT_ID}/lint/config")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["project_id"] == PROJECT_ID
+        assert data["lint_level"] is None
+        assert data["enabled_rules"] is None
+        assert set(data["effective_rules"]) == ALL_RULE_IDS
+
+    @patch("ontokit.api.routes.lint.verify_project_access", new_callable=AsyncMock)
+    def test_config_with_level(
+        self,
+        mock_access: AsyncMock,
+        authed_client: tuple[TestClient, AsyncMock],
+    ) -> None:
+        """When config has a lint_level, returns level rules as effective."""
+        client, mock_session = authed_client
+        mock_access.return_value = Mock()
+
+        now = datetime.now(UTC)
+        mock_config = Mock()
+        mock_config.lint_level = 2
+        mock_config.enabled_rules = None
+        mock_config.updated_at = now
+        mock_config.get_enabled_rule_ids.return_value = get_rules_for_level(2)
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = mock_config
+        mock_session.execute.return_value = mock_result
+
+        response = client.get(f"/api/v1/projects/{PROJECT_ID}/lint/config")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["lint_level"] == 2
+        assert set(data["effective_rules"]) == get_rules_for_level(2)
+
+    @patch("ontokit.api.routes.lint.verify_project_access", new_callable=AsyncMock)
+    def test_config_with_custom_rules(
+        self,
+        mock_access: AsyncMock,
+        authed_client: tuple[TestClient, AsyncMock],
+    ) -> None:
+        """When config has enabled_rules, returns those as effective."""
+        client, mock_session = authed_client
+        mock_access.return_value = Mock()
+
+        now = datetime.now(UTC)
+        mock_config = Mock()
+        mock_config.lint_level = None
+        mock_config.enabled_rules = "missing-label,orphan-class"
+        mock_config.updated_at = now
+        mock_config.get_enabled_rule_ids.return_value = {"missing-label", "orphan-class"}
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = mock_config
+        mock_session.execute.return_value = mock_result
+
+        response = client.get(f"/api/v1/projects/{PROJECT_ID}/lint/config")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["lint_level"] is None
+        assert set(data["enabled_rules"]) == {"missing-label", "orphan-class"}
+        assert set(data["effective_rules"]) == {"missing-label", "orphan-class"}
+
+
+# ---------------------------------------------------------------------------
+# 4. PUT /api/v1/projects/{id}/lint/config
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateLintConfig:
+    """Tests for PUT /api/v1/projects/{id}/lint/config."""
+
+    @patch("ontokit.api.routes.lint.verify_project_access", new_callable=AsyncMock)
+    def test_set_lint_level(
+        self,
+        mock_access: AsyncMock,
+        authed_client: tuple[TestClient, AsyncMock],
+    ) -> None:
+        """Setting lint_level creates a new config and returns level rules."""
+        client, mock_session = authed_client
+        mock_access.return_value = Mock()
+
+        # No existing config
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        mock_session.execute.return_value = mock_result
+
+        # After commit+refresh, mock the config object
+        now = datetime.now(UTC)
+
+        async def _refresh(obj: object) -> None:
+            obj.updated_at = now  # type: ignore[attr-defined]
+            obj.get_enabled_rule_ids = Mock(return_value=get_rules_for_level(3))  # type: ignore[attr-defined]
+
+        mock_session.refresh = AsyncMock(side_effect=_refresh)
+
+        response = client.put(
+            f"/api/v1/projects/{PROJECT_ID}/lint/config",
+            json={"lint_level": 3},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["lint_level"] == 3
+        assert set(data["effective_rules"]) == get_rules_for_level(3)
+
+    @patch("ontokit.api.routes.lint.verify_project_access", new_callable=AsyncMock)
+    def test_set_custom_rules(
+        self,
+        mock_access: AsyncMock,
+        authed_client: tuple[TestClient, AsyncMock],
+    ) -> None:
+        """Setting enabled_rules creates a config with those specific rules."""
+        client, mock_session = authed_client
+        mock_access.return_value = Mock()
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        mock_session.execute.return_value = mock_result
+
+        now = datetime.now(UTC)
+
+        async def _refresh(obj: object) -> None:
+            obj.updated_at = now  # type: ignore[attr-defined]
+            obj.get_enabled_rule_ids = Mock(  # type: ignore[attr-defined]
+                return_value={"missing-label", "orphan-class"}
+            )
+
+        mock_session.refresh = AsyncMock(side_effect=_refresh)
+
+        response = client.put(
+            f"/api/v1/projects/{PROJECT_ID}/lint/config",
+            json={"enabled_rules": ["missing-label", "orphan-class"]},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert set(data["effective_rules"]) == {"missing-label", "orphan-class"}
+
+    @patch("ontokit.api.routes.lint.verify_project_access", new_callable=AsyncMock)
+    def test_invalid_rule_ids_rejected(
+        self,
+        mock_access: AsyncMock,
+        authed_client: tuple[TestClient, AsyncMock],
+    ) -> None:
+        """Unknown rule IDs return 422."""
+        client, mock_session = authed_client
+        mock_access.return_value = Mock()
+
+        response = client.put(
+            f"/api/v1/projects/{PROJECT_ID}/lint/config",
+            json={"enabled_rules": ["missing-label", "totally-fake-rule"]},
+        )
+        assert response.status_code == 422
+        assert "totally-fake-rule" in response.json()["detail"]
+
+    @patch("ontokit.api.routes.lint.verify_project_access", new_callable=AsyncMock)
+    def test_update_existing_config(
+        self,
+        mock_access: AsyncMock,
+        authed_client: tuple[TestClient, AsyncMock],
+    ) -> None:
+        """Updating an existing config modifies the record."""
+        client, mock_session = authed_client
+        mock_access.return_value = Mock()
+
+        now = datetime.now(UTC)
+        existing = Mock()
+        existing.lint_level = 1
+        existing.enabled_rules = None
+        existing.updated_at = now
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = existing
+        mock_session.execute.return_value = mock_result
+
+        async def _refresh(obj: object) -> None:
+            obj.updated_at = now  # type: ignore[attr-defined]
+            obj.get_enabled_rule_ids = Mock(return_value=get_rules_for_level(4))  # type: ignore[attr-defined]
+
+        mock_session.refresh = AsyncMock(side_effect=_refresh)
+
+        response = client.put(
+            f"/api/v1/projects/{PROJECT_ID}/lint/config",
+            json={"lint_level": 4},
+        )
+        assert response.status_code == 200
+        assert existing.lint_level == 4
+
+    @patch("ontokit.api.routes.lint.verify_project_access", new_callable=AsyncMock)
+    def test_reset_config(
+        self,
+        mock_access: AsyncMock,
+        authed_client: tuple[TestClient, AsyncMock],
+    ) -> None:
+        """Setting both to null resets to all rules."""
+        client, mock_session = authed_client
+        mock_access.return_value = Mock()
+
+        now = datetime.now(UTC)
+        existing = Mock()
+        existing.lint_level = 2
+        existing.enabled_rules = "missing-label"
+        existing.updated_at = now
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = existing
+        mock_session.execute.return_value = mock_result
+
+        async def _refresh(obj: object) -> None:
+            obj.updated_at = now  # type: ignore[attr-defined]
+            obj.get_enabled_rule_ids = Mock(return_value=None)  # type: ignore[attr-defined]
+
+        mock_session.refresh = AsyncMock(side_effect=_refresh)
+
+        response = client.put(
+            f"/api/v1/projects/{PROJECT_ID}/lint/config",
+            json={"lint_level": None, "enabled_rules": None},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["lint_level"] is None
+        assert data["enabled_rules"] is None
+        # Effective rules should be all rules when config is reset
+        assert set(data["effective_rules"]) == ALL_RULE_IDS
+
+    def test_lint_level_validation_too_low(
+        self,
+        authed_client: tuple[TestClient, AsyncMock],
+    ) -> None:
+        """lint_level < 1 is rejected by Pydantic validation."""
+        client, _ = authed_client
+        response = client.put(
+            f"/api/v1/projects/{PROJECT_ID}/lint/config",
+            json={"lint_level": 0},
+        )
+        assert response.status_code == 422
+
+    def test_lint_level_validation_too_high(
+        self,
+        authed_client: tuple[TestClient, AsyncMock],
+    ) -> None:
+        """lint_level > 5 is rejected by Pydantic validation."""
+        client, _ = authed_client
+        response = client.put(
+            f"/api/v1/projects/{PROJECT_ID}/lint/config",
+            json={"lint_level": 6},
+        )
+        assert response.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# 5. GET /api/v1/projects/lint/levels
+# ---------------------------------------------------------------------------
+
+
+class TestGetLintLevels:
+    """Tests for GET /api/v1/projects/lint/levels."""
+
+    def test_returns_all_five_levels(self, client: TestClient) -> None:
+        """Returns information about all 5 lint levels."""
+        response = client.get("/api/v1/projects/lint/levels")
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["levels"]) == 5
+        levels = {lvl["level"] for lvl in data["levels"]}
+        assert levels == {1, 2, 3, 4, 5}
+
+    def test_level_info_structure(self, client: TestClient) -> None:
+        """Each level has name, description, and rule_ids."""
+        response = client.get("/api/v1/projects/lint/levels")
+        data = response.json()
+        for level in data["levels"]:
+            assert "level" in level
+            assert "name" in level
+            assert "description" in level
+            assert "rule_ids" in level
+            assert isinstance(level["rule_ids"], list)
+            assert len(level["rule_ids"]) > 0
+
+    def test_level_5_has_all_rules(self, client: TestClient) -> None:
+        """Level 5 includes all available rules."""
+        response = client.get("/api/v1/projects/lint/levels")
+        data = response.json()
+        level_5 = next(lvl for lvl in data["levels"] if lvl["level"] == 5)
+        assert set(level_5["rule_ids"]) == ALL_RULE_IDS
+
+
+# ---------------------------------------------------------------------------
+# 6. Linter integration with config
+# ---------------------------------------------------------------------------
+
+
+class TestLinterWithConfig:
+    """Tests that the linter correctly uses per-project config."""
+
+    async def test_linter_with_level_1_only_checks_critical(self) -> None:
+        """Linter configured with level 1 rules only checks those rules."""
+        rules = get_rules_for_level(1)
+        linter = get_linter(enabled_rules=rules)
+        assert linter.enabled_rules == rules
+
+    async def test_linter_with_custom_subset(self) -> None:
+        """Linter configured with a custom rule set only runs those."""
+        from rdflib import Graph, Namespace
+        from rdflib.namespace import OWL, RDF
+
+        EX = Namespace("http://example.org/")
+        g = Graph()
+        g.add((EX.Lonely, RDF.type, OWL.Class))
+        # This class has no label, no comment, and is orphaned
+
+        # Only enable missing-label
+        linter = OntologyLinter(enabled_rules={"missing-label"})
+        issues = await linter.lint(g, uuid4())
+
+        rule_ids = {i.rule_id for i in issues}
+        assert "missing-label" in rule_ids
+        assert "orphan-class" not in rule_ids
+        assert "missing-comment" not in rule_ids

--- a/tests/unit/test_lint_config.py
+++ b/tests/unit/test_lint_config.py
@@ -74,10 +74,12 @@ class TestLintLevels:
         with pytest.raises(ValueError, match="between 1 and 5"):
             get_rules_for_level(6)
 
-    def test_get_rules_returns_copy(self) -> None:
-        """get_rules_for_level returns a copy, not the original set."""
+    def test_get_rules_is_immutable(self) -> None:
+        """get_rules_for_level returns a frozenset so callers cannot mutate the source."""
         rules = get_rules_for_level(1)
-        rules.add("fake-rule")
+        assert isinstance(rules, frozenset)
+        with pytest.raises(AttributeError):
+            rules.add("fake-rule")  # type: ignore[attr-defined]
         assert "fake-rule" not in LINT_LEVELS[1]
 
     def test_each_level_has_more_rules(self) -> None:
@@ -256,13 +258,10 @@ class TestUpdateLintConfig:
         mock_session: AsyncMock,
         config_after: Mock,
     ) -> None:
-        """Configure mock session for upsert flow (execute upsert, commit, re-fetch)."""
-        # First execute: upsert statement (returns nothing meaningful)
+        """Configure mock session for upsert flow (single execute via RETURNING + commit)."""
         upsert_result = MagicMock()
-        # Second execute: re-fetch after commit
-        refetch_result = MagicMock()
-        refetch_result.scalar_one.return_value = config_after
-        mock_session.execute.side_effect = [upsert_result, refetch_result]
+        upsert_result.scalar_one.return_value = config_after
+        mock_session.execute.return_value = upsert_result
 
     @patch("ontokit.api.routes.lint.verify_project_access", new_callable=AsyncMock)
     def test_set_lint_level(
@@ -331,6 +330,23 @@ class TestUpdateLintConfig:
             json={"enabled_rules": ["missing-label", "totally-fake-rule"]},
         )
         assert response.status_code == 422
+
+    def test_lint_level_and_enabled_rules_together_rejected(
+        self,
+        authed_client: tuple[TestClient, AsyncMock],
+    ) -> None:
+        """Setting both lint_level and enabled_rules is contradictory and must be
+        rejected. Presets are immutable, so the two modes are mutually exclusive."""
+        client, _ = authed_client
+
+        response = client.put(
+            f"/api/v1/projects/{PROJECT_ID}/lint/config",
+            json={"lint_level": 3, "enabled_rules": ["missing-label"]},
+        )
+        assert response.status_code == 422
+        body = response.json()
+        # Confirm the error is the XOR validator, not unrelated noise.
+        assert "mutually exclusive" in str(body).lower()
 
     @patch("ontokit.api.routes.lint.verify_project_access", new_callable=AsyncMock)
     def test_update_existing_config(
@@ -535,3 +551,208 @@ class TestLinterWithConfig:
         assert "missing-label" in rule_ids
         assert "orphan-class" not in rule_ids
         assert "missing-comment" not in rule_ids
+
+    async def test_empty_enabled_rules_disables_linting(self) -> None:
+        """An explicit empty rule set must disable linting completely.
+
+        End-to-end check on the path: PUT enabled_rules=[] persists "" in the
+        DB → ProjectLintConfig.get_enabled_rule_ids() returns set() → worker
+        passes set() to get_linter() → linter produces 0 issues.
+
+        Without this, the empty-set semantics are only proved at the model
+        layer; the worker could silently fall back to "all rules" and the
+        bug wouldn't surface in unit tests.
+        """
+        from rdflib import Graph, Namespace
+        from rdflib.namespace import OWL, RDF, RDFS
+
+        EX = Namespace("http://example.org/")
+        g = Graph()
+        # A graph that would normally fire many rules: orphan, no label,
+        # no comment, undefined parent, etc.
+        g.add((EX.Orphan, RDF.type, OWL.Class))
+        g.add((EX.Bad, RDF.type, OWL.Class))
+        g.add((EX.Bad, RDFS.subClassOf, EX.UndefinedParent))
+
+        # Simulate the resolution chain: model → set() → worker → linter
+        config = ProjectLintConfig()
+        config.enabled_rules = ""  # PUT with enabled_rules=[]
+        config.lint_level = None
+        rules = ProjectLintConfig.get_enabled_rule_ids(config)
+        assert rules == set(), "model must resolve empty string to empty set"
+
+        linter = get_linter(enabled_rules=rules)
+        issues = await linter.lint(g, uuid4())
+        assert issues == [], "empty rule set must produce zero issues"
+
+
+# ---------------------------------------------------------------------------
+# 7. Auth gating: require_manage and require_write
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyProjectAccess:
+    """Direct unit tests for verify_project_access role gating.
+
+    Existing route tests mock verify_project_access entirely, so the new
+    require_manage parameter introduced by this PR is otherwise untested.
+    Editor and viewer must be rejected; admin and owner must pass.
+    """
+
+    @pytest.fixture
+    def mock_db(self) -> AsyncMock:
+        session = AsyncMock()
+        # Project lookup returns a real-looking object
+        project = SimpleNamespace(id=uuid4())
+        execute_result = MagicMock()
+        execute_result.scalar_one_or_none.return_value = project
+        session.execute = AsyncMock(return_value=execute_result)
+        return session
+
+    async def _call_with_role(
+        self,
+        mock_db: AsyncMock,
+        role: str | None,
+        *,
+        require_manage: bool = False,
+        require_write: bool = False,
+    ) -> object:
+        from ontokit.api.routes.lint import verify_project_access
+        from ontokit.core.auth import CurrentUser
+
+        user = CurrentUser(id="u1", email="u@example.com", name="U", username="u", roles=[])
+
+        # Mock get_project_service to return a service whose .get yields
+        # a project_response with the requested user_role.
+        with patch("ontokit.api.routes.lint.get_project_service") as mock_factory:
+            service = AsyncMock()
+            service.get = AsyncMock(return_value=SimpleNamespace(user_role=role))
+            mock_factory.return_value = service
+
+            return await verify_project_access(
+                project_id=uuid4(),
+                db=mock_db,
+                user=user,
+                require_write=require_write,
+                require_manage=require_manage,
+            )
+
+    @pytest.mark.parametrize("role", ["owner", "admin"])
+    async def test_require_manage_allows_owner_and_admin(
+        self, mock_db: AsyncMock, role: str
+    ) -> None:
+        """Owner and admin pass require_manage gating."""
+        result = await self._call_with_role(mock_db, role, require_manage=True)
+        assert result is not None  # returns the Project model
+
+    @pytest.mark.parametrize("role", ["editor", "suggester", "viewer", None])
+    async def test_require_manage_rejects_non_admins(
+        self, mock_db: AsyncMock, role: str | None
+    ) -> None:
+        """Editor, suggester, viewer, and no-role users are rejected with 403."""
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc_info:
+            await self._call_with_role(mock_db, role, require_manage=True)
+        assert exc_info.value.status_code == 403
+        assert "admin" in exc_info.value.detail.lower()
+
+    @pytest.mark.parametrize("role", ["owner", "admin", "editor"])
+    async def test_require_write_allows_writers(self, mock_db: AsyncMock, role: str) -> None:
+        """Owner, admin, and editor pass require_write gating."""
+        result = await self._call_with_role(mock_db, role, require_write=True)
+        assert result is not None
+
+    @pytest.mark.parametrize("role", ["suggester", "viewer", None])
+    async def test_require_write_rejects_non_writers(
+        self, mock_db: AsyncMock, role: str | None
+    ) -> None:
+        """Suggester, viewer, and no-role are rejected by require_write."""
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc_info:
+            await self._call_with_role(mock_db, role, require_write=True)
+        assert exc_info.value.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# 8. Clear lint results endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestClearLintResults:
+    """Tests for DELETE /api/v1/projects/{id}/lint/results.
+
+    This is a destructive admin-only endpoint that this PR introduces with
+    zero coverage. We test happy-path 204 and that the auth gate is wired
+    through with require_manage=True.
+    """
+
+    @patch("ontokit.api.routes.lint.verify_project_access", new_callable=AsyncMock)
+    def test_clear_succeeds_for_admin(
+        self,
+        mock_access: AsyncMock,
+        authed_client: tuple[TestClient, AsyncMock],
+    ) -> None:
+        """Successful clear returns 204 and issues a DELETE on lint_runs."""
+        client, mock_session = authed_client
+        mock_access.return_value = Mock()
+
+        response = client.delete(f"/api/v1/projects/{PROJECT_ID}/lint/results")
+
+        assert response.status_code == 204
+        # Ensure the auth check requested manage-level access.
+        assert mock_access.call_args.kwargs.get("require_manage") is True
+        # Ensure a DELETE statement was executed against the DB.
+        assert mock_session.execute.await_count >= 1
+        mock_session.commit.assert_awaited()
+
+    @patch("ontokit.api.routes.lint.verify_project_access", new_callable=AsyncMock)
+    def test_clear_propagates_403_from_auth(
+        self,
+        mock_access: AsyncMock,
+        authed_client: tuple[TestClient, AsyncMock],
+    ) -> None:
+        """When verify_project_access raises 403, the route returns 403 and
+        does not commit any deletes."""
+        from fastapi import HTTPException
+
+        client, mock_session = authed_client
+        mock_access.side_effect = HTTPException(status_code=403, detail="Admin access required")
+
+        response = client.delete(f"/api/v1/projects/{PROJECT_ID}/lint/results")
+
+        assert response.status_code == 403
+        mock_session.commit.assert_not_awaited()
+
+    def test_clear_requires_authentication(self) -> None:
+        """Unauthenticated callers cannot clear lint results."""
+        from ontokit.core.auth import get_current_user
+        from ontokit.core.database import get_db
+        from ontokit.main import app
+
+        async def _no_user() -> None:
+            from fastapi import HTTPException
+
+            raise HTTPException(status_code=401, detail="Not authenticated")
+
+        async def _no_db():  # type: ignore[no-untyped-def]
+            yield AsyncMock()
+
+        original_app_override_get_current_user = app.dependency_overrides.get(get_current_user)
+        original_app_override_get_db = app.dependency_overrides.get(get_db)
+        app.dependency_overrides[get_current_user] = _no_user
+        app.dependency_overrides[get_db] = _no_db
+        try:
+            client = TestClient(app, raise_server_exceptions=False)
+            response = client.delete(f"/api/v1/projects/{PROJECT_ID}/lint/results")
+            assert response.status_code == 401
+        finally:
+            if original_app_override_get_current_user is None:
+                del app.dependency_overrides[get_current_user]
+            else:
+                app.dependency_overrides[get_current_user] = original_app_override_get_current_user
+            if original_app_override_get_db is None:
+                del app.dependency_overrides[get_db]
+            else:
+                app.dependency_overrides[get_db] = original_app_override_get_db

--- a/tests/unit/test_lint_config.py
+++ b/tests/unit/test_lint_config.py
@@ -143,10 +143,10 @@ class TestProjectLintConfigModel:
         assert result == {"missing-label", "orphan-class"}
 
     def test_empty_enabled_rules_string(self) -> None:
-        """An empty enabled_rules string is treated as no config (all rules)."""
+        """An empty enabled_rules string means explicitly 'no rules' (empty set)."""
         config = self._make_config(enabled_rules="")
         result = config.get_enabled_rule_ids()
-        assert result is None
+        assert result == set()
 
     def test_repr(self) -> None:
         """__repr__ includes project_id and lint_level."""
@@ -251,29 +251,37 @@ class TestGetLintConfig:
 class TestUpdateLintConfig:
     """Tests for PUT /api/v1/projects/{id}/lint/config."""
 
+    @staticmethod
+    def _mock_upsert_session(
+        mock_session: AsyncMock,
+        config_after: Mock,
+    ) -> None:
+        """Configure mock session for upsert flow (execute upsert, commit, re-fetch)."""
+        # First execute: upsert statement (returns nothing meaningful)
+        upsert_result = MagicMock()
+        # Second execute: re-fetch after commit
+        refetch_result = MagicMock()
+        refetch_result.scalar_one.return_value = config_after
+        mock_session.execute.side_effect = [upsert_result, refetch_result]
+
     @patch("ontokit.api.routes.lint.verify_project_access", new_callable=AsyncMock)
     def test_set_lint_level(
         self,
         mock_access: AsyncMock,
         authed_client: tuple[TestClient, AsyncMock],
     ) -> None:
-        """Setting lint_level creates a new config and returns level rules."""
+        """Setting lint_level creates/updates config and returns level rules."""
         client, mock_session = authed_client
         mock_access.return_value = Mock()
 
-        # No existing config
-        mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = None
-        mock_session.execute.return_value = mock_result
-
-        # After commit+refresh, mock the config object
         now = datetime.now(UTC)
+        config_after = Mock()
+        config_after.lint_level = 3
+        config_after.enabled_rules = None
+        config_after.updated_at = now
+        config_after.get_enabled_rule_ids.return_value = get_rules_for_level(3)
 
-        async def _refresh(obj: object) -> None:
-            obj.updated_at = now  # type: ignore[attr-defined]
-            obj.get_enabled_rule_ids = Mock(return_value=get_rules_for_level(3))  # type: ignore[attr-defined]
-
-        mock_session.refresh = AsyncMock(side_effect=_refresh)
+        self._mock_upsert_session(mock_session, config_after)
 
         response = client.put(
             f"/api/v1/projects/{PROJECT_ID}/lint/config",
@@ -294,19 +302,14 @@ class TestUpdateLintConfig:
         client, mock_session = authed_client
         mock_access.return_value = Mock()
 
-        mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = None
-        mock_session.execute.return_value = mock_result
-
         now = datetime.now(UTC)
+        config_after = Mock()
+        config_after.lint_level = None
+        config_after.enabled_rules = "missing-label,orphan-class"
+        config_after.updated_at = now
+        config_after.get_enabled_rule_ids.return_value = {"missing-label", "orphan-class"}
 
-        async def _refresh(obj: object) -> None:
-            obj.updated_at = now  # type: ignore[attr-defined]
-            obj.get_enabled_rule_ids = Mock(  # type: ignore[attr-defined]
-                return_value={"missing-label", "orphan-class"}
-            )
-
-        mock_session.refresh = AsyncMock(side_effect=_refresh)
+        self._mock_upsert_session(mock_session, config_after)
 
         response = client.put(
             f"/api/v1/projects/{PROJECT_ID}/lint/config",
@@ -316,22 +319,18 @@ class TestUpdateLintConfig:
         data = response.json()
         assert set(data["effective_rules"]) == {"missing-label", "orphan-class"}
 
-    @patch("ontokit.api.routes.lint.verify_project_access", new_callable=AsyncMock)
     def test_invalid_rule_ids_rejected(
         self,
-        mock_access: AsyncMock,
         authed_client: tuple[TestClient, AsyncMock],
     ) -> None:
-        """Unknown rule IDs return 422."""
-        client, mock_session = authed_client
-        mock_access.return_value = Mock()
+        """Unknown rule IDs return 422 via Pydantic schema validation."""
+        client, _ = authed_client
 
         response = client.put(
             f"/api/v1/projects/{PROJECT_ID}/lint/config",
             json={"enabled_rules": ["missing-label", "totally-fake-rule"]},
         )
         assert response.status_code == 422
-        assert "totally-fake-rule" in response.json()["detail"]
 
     @patch("ontokit.api.routes.lint.verify_project_access", new_callable=AsyncMock)
     def test_update_existing_config(
@@ -339,32 +338,27 @@ class TestUpdateLintConfig:
         mock_access: AsyncMock,
         authed_client: tuple[TestClient, AsyncMock],
     ) -> None:
-        """Updating an existing config modifies the record."""
+        """Updating an existing config uses upsert and returns new state."""
         client, mock_session = authed_client
         mock_access.return_value = Mock()
 
         now = datetime.now(UTC)
-        existing = Mock()
-        existing.lint_level = 1
-        existing.enabled_rules = None
-        existing.updated_at = now
+        config_after = Mock()
+        config_after.lint_level = 4
+        config_after.enabled_rules = None
+        config_after.updated_at = now
+        config_after.get_enabled_rule_ids.return_value = get_rules_for_level(4)
 
-        mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = existing
-        mock_session.execute.return_value = mock_result
-
-        async def _refresh(obj: object) -> None:
-            obj.updated_at = now  # type: ignore[attr-defined]
-            obj.get_enabled_rule_ids = Mock(return_value=get_rules_for_level(4))  # type: ignore[attr-defined]
-
-        mock_session.refresh = AsyncMock(side_effect=_refresh)
+        self._mock_upsert_session(mock_session, config_after)
 
         response = client.put(
             f"/api/v1/projects/{PROJECT_ID}/lint/config",
             json={"lint_level": 4},
         )
         assert response.status_code == 200
-        assert existing.lint_level == 4
+        data = response.json()
+        assert data["lint_level"] == 4
+        assert set(data["effective_rules"]) == get_rules_for_level(4)
 
     @patch("ontokit.api.routes.lint.verify_project_access", new_callable=AsyncMock)
     def test_reset_config(
@@ -377,20 +371,13 @@ class TestUpdateLintConfig:
         mock_access.return_value = Mock()
 
         now = datetime.now(UTC)
-        existing = Mock()
-        existing.lint_level = 2
-        existing.enabled_rules = "missing-label"
-        existing.updated_at = now
+        config_after = Mock()
+        config_after.lint_level = None
+        config_after.enabled_rules = None
+        config_after.updated_at = now
+        config_after.get_enabled_rule_ids.return_value = None
 
-        mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = existing
-        mock_session.execute.return_value = mock_result
-
-        async def _refresh(obj: object) -> None:
-            obj.updated_at = now  # type: ignore[attr-defined]
-            obj.get_enabled_rule_ids = Mock(return_value=None)  # type: ignore[attr-defined]
-
-        mock_session.refresh = AsyncMock(side_effect=_refresh)
+        self._mock_upsert_session(mock_session, config_after)
 
         response = client.put(
             f"/api/v1/projects/{PROJECT_ID}/lint/config",
@@ -400,8 +387,34 @@ class TestUpdateLintConfig:
         data = response.json()
         assert data["lint_level"] is None
         assert data["enabled_rules"] is None
-        # Effective rules should be all rules when config is reset
         assert set(data["effective_rules"]) == ALL_RULE_IDS
+
+    @patch("ontokit.api.routes.lint.verify_project_access", new_callable=AsyncMock)
+    def test_set_empty_rules_disables_all(
+        self,
+        mock_access: AsyncMock,
+        authed_client: tuple[TestClient, AsyncMock],
+    ) -> None:
+        """Setting enabled_rules to empty list explicitly disables all rules."""
+        client, mock_session = authed_client
+        mock_access.return_value = Mock()
+
+        now = datetime.now(UTC)
+        config_after = Mock()
+        config_after.lint_level = None
+        config_after.enabled_rules = ""
+        config_after.updated_at = now
+        config_after.get_enabled_rule_ids.return_value = set()
+
+        self._mock_upsert_session(mock_session, config_after)
+
+        response = client.put(
+            f"/api/v1/projects/{PROJECT_ID}/lint/config",
+            json={"enabled_rules": []},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["effective_rules"] == []
 
     @patch("ontokit.api.routes.lint.get_project_service")
     def test_manage_access_forbidden_for_editor(

--- a/tests/unit/test_lint_config.py
+++ b/tests/unit/test_lint_config.py
@@ -142,10 +142,10 @@ class TestProjectLintConfigModel:
         assert result == {"missing-label", "orphan-class"}
 
     def test_empty_enabled_rules_string(self) -> None:
-        """An empty enabled_rules string returns empty set."""
+        """An empty enabled_rules string is treated as no config (all rules)."""
         config = self._make_config(enabled_rules="")
         result = config.get_enabled_rule_ids()
-        assert result == set()
+        assert result is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_lint_routes.py
+++ b/tests/unit/test_lint_routes.py
@@ -86,22 +86,55 @@ class TestTriggerLint:
         assert data["job_id"] == "job-42"
         assert data["status"] == "queued"
 
+    @patch("ontokit.api.routes.lint.BareGitRepositoryService")
     @patch("ontokit.api.routes.lint.verify_project_access", new_callable=AsyncMock)
     def test_trigger_lint_no_ontology_file(
         self,
         mock_access: AsyncMock,
+        mock_git_svc: MagicMock,
         authed_client: tuple[TestClient, AsyncMock],
     ) -> None:
-        """Returns 400 when project has no source file."""
+        """Returns 400 when project has neither source_file_path nor a git repository."""
         client, _ = authed_client
 
         mock_project = Mock()
         mock_project.source_file_path = None
         mock_access.return_value = mock_project
+        mock_git_svc.return_value.repository_exists.return_value = False
 
         response = client.post(f"/api/v1/projects/{PROJECT_ID}/lint/run")
         assert response.status_code == 400
         assert "no ontology file" in response.json()["detail"].lower()
+
+    @patch("ontokit.api.routes.lint.get_arq_pool")
+    @patch("ontokit.api.routes.lint.BareGitRepositoryService")
+    @patch("ontokit.api.routes.lint.verify_project_access", new_callable=AsyncMock)
+    def test_trigger_lint_git_only_project_accepted(
+        self,
+        mock_access: AsyncMock,
+        mock_git_svc: MagicMock,
+        mock_pool_fn: AsyncMock,
+        authed_client: tuple[TestClient, AsyncMock],
+    ) -> None:
+        """Git-backed projects without source_file_path are accepted (worker handles loading)."""
+        client, mock_session = authed_client
+
+        mock_project = Mock()
+        mock_project.source_file_path = None
+        mock_access.return_value = mock_project
+        mock_git_svc.return_value.repository_exists.return_value = True
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        mock_session.execute.return_value = mock_result
+
+        mock_pool = AsyncMock()
+        mock_pool.enqueue_job.return_value = Mock(job_id="job-git-1")
+        mock_pool_fn.return_value = mock_pool
+
+        response = client.post(f"/api/v1/projects/{PROJECT_ID}/lint/run")
+        assert response.status_code == 202
+        assert response.json()["job_id"] == "job-git-1"
 
     @patch("ontokit.api.routes.lint.verify_project_access", new_callable=AsyncMock)
     def test_trigger_lint_already_running(

--- a/tests/unit/test_lint_routes.py
+++ b/tests/unit/test_lint_routes.py
@@ -25,12 +25,14 @@ class TestLintRules:
                 name="Missing label",
                 description="Class has no label",
                 severity="warning",
+                scope=["class", "property", "individual"],
             ),
             SimpleNamespace(
                 rule_id="R002",
                 name="Orphan class",
                 description="Class has no parent",
                 severity="info",
+                scope=["class"],
             ),
         ]
 
@@ -228,6 +230,7 @@ class TestGetLintRun:
         mock_issue.rule_id = "R001"
         mock_issue.message = "Missing label"
         mock_issue.subject_iri = "http://example.org/Foo"
+        mock_issue.subject_type = "class"
         mock_issue.details = None
         mock_issue.created_at = now
         mock_issue.resolved_at = None
@@ -433,6 +436,7 @@ class TestGetLintIssues:
         mock_issue.rule_id = "R010"
         mock_issue.message = "Cyclic dependency"
         mock_issue.subject_iri = "http://example.org/Bar"
+        mock_issue.subject_type = "class"
         mock_issue.details = None
         mock_issue.created_at = now
         mock_issue.resolved_at = None

--- a/tests/unit/test_lint_routes_extended.py
+++ b/tests/unit/test_lint_routes_extended.py
@@ -152,6 +152,7 @@ class TestGetLintIssuesFilters:
         mock_issue.rule_id = "R005"
         mock_issue.message = "Missing comment"
         mock_issue.subject_iri = "http://example.org/Foo"
+        mock_issue.subject_type = "class"
         mock_issue.details = None
         mock_issue.created_at = now
         mock_issue.resolved_at = None
@@ -204,6 +205,7 @@ class TestGetLintIssuesFilters:
         mock_issue.rule_id = "R010"
         mock_issue.message = "Cyclic dependency"
         mock_issue.subject_iri = "http://example.org/SpecificClass"
+        mock_issue.subject_type = "class"
         mock_issue.details = None
         mock_issue.created_at = now
         mock_issue.resolved_at = None

--- a/tests/unit/test_linter.py
+++ b/tests/unit/test_linter.py
@@ -47,6 +47,7 @@ async def test_missing_label() -> None:
     assert len(matches) == 1
     assert matches[0].issue_type == "warning"
     assert matches[0].subject_iri == str(EX.Animal)
+    assert matches[0].subject_type == "class"
 
 
 # ---------------------------------------------------------------------------
@@ -701,6 +702,7 @@ async def test_redundant_regional_label() -> None:
     assert "@es-mx" in matches[0].message
     assert matches[0].details["base_language"] == "es"
     assert sorted(matches[0].details["regional_tags"]) == ["es-es", "es-mx"]
+    assert matches[0].subject_type == "class"
 
 
 async def test_no_redundant_regional_when_values_differ() -> None:
@@ -745,6 +747,9 @@ async def test_redundant_regional_base_and_regional_same_value() -> None:
     assert len(matches) == 1
     assert "@es" in matches[0].message
     assert "@es-es" in matches[0].message
+    # Base tag is present, so message should suggest removing the regional variant
+    assert "consider removing" in matches[0].message
+    assert matches[0].subject_type == "class"
 
 
 async def test_redundant_regional_skips_non_literal_and_untagged() -> None:

--- a/tests/unit/test_linter.py
+++ b/tests/unit/test_linter.py
@@ -731,6 +731,22 @@ async def test_no_redundant_regional_for_base_language() -> None:
     assert len(matches) == 0
 
 
+async def test_redundant_regional_base_and_regional_same_value() -> None:
+    """Base tag @es and regional @es-es with same value triggers the rule."""
+    g = Graph()
+    g.add((EX.Thing, RDF.type, OWL.Class))
+    g.add((EX.Thing, SKOS.altLabel, Literal("Cosa", lang="es")))
+    g.add((EX.Thing, SKOS.altLabel, Literal("Cosa", lang="es-es")))
+
+    linter = OntologyLinter(enabled_rules={"redundant-regional-label"})
+    issues = await linter.lint(g, PROJECT_ID)
+
+    matches = _results_with_rule(issues, "redundant-regional-label")
+    assert len(matches) == 1
+    assert "@es" in matches[0].message
+    assert "@es-es" in matches[0].message
+
+
 async def test_redundant_regional_skips_non_literal_and_untagged() -> None:
     """Non-literal objects and literals without language tags are skipped."""
     g = Graph()

--- a/tests/unit/test_linter.py
+++ b/tests/unit/test_linter.py
@@ -3,7 +3,7 @@
 from uuid import uuid4
 
 from rdflib import BNode, Graph, Literal, Namespace
-from rdflib.namespace import OWL, RDF, RDFS, XSD
+from rdflib.namespace import OWL, RDF, RDFS, SKOS, XSD
 
 from ontokit.services.linter import (
     LINT_RULES,
@@ -534,8 +534,6 @@ async def test_no_missing_english_label_when_present() -> None:
 # ---------------------------------------------------------------------------
 # 18. missing-language-tag
 # ---------------------------------------------------------------------------
-
-SKOS = Namespace("http://www.w3.org/2004/02/skos/core#")
 
 
 async def test_missing_language_tag_plain_literal() -> None:

--- a/tests/unit/test_linter.py
+++ b/tests/unit/test_linter.py
@@ -617,9 +617,8 @@ async def test_bnode_subjects_skipped() -> None:
     linter = OntologyLinter(enabled_rules=rules)
     issues = await linter.lint(g, PROJECT_ID)
 
-    # No issue should reference a BNode IRI
-    for issue in issues:
-        assert issue.subject_iri is None or not issue.subject_iri.startswith("_:")
+    # BNode is the only subject, so no issues should be produced at all
+    assert len(issues) == 0
 
 
 async def test_owl_thing_skipped() -> None:
@@ -641,9 +640,8 @@ async def test_owl_thing_skipped() -> None:
     linter = OntologyLinter(enabled_rules=rules)
     issues = await linter.lint(g, PROJECT_ID)
 
-    owl_thing_iri = str(OWL.Thing)
-    for issue in issues:
-        assert issue.subject_iri != owl_thing_iri
+    # OWL.Thing is the only subject, so no issues should be produced at all
+    assert len(issues) == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_linter.py
+++ b/tests/unit/test_linter.py
@@ -766,3 +766,57 @@ async def test_redundant_regional_skips_non_literal_and_untagged() -> None:
 
     matches = _results_with_rule(issues, "redundant-regional-label")
     assert len(matches) == 0
+
+
+# ---------------------------------------------------------------------------
+# 22. missing-type-declaration
+# ---------------------------------------------------------------------------
+
+
+async def test_missing_type_declaration_with_ontology_iri() -> None:
+    """A subject in the ontology namespace with no rdf:type triggers the rule."""
+    ONT = Namespace("http://example.org/ontology#")
+    g = Graph()
+    g.add((ONT[""], RDF.type, OWL.Ontology))
+    g.add((ONT.Animal, RDF.type, OWL.Class))
+    # Untyped resource in the same namespace
+    g.add((ONT.mystery, RDFS.label, Literal("Mystery", lang="en")))
+
+    linter = OntologyLinter(enabled_rules={"missing-type-declaration"})
+    issues = await linter.lint(g, PROJECT_ID)
+
+    matches = _results_with_rule(issues, "missing-type-declaration")
+    assert len(matches) == 1
+    assert matches[0].subject_iri == str(ONT.mystery)
+
+
+async def test_missing_type_declaration_inferred_namespace() -> None:
+    """Without owl:Ontology, infers namespace from most common prefix."""
+    g = Graph()
+    # No owl:Ontology declaration — must infer namespace
+    g.add((EX.A, RDF.type, OWL.Class))
+    g.add((EX.B, RDF.type, OWL.Class))
+    g.add((EX.C, RDF.type, OWL.Class))
+    # Untyped resource in the same namespace
+    g.add((EX.orphan, RDFS.label, Literal("Orphan", lang="en")))
+
+    linter = OntologyLinter(enabled_rules={"missing-type-declaration"})
+    issues = await linter.lint(g, PROJECT_ID)
+
+    matches = _results_with_rule(issues, "missing-type-declaration")
+    assert len(matches) == 1
+    assert matches[0].subject_iri == str(EX.orphan)
+
+
+async def test_no_missing_type_declaration_when_typed() -> None:
+    """A fully typed ontology should not trigger the rule."""
+    g = Graph()
+    g.add((EX.Animal, RDF.type, OWL.Class))
+    g.add((EX.Dog, RDF.type, OWL.Class))
+    g.add((EX.Dog, RDFS.subClassOf, EX.Animal))
+
+    linter = OntologyLinter(enabled_rules={"missing-type-declaration"})
+    issues = await linter.lint(g, PROJECT_ID)
+
+    matches = _results_with_rule(issues, "missing-type-declaration")
+    assert len(matches) == 0

--- a/tests/unit/test_linter.py
+++ b/tests/unit/test_linter.py
@@ -673,3 +673,57 @@ async def test_no_missing_english_label_skos_preflabel_en() -> None:
 
     matches = _results_with_rule(issues, "missing-english-label")
     assert len(matches) == 0
+
+
+# ---------------------------------------------------------------------------
+# 21. redundant-regional-label
+# ---------------------------------------------------------------------------
+
+
+async def test_redundant_regional_label() -> None:
+    """Identical values across regional variants trigger redundant-regional-label."""
+    g = Graph()
+    g.add((EX.Thing, RDF.type, OWL.Class))
+    g.add((EX.Thing, SKOS.altLabel, Literal("Asignación", lang="es-es")))
+    g.add((EX.Thing, SKOS.altLabel, Literal("Asignación", lang="es-mx")))
+
+    linter = OntologyLinter(enabled_rules={"redundant-regional-label"})
+    issues = await linter.lint(g, PROJECT_ID)
+
+    matches = _results_with_rule(issues, "redundant-regional-label")
+    assert len(matches) == 1
+    assert matches[0].issue_type == "info"
+    assert matches[0].subject_iri == str(EX.Thing)
+    assert matches[0].details is not None
+    assert "@es-es" in matches[0].message
+    assert "@es-mx" in matches[0].message
+    assert matches[0].details["base_language"] == "es"
+    assert sorted(matches[0].details["regional_tags"]) == ["es-es", "es-mx"]
+
+
+async def test_no_redundant_regional_when_values_differ() -> None:
+    """Different values across regional variants do NOT trigger the rule."""
+    g = Graph()
+    g.add((EX.Thing, RDF.type, OWL.Class))
+    g.add((EX.Thing, SKOS.altLabel, Literal("Color", lang="en-us")))
+    g.add((EX.Thing, SKOS.altLabel, Literal("Colour", lang="en-gb")))
+
+    linter = OntologyLinter(enabled_rules={"redundant-regional-label"})
+    issues = await linter.lint(g, PROJECT_ID)
+
+    matches = _results_with_rule(issues, "redundant-regional-label")
+    assert len(matches) == 0
+
+
+async def test_no_redundant_regional_for_base_language() -> None:
+    """A single regional tag or base-only tags do not trigger the rule."""
+    g = Graph()
+    g.add((EX.Thing, RDF.type, OWL.Class))
+    g.add((EX.Thing, RDFS.label, Literal("Thing", lang="en")))
+    g.add((EX.Thing, RDFS.label, Literal("Chose", lang="fr")))
+
+    linter = OntologyLinter(enabled_rules={"redundant-regional-label"})
+    issues = await linter.lint(g, PROJECT_ID)
+
+    matches = _results_with_rule(issues, "redundant-regional-label")
+    assert len(matches) == 0

--- a/tests/unit/test_linter.py
+++ b/tests/unit/test_linter.py
@@ -613,6 +613,7 @@ async def test_bnode_subjects_skipped() -> None:
         "label-per-language",
         "missing-english-label",
         "missing-language-tag",
+        "redundant-regional-label",
     }
     linter = OntologyLinter(enabled_rules=rules)
     issues = await linter.lint(g, PROJECT_ID)
@@ -636,6 +637,7 @@ async def test_owl_thing_skipped() -> None:
         "label-per-language",
         "missing-english-label",
         "missing-language-tag",
+        "redundant-regional-label",
     }
     linter = OntologyLinter(enabled_rules=rules)
     issues = await linter.lint(g, PROJECT_ID)
@@ -721,6 +723,22 @@ async def test_no_redundant_regional_for_base_language() -> None:
     g.add((EX.Thing, RDF.type, OWL.Class))
     g.add((EX.Thing, RDFS.label, Literal("Thing", lang="en")))
     g.add((EX.Thing, RDFS.label, Literal("Chose", lang="fr")))
+
+    linter = OntologyLinter(enabled_rules={"redundant-regional-label"})
+    issues = await linter.lint(g, PROJECT_ID)
+
+    matches = _results_with_rule(issues, "redundant-regional-label")
+    assert len(matches) == 0
+
+
+async def test_redundant_regional_skips_non_literal_and_untagged() -> None:
+    """Non-literal objects and literals without language tags are skipped."""
+    g = Graph()
+    g.add((EX.Thing, RDF.type, OWL.Class))
+    # URIRef as label value (not a literal)
+    g.add((EX.Thing, RDFS.label, EX.SomeURI))
+    # Plain literal without language tag
+    g.add((EX.Thing, RDFS.label, Literal("plain")))
 
     linter = OntologyLinter(enabled_rules={"redundant-regional-label"})
     issues = await linter.lint(g, PROJECT_ID)

--- a/tests/unit/test_linter.py
+++ b/tests/unit/test_linter.py
@@ -2,7 +2,7 @@
 
 from uuid import uuid4
 
-from rdflib import BNode, Graph, Literal, Namespace
+from rdflib import BNode, Graph, Literal, Namespace, URIRef
 from rdflib.namespace import OWL, RDF, RDFS, SKOS, XSD
 
 from ontokit.services.linter import (
@@ -389,6 +389,22 @@ async def test_label_per_language_no_issue_when_same() -> None:
 
     matches = _results_with_rule(issues, "label-per-language")
     assert len(matches) == 0
+
+
+async def test_label_per_language_case_insensitive_lang_tag() -> None:
+    """BCP-47 says language tags are case-insensitive — @en-US and @en-us are the
+    same language and conflicting labels under those tags must be flagged."""
+    g = Graph()
+    g.add((EX.Animal, RDF.type, OWL.Class))
+    g.add((EX.Animal, RDFS.label, Literal("Apple", lang="en-US")))
+    g.add((EX.Animal, RDFS.label, Literal("Banana", lang="en-us")))
+
+    linter = OntologyLinter(enabled_rules={"label-per-language"})
+    issues = await linter.lint(g, PROJECT_ID)
+
+    matches = _results_with_rule(issues, "label-per-language")
+    assert len(matches) == 1
+    assert matches[0].subject_iri == str(EX.Animal)
 
 
 # ---------------------------------------------------------------------------
@@ -818,3 +834,81 @@ async def test_no_missing_type_declaration_when_typed() -> None:
 
     matches = _results_with_rule(issues, "missing-type-declaration")
     assert len(matches) == 0
+
+
+async def test_missing_type_declaration_slash_namespace_ontology() -> None:
+    """Ontology IRI without a trailing separator and slash-style subjects.
+
+    Exercises the candidate-namespace branch that picks ``base + "/"`` over
+    ``base + "#"`` when the actual subjects use slashes.
+    """
+    g = Graph()
+    onto = "http://example.org/myonto"
+    g.add((URIRef(onto), RDF.type, OWL.Ontology))
+    g.add((URIRef(f"{onto}/Animal"), RDF.type, OWL.Class))
+    # Untyped resource in the same slash-namespace
+    g.add((URIRef(f"{onto}/mystery"), RDFS.label, Literal("Mystery", lang="en")))
+
+    linter = OntologyLinter(enabled_rules={"missing-type-declaration"})
+    issues = await linter.lint(g, PROJECT_ID)
+
+    matches = _results_with_rule(issues, "missing-type-declaration")
+    assert len(matches) == 1
+    assert matches[0].subject_iri == f"{onto}/mystery"
+
+
+async def test_missing_type_declaration_inferred_hash_namespace() -> None:
+    """Inferred-namespace branch should pick the ``#``-prefix when subjects use it."""
+    HASH = Namespace("http://example.org/onto#")
+    g = Graph()
+    # No owl:Ontology declaration — namespace must be inferred
+    g.add((HASH.A, RDF.type, OWL.Class))
+    g.add((HASH.B, RDF.type, OWL.Class))
+    # Untyped resource sharing the inferred hash namespace
+    g.add((HASH.orphan, RDFS.label, Literal("Orphan", lang="en")))
+
+    linter = OntologyLinter(enabled_rules={"missing-type-declaration"})
+    issues = await linter.lint(g, PROJECT_ID)
+
+    matches = _results_with_rule(issues, "missing-type-declaration")
+    assert len(matches) == 1
+    assert matches[0].subject_iri == str(HASH.orphan)
+
+
+async def test_missing_type_declaration_inferred_deep_slash_namespace() -> None:
+    """Inferred-namespace branch should pick the deepest ``/``-prefix when no ``#``."""
+    base = "http://example.org/vocab/v1/"
+    g = Graph()
+    g.add((URIRef(f"{base}A"), RDF.type, OWL.Class))
+    g.add((URIRef(f"{base}B"), RDF.type, OWL.Class))
+    g.add((URIRef(f"{base}orphan"), RDFS.label, Literal("Orphan", lang="en")))
+
+    linter = OntologyLinter(enabled_rules={"missing-type-declaration"})
+    issues = await linter.lint(g, PROJECT_ID)
+
+    matches = _results_with_rule(issues, "missing-type-declaration")
+    assert len(matches) == 1
+    assert matches[0].subject_iri == f"{base}orphan"
+
+
+# ---------------------------------------------------------------------------
+# 23. undefined-prefix subject_type
+# ---------------------------------------------------------------------------
+
+
+async def test_undefined_prefix_subject_type_reflects_entity() -> None:
+    """undefined-prefix issues classify the offending term so the frontend
+    can navigate to the right entity panel."""
+    g = Graph()
+    # A class typed via rdf:type but referencing an undefined prefix in its IRI.
+    bad_class = URIRef("undefined:BadClass")
+    g.add((bad_class, RDF.type, OWL.Class))
+
+    linter = OntologyLinter(enabled_rules={"undefined-prefix"})
+    issues = await linter.lint(g, PROJECT_ID)
+
+    matches = [
+        i for i in _results_with_rule(issues, "undefined-prefix") if i.subject_iri == str(bad_class)
+    ]
+    assert matches, "expected an undefined-prefix issue for the bad class IRI"
+    assert matches[0].subject_type == "class"

--- a/tests/unit/test_linter.py
+++ b/tests/unit/test_linter.py
@@ -2,8 +2,8 @@
 
 from uuid import uuid4
 
-from rdflib import Graph, Literal, Namespace
-from rdflib.namespace import OWL, RDF, RDFS
+from rdflib import BNode, Graph, Literal, Namespace
+from rdflib.namespace import OWL, RDF, RDFS, XSD
 
 from ontokit.services.linter import (
     LINT_RULES,
@@ -522,6 +522,153 @@ async def test_no_missing_english_label_when_present() -> None:
     g.add((EX.Thing, RDF.type, OWL.Class))
     g.add((EX.Thing, RDFS.label, Literal("Thing", lang="en")))
     g.add((EX.Thing, RDFS.label, Literal("Chose", lang="fr")))
+
+    linter = OntologyLinter(enabled_rules={"missing-english-label"})
+    issues = await linter.lint(g, PROJECT_ID)
+
+    matches = _results_with_rule(issues, "missing-english-label")
+    assert len(matches) == 0
+
+
+# ---------------------------------------------------------------------------
+# 18. missing-language-tag
+# ---------------------------------------------------------------------------
+
+SKOS = Namespace("http://www.w3.org/2004/02/skos/core#")
+
+
+async def test_missing_language_tag_plain_literal() -> None:
+    """A plain literal without a language tag triggers missing-language-tag."""
+    g = Graph()
+    g.add((EX.Animal, RDF.type, OWL.Class))
+    g.add((EX.Animal, RDFS.label, Literal("Animal")))  # no lang
+
+    linter = OntologyLinter(enabled_rules={"missing-language-tag"})
+    issues = await linter.lint(g, PROJECT_ID)
+
+    matches = _results_with_rule(issues, "missing-language-tag")
+    assert len(matches) == 1
+    assert matches[0].issue_type == "warning"
+    assert matches[0].subject_iri == str(EX.Animal)
+
+
+async def test_missing_language_tag_xsd_string() -> None:
+    """An xsd:string typed literal triggers missing-language-tag with datatype note."""
+    g = Graph()
+    g.add((EX.Animal, RDF.type, OWL.Class))
+    g.add((EX.Animal, RDFS.label, Literal("Animal", datatype=XSD.string)))
+
+    linter = OntologyLinter(enabled_rules={"missing-language-tag"})
+    issues = await linter.lint(g, PROJECT_ID)
+
+    matches = _results_with_rule(issues, "missing-language-tag")
+    assert len(matches) == 1
+    assert "xsd:string" in matches[0].message
+
+
+async def test_no_missing_language_tag_when_present() -> None:
+    """A literal with a language tag does not trigger missing-language-tag."""
+    g = Graph()
+    g.add((EX.Animal, RDF.type, OWL.Class))
+    g.add((EX.Animal, RDFS.label, Literal("Animal", lang="en")))
+
+    linter = OntologyLinter(enabled_rules={"missing-language-tag"})
+    issues = await linter.lint(g, PROJECT_ID)
+
+    matches = _results_with_rule(issues, "missing-language-tag")
+    assert len(matches) == 0
+
+
+async def test_missing_language_tag_non_literal_object_skipped() -> None:
+    """A URIRef object on a label predicate is silently skipped."""
+    g = Graph()
+    g.add((EX.Animal, RDF.type, OWL.Class))
+    g.add((EX.Animal, RDFS.label, EX.SomeURI))  # not a literal
+
+    linter = OntologyLinter(enabled_rules={"missing-language-tag"})
+    issues = await linter.lint(g, PROJECT_ID)
+
+    matches = _results_with_rule(issues, "missing-language-tag")
+    assert len(matches) == 0
+
+
+# ---------------------------------------------------------------------------
+# 19. BNode / OWL.Thing skip branches
+# ---------------------------------------------------------------------------
+
+
+async def test_bnode_subjects_skipped() -> None:
+    """BNode subjects are skipped by all annotation lint rules."""
+    g = Graph()
+    bnode = BNode()
+    g.add((bnode, RDF.type, OWL.Class))
+    g.add((bnode, RDFS.label, Literal("Blank", lang="fr")))
+    g.add((bnode, RDFS.label, Literal("Other", lang="fr")))
+
+    rules = {
+        "missing-label",
+        "missing-comment",
+        "empty-label",
+        "duplicate-label",
+        "label-per-language",
+        "missing-english-label",
+        "missing-language-tag",
+    }
+    linter = OntologyLinter(enabled_rules=rules)
+    issues = await linter.lint(g, PROJECT_ID)
+
+    # No issue should reference a BNode IRI
+    for issue in issues:
+        assert issue.subject_iri is None or not issue.subject_iri.startswith("_:")
+
+
+async def test_owl_thing_skipped() -> None:
+    """OWL.Thing is skipped by all annotation lint rules."""
+    g = Graph()
+    g.add((OWL.Thing, RDF.type, OWL.Class))
+    g.add((OWL.Thing, RDFS.label, Literal("Thing", lang="fr")))
+    g.add((OWL.Thing, RDFS.label, Literal("Chose", lang="fr")))
+
+    rules = {
+        "missing-label",
+        "missing-comment",
+        "empty-label",
+        "duplicate-label",
+        "label-per-language",
+        "missing-english-label",
+        "missing-language-tag",
+    }
+    linter = OntologyLinter(enabled_rules=rules)
+    issues = await linter.lint(g, PROJECT_ID)
+
+    owl_thing_iri = str(OWL.Thing)
+    for issue in issues:
+        assert issue.subject_iri != owl_thing_iri
+
+
+# ---------------------------------------------------------------------------
+# 20. missing-english-label with skos:prefLabel
+# ---------------------------------------------------------------------------
+
+
+async def test_missing_english_label_skos_preflabel() -> None:
+    """A resource with only a non-English skos:prefLabel triggers the rule."""
+    g = Graph()
+    g.add((EX.Chose, RDF.type, OWL.Class))
+    g.add((EX.Chose, SKOS.prefLabel, Literal("Chose", lang="fr")))
+
+    linter = OntologyLinter(enabled_rules={"missing-english-label"})
+    issues = await linter.lint(g, PROJECT_ID)
+
+    matches = _results_with_rule(issues, "missing-english-label")
+    assert len(matches) == 1
+
+
+async def test_no_missing_english_label_skos_preflabel_en() -> None:
+    """An English skos:prefLabel satisfies the rule even without rdfs:label."""
+    g = Graph()
+    g.add((EX.Thing, RDF.type, OWL.Class))
+    g.add((EX.Thing, SKOS.prefLabel, Literal("Thing", lang="en")))
 
     linter = OntologyLinter(enabled_rules={"missing-english-label"})
     issues = await linter.lint(g, PROJECT_ID)

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -312,8 +312,8 @@ class TestRunLintTask:
     async def test_lint_falls_back_when_config_table_missing(
         self, mock_ctx: dict[str, Any], project_id: str
     ) -> None:
-        """If project_lint_configs table is absent (migration not run), the
-        worker logs, rolls back, and falls back to all rules."""
+        """If project_lint_configs table is absent (migration not run, pgcode
+        42P01), the worker logs, rolls back, and falls back to all rules."""
         from sqlalchemy.exc import ProgrammingError
 
         project = Mock()
@@ -322,10 +322,14 @@ class TestRunLintTask:
         project_result = Mock()
         project_result.scalar_one_or_none.return_value = project
 
+        # asyncpg's UndefinedTableError carries pgcode "42P01" on .pgcode;
+        # SQLAlchemy exposes that via ProgrammingError.orig.
+        orig = Mock()
+        orig.pgcode = "42P01"
         # First execute() returns the project; second (lint config lookup) raises.
         mock_ctx["db"].execute.side_effect = [
             project_result,
-            ProgrammingError("relation does not exist", None, Exception("undefined table")),
+            ProgrammingError("relation does not exist", None, orig),
         ]
 
         mock_run = MagicMock()
@@ -347,6 +351,41 @@ class TestRunLintTask:
         mock_ctx["db"].rollback.assert_awaited()
         # Linter must be constructed with enabled_rules=None (= all rules).
         mock_get_linter.assert_called_with(enabled_rules=None)
+
+    @pytest.mark.asyncio
+    async def test_lint_propagates_non_undefined_table_programming_error(
+        self, mock_ctx: dict[str, Any], project_id: str
+    ) -> None:
+        """A ProgrammingError that is *not* undefined_table (42P01) — e.g. a
+        syntax error or missing column — must propagate, not be swallowed."""
+        from sqlalchemy.exc import ProgrammingError
+
+        project = Mock()
+        project.source_file_path = "ontokit/test.ttl"
+
+        project_result = Mock()
+        project_result.scalar_one_or_none.return_value = project
+
+        # 42703 = undefined_column. Should NOT be treated as missing-table.
+        orig = Mock()
+        orig.pgcode = "42703"
+        mock_ctx["db"].execute.side_effect = [
+            project_result,
+            ProgrammingError("column does not exist", None, orig),
+        ]
+
+        mock_run = MagicMock()
+        mock_run.id = uuid.uuid4()
+
+        with (
+            patch("ontokit.worker.get_storage_service"),
+            patch("ontokit.worker.get_ontology_service") as mock_onto_svc,
+            patch("ontokit.worker.LintRun", return_value=mock_run),
+        ):
+            mock_onto_svc.return_value.load_from_storage = AsyncMock(return_value=Mock())
+
+            with pytest.raises(ProgrammingError):
+                await run_lint_task(mock_ctx, project_id)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -227,9 +227,10 @@ class TestRunLintTask:
     async def test_lint_no_source_file_raises(
         self, mock_ctx: dict[str, Any], project_id: str
     ) -> None:
-        """Raises ValueError when the project has no source_file_path."""
+        """Raises ValueError when the project has no source_file_path and no git integration."""
         project = Mock()
         project.source_file_path = None
+        project.github_integration = None
         mock_result = Mock()
         mock_result.scalar_one_or_none.return_value = project
         mock_ctx["db"].execute.return_value = mock_result

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -308,6 +308,46 @@ class TestRunLintTask:
 
         assert mock_ctx["redis"].publish.await_count >= 2
 
+    @pytest.mark.asyncio
+    async def test_lint_falls_back_when_config_table_missing(
+        self, mock_ctx: dict[str, Any], project_id: str
+    ) -> None:
+        """If project_lint_configs table is absent (migration not run), the
+        worker logs, rolls back, and falls back to all rules."""
+        from sqlalchemy.exc import ProgrammingError
+
+        project = Mock()
+        project.source_file_path = "ontokit/test.ttl"
+
+        project_result = Mock()
+        project_result.scalar_one_or_none.return_value = project
+
+        # First execute() returns the project; second (lint config lookup) raises.
+        mock_ctx["db"].execute.side_effect = [
+            project_result,
+            ProgrammingError("relation does not exist", None, Exception("undefined table")),
+        ]
+
+        mock_run = MagicMock()
+        mock_run.id = uuid.uuid4()
+
+        with (
+            patch("ontokit.worker.get_storage_service"),
+            patch("ontokit.worker.get_ontology_service") as mock_onto_svc,
+            patch("ontokit.worker.get_linter") as mock_get_linter,
+            patch("ontokit.worker.LintRun", return_value=mock_run),
+        ):
+            mock_onto_svc.return_value.load_from_storage = AsyncMock(return_value=Mock())
+            mock_get_linter.return_value.lint = AsyncMock(return_value=[])
+
+            result = await run_lint_task(mock_ctx, project_id)
+
+        assert result["status"] == "completed"
+        # The session must be rolled back to clear the failed transaction.
+        mock_ctx["db"].rollback.assert_awaited()
+        # Linter must be constructed with enabled_rules=None (= all rules).
+        mock_get_linter.assert_called_with(enabled_rules=None)
+
 
 # ---------------------------------------------------------------------------
 # Lifecycle hooks


### PR DESCRIPTION
## Summary

- Adds per-project lint configuration so owners/admins can enable/disable specific linting rules or select a progressive lint level (1-5)
- New `project_lint_configs` table, `ProjectLintConfig` model, Pydantic schemas, and API endpoints (`GET`/`PUT` `/api/v1/projects/{id}/lint/config`, `GET /api/v1/projects/lint/levels`)
- Worker (`run_lint_task`) now loads per-project config before running the linter
- Bulk clear lint results endpoint for admin/owner cleanup
- Broadened annotation lint rules (missing-label, missing-comment, empty-label, duplicate-label, label-per-language, missing-english-label, missing-language-tag) to check all URI subjects, not only OWL classes
- New lint rule: `missing-language-tag` — detects plain literals or xsd:string without language tags
- New lint rule: `redundant-regional-label` — detects identical values across regional language variants (e.g., @es-es and @es-mx)
- Adds `skos:hiddenLabel` to backend annotation extraction and `LABEL_PROPERTY_MAP`
- Lint issue results now include `subject_type` for entity-aware frontend navigation
- Immutable rule sets (`frozenset`) prevent accidental mutation of level definitions
- Module-level SKOS import replaces repeated in-function declarations

### Progressive Lint Levels
| Level | Name | Rules |
|-------|------|-------|
| 1 | Critical | `undefined-parent`, `circular-hierarchy`, `undefined-prefix` |
| 2 | Consistency | + `orphan-class`, `duplicate-triple`, `disjoint-violation` |
| 3 | Labels | + `missing-label`, `empty-label`, `duplicate-label`, `missing-english-label`, `missing-language-tag` |
| 4 | Quality | + `missing-comment`, `label-per-language`, `redundant-regional-label` |
| 5 | All | + `domain-violation`, `range-violation`, `cardinality-violation`, `inverse-property-inconsistency` (all 18 rules) |

Closes #26
Closes #95
Closes #96
Closes #97

## Test plan
- [x] New unit tests in `tests/unit/test_lint_config.py`, `tests/unit/test_linter.py`, and `tests/unit/test_worker.py` (XOR validator, namespace-heuristic # vs /, undefined-prefix entity typing, ProgrammingError fallback)
- [x] All 1499 tests pass
- [x] mypy strict mode passes on all changed files
- [x] ruff lint + format clean
- [x] Multiple rounds of CodeRabbit review findings addressed
- [x] Deferred review findings cleaned up on `fix/pr-94-blockers` (M1: RETURNING upsert, M2: ProgrammingError fallback, M3: drop frozenset→set cast, M4: namespace heuristic tests, M5: entity-aware undefined-prefix; L1/L3/L5 nits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-project persisted lint config (GET/PUT) with computed effective rules and upsert
  * Admin-only endpoint to clear a project's terminal lint results
  * Endpoint listing progressive lint levels and included rules
  * Lint runs can load from a git branch and respect per-project config
  * API responses now include issue entity type and rule applicability scope

* **Enhancements**
  * New lint checks: missing language tags, redundant regional labels, missing type declarations
  * Improved duplicate-triple and label handling; skos:hiddenLabel recognized

* **Bug Fixes**
  * WebSocket teardown now properly closes pubsub connections

* **Tests**
  * Expanded coverage for config, levels, new rules, endpoints, and worker behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

