### PR TITLE
fix(embeddings): replace :name::vector with CAST() so bindparams resolve

### DIFF
--- a/ontokit/main.py
+++ b/ontokit/main.py
@@ -334,6 +334,27 @@ async def rate_limit_handler(_request: Request, exc: RateLimitExceeded) -> JSONR
     return response
 
 
+@app.exception_handler(Exception)
+async def unhandled_exception_handler(_request: Request, exc: Exception) -> JSONResponse:
+    """Convert any uncaught exception into a CORS-allowed JSON 500.
+
+    Without this, an exception that escapes every other handler propagates to
+    Starlette's ServerErrorMiddleware, which sits *outside* CORSMiddleware. The
+    resulting response goes out without ``Access-Control-Allow-Origin``, so the
+    browser blocks it before the frontend can read the status. The frontend
+    sees an opaque "CORS error" instead of a parseable 500, masking the real
+    cause (and the real bug).
+
+    In development we re-raise so Starlette's debug traceback page still shows;
+    staging and production return a structured JSON envelope matching the rest
+    of the error contract.
+    """
+    logger.exception("Unhandled exception", exc_info=exc)
+    if settings.is_development:
+        raise exc
+    return _error_response(500, "internal_server_error", "Internal server error")
+
+
 # --- Routers ---------------------------------------------------------------
 
 app.include_router(api_router, prefix="/api/v1")

--- a/ontokit/services/embedding_service.py
+++ b/ontokit/services/embedding_service.py
@@ -4,7 +4,7 @@ import base64
 import hashlib
 import logging
 from datetime import UTC, datetime
-from typing import cast
+from typing import Protocol, cast, runtime_checkable
 from uuid import UUID
 
 from cryptography.fernet import Fernet
@@ -58,17 +58,29 @@ def _decrypt_secret(ciphertext: str) -> str:
     return _get_fernet().decrypt(ciphertext.encode()).decode()
 
 
-def _vec_to_str(vec: list[float] | object) -> str:
+@runtime_checkable
+class _HasToList(Protocol):
+    """Anything that exposes a ``tolist()`` method returning a list of floats.
+
+    Matches numpy's ``ndarray.tolist()`` and torch tensors' equivalent
+    without pulling either library into the dependency surface here.
+    """
+
+    def tolist(self) -> list[float]: ...
+
+
+def _vec_to_str(vec: list[float] | _HasToList) -> str:
     """Convert an embedding vector to a pgvector-compatible string.
 
-    Accepts either a Python ``list[float]`` (newly-embedded queries) or a
-    numpy array (what pgvector deserializes column reads into). pgvector's
-    text input format is ``[v1,v2,...]`` — space-separated values are
-    rejected. ``str(list)`` produces commas; ``str(np.ndarray)`` produces
-    spaces. Normalize via ``.tolist()`` so the output is always pgvector-
-    parseable regardless of the input source.
+    Accepts either a Python ``list[float]`` (newly-embedded queries) or any
+    object exposing ``tolist()`` — typically a numpy array, which is what
+    pgvector deserializes ``Vector`` column reads into. pgvector's text input
+    format is ``[v1,v2,...]``: space-separated values are rejected.
+    ``str(list)`` produces commas; ``str(np.ndarray)`` produces spaces.
+    Normalize via ``.tolist()`` so the output is always pgvector-parseable
+    regardless of the input source.
     """
-    if hasattr(vec, "tolist"):
+    if isinstance(vec, _HasToList):
         vec = vec.tolist()
     return str(vec)
 

--- a/ontokit/services/embedding_service.py
+++ b/ontokit/services/embedding_service.py
@@ -58,8 +58,18 @@ def _decrypt_secret(ciphertext: str) -> str:
     return _get_fernet().decrypt(ciphertext.encode()).decode()
 
 
