### PR TITLE
chore(packaging): add Python 3.13 trove classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 


### PR DESCRIPTION
## Summary

- Adds `\"Programming Language :: Python :: 3.13\"` to `pyproject.toml` classifiers so PyPI metadata matches reality (project has been on 3.13 since 095b351).
- Leaves `requires-python = \">=3.11\"` untouched. 3.11/3.12 remain nominally supported per the install constraint even though only 3.13 is exercised in CI.

Closes #102

## Open question (out of scope here)

Whether to bump the floor to `requires-python = \">=3.13\"` and drop the 3.11/3.12 classifiers — current CI doesn't actually verify 3.11/3.12 compatibility, so the support claim is aspirational. Suggest tracking that as a follow-up rather than bundling here.

## Test plan
- [x] `uv run python -c \"import ontokit\"` (sanity)
- [x] No code changed; pre-commit hooks skip ruff/mypy on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)