-def _vec_to_str(vec: list[float]) -> str:
-    """Convert an embedding vector to a pgvector-compatible string."""
+def _vec_to_str(vec: list[float] | object) -> str:
+    """Convert an embedding vector to a pgvector-compatible string.
+
+    Accepts either a Python ``list[float]`` (newly-embedded queries) or a
+    numpy array (what pgvector deserializes column reads into). pgvector's
+    text input format is ``[v1,v2,...]`` — space-separated values are
+    rejected. ``str(list)`` produces commas; ``str(np.ndarray)`` produces
+    spaces. Normalize via ``.tolist()`` so the output is always pgvector-
+    parseable regardless of the input source.
+    """
+    if hasattr(vec, "tolist"):
+        vec = vec.tolist()
     return str(vec)
 
 

--- a/ontokit/services/embedding_service.py
+++ b/ontokit/services/embedding_service.py
@@ -508,13 +508,16 @@ class EmbeddingService:
         provider = await self._get_provider(project_id)
         query_vec = await provider.embed_text(query)
 
-        # pgvector cosine distance: <=> returns distance (0=identical), score = 1 - distance
+        # pgvector cosine distance: <=> returns distance (0=identical), score = 1 - distance.
+        # NOTE: must use CAST(:query_vec AS vector) — SQLAlchemy's text() parser silently
+        # drops :name bindparams when immediately followed by ::type (Postgres cast syntax),
+        # producing a syntax error at the literal ":" in the wire SQL.
         query_str = text("""
             SELECT entity_iri, label, entity_type, deprecated,
-                   1 - (embedding <=> :query_vec::vector) AS score
+                   1 - (embedding <=> CAST(:query_vec AS vector)) AS score
             FROM entity_embeddings
             WHERE project_id = :pid AND branch = :br
-            ORDER BY embedding <=> :query_vec::vector
+            ORDER BY embedding <=> CAST(:query_vec AS vector)
             LIMIT :lim
         """)
 
@@ -566,13 +569,13 @@ class EmbeddingService:
         if not emb:
             return []
 
-        # kNN search excluding self
+        # kNN search excluding self. See note in semantic_search() above re: CAST() vs ::vector.
         query_str = text("""
             SELECT entity_iri, label, entity_type, deprecated,
-                   1 - (embedding <=> :query_vec::vector) AS score
+                   1 - (embedding <=> CAST(:query_vec AS vector)) AS score
             FROM entity_embeddings
             WHERE project_id = :pid AND branch = :br AND entity_iri != :self_iri
-            ORDER BY embedding <=> :query_vec::vector
+            ORDER BY embedding <=> CAST(:query_vec AS vector)
             LIMIT :lim
         """)
 

--- a/tests/unit/test_embedding_service.py
+++ b/tests/unit/test_embedding_service.py
@@ -1269,6 +1269,60 @@ class TestSemanticSearch:
         assert result.results[0].iri == "http://example.org/Match"
         assert result.results[0].score == 0.85
 
+    @pytest.mark.asyncio
+    async def test_search_query_has_no_unresolved_bindparams(
+        self, service: EmbeddingService, mock_db: AsyncMock
+    ) -> None:
+        """Mirror of the find_similar regression for #98.
+
+        Same SQLAlchemy ``text()`` parser bug as the kNN exclusion query — the
+        semantic_search query template also used ``:query_vec::vector`` and
+        produced the same unparseable wire SQL. Exercises the third execute
+        call (count, provider config, kNN) and asserts the kNN statement
+        compiles without leftover ``:name`` placeholders.
+        """
+        from unittest.mock import patch
+
+        from sqlalchemy import text
+        from sqlalchemy.dialects import postgresql
+
+        count_result = MagicMock()
+        count_result.scalar.return_value = 10
+
+        cfg_result = MagicMock()
+        cfg_result.scalar_one_or_none.return_value = _make_config_row()
+
+        mock_provider = AsyncMock()
+        mock_provider.embed_text = AsyncMock(return_value=[0.1, 0.2, 0.3])
+
+        search_result = MagicMock()
+        search_result.__iter__ = Mock(return_value=iter([]))
+
+        mock_db.execute.side_effect = [count_result, cfg_result, search_result]
+
+        with (
+            patch("ontokit.services.embedding_service.Vector", new="not-None"),
+            patch(
+                "ontokit.services.embedding_service.get_embedding_provider",
+                return_value=mock_provider,
+            ),
+        ):
+            await service.semantic_search(PROJECT_ID, BRANCH, "find match")
+
+        # Inspect the kNN query (third execute call: count → provider config →
+        # kNN). Use the public compiled.params API instead of the private
+        # ``_bindparams`` attribute so the assertion stays valid across
+        # SQLAlchemy versions.
+        knn_stmt = mock_db.execute.await_args_list[2].args[0]
+        assert isinstance(knn_stmt, type(text("")))
+        compiled = knn_stmt.compile(dialect=postgresql.dialect())  # type: ignore[no-untyped-call]
+        compiled_sql = str(compiled)
+        assert ":query_vec" not in compiled_sql, (
+            f"Unresolved :query_vec bindparam in compiled SQL — {compiled_sql!r}"
+        )
+        # No self_iri here — semantic_search doesn't exclude any subject.
+        assert set(compiled.params.keys()) == {"query_vec", "pid", "br", "lim"}
+
 
 # ---------------------------------------------------------------------------
 # find_similar
@@ -1376,14 +1430,17 @@ class TestFindSimilar:
 
         # Inspect the kNN query (second execute call) — its compiled SQL must
         # contain zero ``:name`` placeholders and must declare the expected
-        # bindparams.
+        # bindparams. Use the public compiled.params API rather than the
+        # private ``_bindparams`` attribute so the assertion stays valid
+        # across SQLAlchemy versions.
         knn_stmt = mock_db.execute.await_args_list[1].args[0]
         assert isinstance(knn_stmt, type(text("")))
-        compiled = str(knn_stmt.compile(dialect=postgresql.dialect()))  # type: ignore[no-untyped-call]
-        assert ":query_vec" not in compiled, (
-            f"Unresolved :query_vec bindparam in compiled SQL — {compiled!r}"
+        compiled = knn_stmt.compile(dialect=postgresql.dialect())  # type: ignore[no-untyped-call]
+        compiled_sql = str(compiled)
+        assert ":query_vec" not in compiled_sql, (
+            f"Unresolved :query_vec bindparam in compiled SQL — {compiled_sql!r}"
         )
-        assert set(knn_stmt._bindparams.keys()) == {
+        assert set(compiled.params.keys()) == {
             "query_vec",
             "pid",
             "br",

--- a/tests/unit/test_embedding_service.py
+++ b/tests/unit/test_embedding_service.py
@@ -1343,6 +1343,54 @@ class TestFindSimilar:
         assert results[0].iri == "http://example.org/Similar"
         assert results[0].score == 0.92
 
+    @pytest.mark.asyncio
+    async def test_search_query_has_no_unresolved_bindparams(
+        self, service: EmbeddingService, mock_db: AsyncMock
+    ) -> None:
+        """Regression for #98.
+
+        SQLAlchemy's ``text()`` parser silently drops ``:name`` bindparams when
+        immediately followed by ``::type`` (Postgres cast). The previous query
+        used ``:query_vec::vector``, which compiled to wire SQL with a literal
+        ``:query_vec`` and produced a 500 (\"syntax error at or near ':'\") on
+        every call. Assert the kNN query bound to find_similar() resolves all
+        named placeholders.
+        """
+        from unittest.mock import patch
+
+        from sqlalchemy import text
+        from sqlalchemy.dialects import postgresql
+
+        source_emb = MagicMock()
+        source_emb.embedding = [0.1, 0.2, 0.3]
+        emb_result = MagicMock()
+        emb_result.scalar_one_or_none.return_value = source_emb
+
+        search_result = MagicMock()
+        search_result.__iter__ = Mock(return_value=iter([]))
+
+        mock_db.execute.side_effect = [emb_result, search_result]
+
+        with patch("ontokit.services.embedding_service.Vector", new="not-None"):
+            await service.find_similar(PROJECT_ID, BRANCH, "http://example.org/Source")
+
+        # Inspect the kNN query (second execute call) — its compiled SQL must
+        # contain zero ``:name`` placeholders and must declare the expected
+        # bindparams.
+        knn_stmt = mock_db.execute.await_args_list[1].args[0]
+        assert isinstance(knn_stmt, type(text("")))
+        compiled = str(knn_stmt.compile(dialect=postgresql.dialect()))  # type: ignore[no-untyped-call]
+        assert ":query_vec" not in compiled, (
+            f"Unresolved :query_vec bindparam in compiled SQL — {compiled!r}"
+        )
+        assert set(knn_stmt._bindparams.keys()) == {
+            "query_vec",
+            "pid",
+            "br",
+            "self_iri",
+            "lim",
+        }
+
 
 # ---------------------------------------------------------------------------
 # rank_suggestions

--- a/tests/unit/test_embedding_service.py
+++ b/tests/unit/test_embedding_service.py
@@ -284,6 +284,26 @@ class TestHelperUtilities:
         result = _vec_to_str(vec)
         assert result == str(vec)
 
+    def test_vec_to_str_handles_numpy_array(self) -> None:
+        """Regression for #98 (second cause).
+
+        pgvector deserializes ``Vector`` columns into numpy arrays, but
+        ``str(np.ndarray)`` is space-separated (``[0.1 0.2 0.3]``) which
+        pgvector's text input parser then rejects with ``invalid input
+        syntax for type vector``. ``_vec_to_str`` must normalize via
+        ``.tolist()`` so the output is the comma-separated form pgvector
+        expects, regardless of input source.
+        """
+        import numpy as np
+
+        from ontokit.services.embedding_service import _vec_to_str
+
+        arr = np.array([0.1, 0.2, 0.3])
+        result = _vec_to_str(arr)
+        assert "," in result, f"expected comma-separated output, got {result!r}"
+        # Same shape as the list path
+        assert result == str([0.1, 0.2, 0.3])
+
 
 # ---------------------------------------------------------------------------
 # _get_provider

--- a/tests/unit/test_embedding_service.py
+++ b/tests/unit/test_embedding_service.py
@@ -7,6 +7,8 @@ from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, Mock
 
 import pytest
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.sql.elements import TextClause
 
 from ontokit.services.embedding_service import EmbeddingService
 
@@ -1303,9 +1305,6 @@ class TestSemanticSearch:
         """
         from unittest.mock import patch
 
-        from sqlalchemy import text
-        from sqlalchemy.dialects import postgresql
-
         count_result = MagicMock()
         count_result.scalar.return_value = 10
 
@@ -1334,7 +1333,7 @@ class TestSemanticSearch:
         # ``_bindparams`` attribute so the assertion stays valid across
         # SQLAlchemy versions.
         knn_stmt = mock_db.execute.await_args_list[2].args[0]
-        assert isinstance(knn_stmt, type(text("")))
+        assert isinstance(knn_stmt, TextClause)
         compiled = knn_stmt.compile(dialect=postgresql.dialect())  # type: ignore[no-untyped-call]
         compiled_sql = str(compiled)
         assert ":query_vec" not in compiled_sql, (
@@ -1432,9 +1431,6 @@ class TestFindSimilar:
         """
         from unittest.mock import patch
 
-        from sqlalchemy import text
-        from sqlalchemy.dialects import postgresql
-
         source_emb = MagicMock()
         source_emb.embedding = [0.1, 0.2, 0.3]
         emb_result = MagicMock()
@@ -1454,7 +1450,7 @@ class TestFindSimilar:
         # private ``_bindparams`` attribute so the assertion stays valid
         # across SQLAlchemy versions.
         knn_stmt = mock_db.execute.await_args_list[1].args[0]
-        assert isinstance(knn_stmt, type(text("")))
+        assert isinstance(knn_stmt, TextClause)
         compiled = knn_stmt.compile(dialect=postgresql.dialect())  # type: ignore[no-untyped-call]
         compiled_sql = str(compiled)
         assert ":query_vec" not in compiled_sql, (

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+import json
+from unittest.mock import Mock
+
 import pytest
 from fastapi.testclient import TestClient
 
+from ontokit.core.config import settings
 from ontokit.core.exceptions import ConflictError, ForbiddenError, NotFoundError, ValidationError
-from ontokit.main import app
+from ontokit.main import app, unhandled_exception_handler
 
 
 @pytest.fixture
@@ -134,51 +138,29 @@ class TestUnhandledExceptionHandler:
     """
 
     @pytest.mark.asyncio
-    async def test_returns_json_500_in_production(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """In non-development environments, the handler returns the project's
-        standard error envelope at 500."""
-        import json
-        from unittest.mock import Mock
-
-        from ontokit.core.config import settings
-        from ontokit.main import unhandled_exception_handler
-
-        monkeypatch.setattr(settings, "app_env", "production")
+    @pytest.mark.parametrize("env", ["production", "staging"])
+    async def test_returns_json_500_in_non_development(
+        self, monkeypatch: pytest.MonkeyPatch, env: str
+    ) -> None:
+        """In production and staging, the handler returns the project's
+        standard error envelope at 500. Staging behaves like production so the
+        response shape matches what the frontend will see live."""
+        monkeypatch.setattr(settings, "app_env", env)
 
         response = await unhandled_exception_handler(Mock(), RuntimeError("kaboom"))
 
         assert response.status_code == 500
-        body = json.loads(bytes(response.body))
+        # JSONResponse.body is always bytes at runtime; the assert narrows the
+        # Starlette stub's bytes | memoryview[int] union for json.loads.
+        assert isinstance(response.body, bytes)
+        body = json.loads(response.body)
         assert body["error"]["code"] == "internal_server_error"
         assert body["error"]["message"] == "Internal server error"
-
-    @pytest.mark.asyncio
-    async def test_returns_json_500_in_staging(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Staging behaves like production so the response shape matches what
-        the frontend will see live."""
-        import json
-        from unittest.mock import Mock
-
-        from ontokit.core.config import settings
-        from ontokit.main import unhandled_exception_handler
-
-        monkeypatch.setattr(settings, "app_env", "staging")
-
-        response = await unhandled_exception_handler(Mock(), RuntimeError("kaboom"))
-
-        assert response.status_code == 500
-        body = json.loads(bytes(response.body))
-        assert body["error"]["code"] == "internal_server_error"
 
     @pytest.mark.asyncio
     async def test_reraises_in_development(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """In development the handler re-raises so Starlette's debug page
         still surfaces the traceback for the developer."""
-        from unittest.mock import Mock
-
-        from ontokit.core.config import settings
-        from ontokit.main import unhandled_exception_handler
-
         monkeypatch.setattr(settings, "app_env", "development")
 
         with pytest.raises(RuntimeError, match="kaboom"):

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -121,3 +121,65 @@ class TestMiddlewareRegistered:
         response = client.get("/health")
         # SecurityHeadersMiddleware should add common security headers
         assert "x-content-type-options" in response.headers
+
+
+class TestUnhandledExceptionHandler:
+    """Tests for the catch-all Exception handler (issue #98 follow-up).
+
+    Without this handler, an exception escaping every other handler
+    propagates to Starlette's outer ServerErrorMiddleware and the response
+    goes out without CORS headers, so the browser blocks it before the
+    frontend can read the status — masking the underlying bug behind an
+    opaque "CORS error".
+    """
+
+    @pytest.mark.asyncio
+    async def test_returns_json_500_in_production(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """In non-development environments, the handler returns the project's
+        standard error envelope at 500."""
+        import json
+        from unittest.mock import Mock
+
+        from ontokit.core.config import settings
+        from ontokit.main import unhandled_exception_handler
+
+        monkeypatch.setattr(settings, "app_env", "production")
+
+        response = await unhandled_exception_handler(Mock(), RuntimeError("kaboom"))
+
+        assert response.status_code == 500
+        body = json.loads(bytes(response.body))
+        assert body["error"]["code"] == "internal_server_error"
+        assert body["error"]["message"] == "Internal server error"
+
+    @pytest.mark.asyncio
+    async def test_returns_json_500_in_staging(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Staging behaves like production so the response shape matches what
+        the frontend will see live."""
+        import json
+        from unittest.mock import Mock
+
+        from ontokit.core.config import settings
+        from ontokit.main import unhandled_exception_handler
+
+        monkeypatch.setattr(settings, "app_env", "staging")
+
+        response = await unhandled_exception_handler(Mock(), RuntimeError("kaboom"))
+
+        assert response.status_code == 500
+        body = json.loads(bytes(response.body))
+        assert body["error"]["code"] == "internal_server_error"
+
+    @pytest.mark.asyncio
+    async def test_reraises_in_development(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """In development the handler re-raises so Starlette's debug page
+        still surfaces the traceback for the developer."""
+        from unittest.mock import Mock
+
+        from ontokit.core.config import settings
+        from ontokit.main import unhandled_exception_handler
+
+        monkeypatch.setattr(settings, "app_env", "development")
+
+        with pytest.raises(RuntimeError, match="kaboom"):
+            await unhandled_exception_handler(Mock(), RuntimeError("kaboom"))


### PR DESCRIPTION
## Summary

Fixes #98 — \`/entities/{iri}/similar\` (and \`/search/semantic\`) returned HTTP 500 with no CORS headers on every call.

## Root cause

SQLAlchemy's \`text()\` bindparam regex silently drops \`:name\` placeholders when they are immediately followed by \`::type\` (Postgres cast syntax). Reproduced in a Python REPL:

\`\`\`python
>>> from sqlalchemy import text
>>> text(\"SELECT :a, :b::int, :c\")._bindparams.keys()
dict_keys(['a', 'c'])     # :b silently dropped!
\`\`\`

So both kNN queries (\`find_similar\` and \`semantic_search\`) embedded a literal \`:query_vec\` in the wire SQL, which Postgres then rejected:

\`\`\`
ERROR: syntax error at or near \":\" at character 103
STATEMENT:
    SELECT 1 - (embedding <=> :query_vec::vector) AS score
    ...
\`\`\`

## Fix

Replace \`:query_vec::vector\` with \`CAST(:query_vec AS vector)\` in both queries — functionally identical SQL but uses syntax SQLAlchemy's parser handles correctly. Inline comment left so future readers don't reintroduce the broken form.

The CORS-header symptom in #98 was downstream: when a route raises an unhandled exception, the response was generated by Starlette's outer \`ServerErrorMiddleware\` — which sits *outside* \`CORSMiddleware\` — so the 500 went out without \`Access-Control-Allow-Origin\` and the browser blocked it before the frontend could read the status. Fixing the SQL/numpy bugs above makes the CORS report disappear *for this endpoint*, but the next unhandled exception anywhere else would hit the same trap.

This PR also closes that gap with a catch-all \`@app.exception_handler(Exception)\` (commit c70f851) that converts any uncaught exception into the project's standard JSON error envelope at 500. Behavior is conditional on \`settings.app_env\`:

- **development** — re-raise so Starlette's debug traceback page still surfaces the error
- **staging / production** — return JSON 500 so the response passes back through \`CORSMiddleware\` and the frontend sees a parseable, CORS-allowed response instead of an opaque "CORS error"

Closes #98

## Test plan
- [x] Regression tests \`test_search_query_has_no_unresolved_bindparams\` (in both \`TestFindSimilar\` and \`TestSemanticSearch\`) inspect the compiled SQL of the kNN query and assert no literal \`:query_vec\` remains and all expected bindparams resolve via the public \`compiled.params\` API.
- [x] \`test_vec_to_str_handles_numpy_array\` locks in the numpy-array path that broke the original smoke test.
- [x] \`TestUnhandledExceptionHandler\` covers all three branches of the catch-all handler (production / staging / development).
- [x] All 1508 tests pass
- [x] mypy strict + ruff lint + ruff format clean
- [x] Manual smoke against running stack: \`GET /api/v1/projects/{id}/entities/{iri}/similar?branch=main&limit=5\` → **HTTP 200, application/json, CORS header present**, 5 ranked results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a global exception handler that returns a consistent JSON 500 error in production/staging and surfaces errors in development.

* **Bug Fixes**
  * Improved vector formatting and SQL compatibility for semantic search and similarity queries to prevent malformed query generation.

* **Tests**
  * Added regression tests validating vector formatting and correct SQL generation for similarity/semantic search, plus tests for the new exception handler.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

