### PR TITLE
feat(search): expose property subtype in EntitySearchResult

### DIFF
--- a/ontokit/schemas/owl_class.py
+++ b/ontokit/schemas/owl_class.py
@@ -114,6 +114,11 @@ class EntitySearchResult(BaseModel):
     iri: str
     label: str
     entity_type: Literal["class", "property", "individual"]
+    # OWL property subtype, populated only when entity_type == "property". None
+    # for class / individual results, and also for properties whose rdf:type
+    # resolves to none of OWL.{Object,Datatype,Annotation}Property (defensive
+    # fallback). Lets clients group properties without IRI-substring guesses.
+    property_kind: Literal["object", "data", "annotation"] | None = None
     deprecated: bool = False
 
 

--- a/ontokit/services/indexed_ontology.py
+++ b/ontokit/services/indexed_ontology.py
@@ -271,6 +271,7 @@ class IndexedOntologyService:
                             iri=r["iri"],
                             label=r["label"],
                             entity_type=r["entity_type"],
+                            property_kind=r.get("property_kind"),
                             deprecated=r["deprecated"],
                         )
                         for r in result["results"]

--- a/ontokit/services/ontology.py
+++ b/ontokit/services/ontology.py
@@ -457,19 +457,21 @@ class OntologyService:
         graph = await self._get_graph(project_id, branch)
         query_lower = query.lower()
 
-        # Map entity type names to (RDF type, result entity_type)
-        type_mapping: dict[str, list[tuple[URIRef, str]]] = {
-            "class": [(OWL.Class, "class")],
+        # Map entity type names to (RDF type, result entity_type, property_kind).
+        # property_kind preserves the OWL subtype so clients can categorize
+        # properties without IRI-substring guesses (see issue #117).
+        type_mapping: dict[str, list[tuple[URIRef, str, str | None]]] = {
+            "class": [(OWL.Class, "class", None)],
             "property": [
-                (OWL.ObjectProperty, "property"),
-                (OWL.DatatypeProperty, "property"),
-                (OWL.AnnotationProperty, "property"),
+                (OWL.ObjectProperty, "property", "object"),
+                (OWL.DatatypeProperty, "property", "data"),
+                (OWL.AnnotationProperty, "property", "annotation"),
             ],
-            "individual": [(OWL.NamedIndividual, "individual")],
+            "individual": [(OWL.NamedIndividual, "individual", None)],
         }
 
         allowed_types = entity_types or ["class", "property", "individual"]
-        rdf_types: list[tuple[URIRef, str]] = []
+        rdf_types: list[tuple[URIRef, str, str | None]] = []
         for t in allowed_types:
             if t in type_mapping:
                 rdf_types.extend(type_mapping[t])
@@ -477,7 +479,7 @@ class OntologyService:
         owl_thing = OWL.Thing
         results: list[EntitySearchResult] = []
 
-        for rdf_type, entity_type in rdf_types:
+        for rdf_type, entity_type, property_kind in rdf_types:
             for subject in graph.subjects(RDF.type, rdf_type):
                 if not isinstance(subject, URIRef):
                     continue
@@ -528,6 +530,10 @@ class OntologyService:
                         label=display_label,
                         entity_type=cast(
                             TypingLiteral["class", "property", "individual"], entity_type
+                        ),
+                        property_kind=cast(
+                            TypingLiteral["object", "data", "annotation"] | None,
+                            property_kind,
                         ),
                         deprecated=deprecated,
                     )

--- a/ontokit/services/ontology_index.py
+++ b/ontokit/services/ontology_index.py
@@ -1012,6 +1012,11 @@ class OntologyIndexService:
             ENTITY_TYPE_ANNOTATION_PROPERTY: "property",
             ENTITY_TYPE_INDIVIDUAL: "individual",
         }
+        property_kind_map = {
+            ENTITY_TYPE_OBJECT_PROPERTY: "object",
+            ENTITY_TYPE_DATATYPE_PROPERTY: "data",
+            ENTITY_TYPE_ANNOTATION_PROPERTY: "annotation",
+        }
 
         prefs = label_preferences or DEFAULT_LABEL_PREFERENCES
         results = []
@@ -1022,6 +1027,7 @@ class OntologyIndexService:
                     "iri": row.iri,
                     "label": label or row.local_name,
                     "entity_type": reverse_type_map.get(row.entity_type, row.entity_type),
+                    "property_kind": property_kind_map.get(row.entity_type),
                     "deprecated": row.deprecated,
                 }
             )

--- a/tests/unit/test_indexed_ontology.py
+++ b/tests/unit/test_indexed_ontology.py
@@ -608,3 +608,44 @@ class TestSearchEntities:
         mock_ontology_service.search_entities.assert_awaited_once_with(
             PROJECT_ID, "Person", None, None, 50, BRANCH
         )
+
+    @pytest.mark.asyncio
+    async def test_propagates_property_kind_from_index(
+        self, service: IndexedOntologyService
+    ) -> None:
+        """property_kind from index dicts is forwarded onto EntitySearchResult."""
+        service.index.is_index_ready = AsyncMock(return_value=True)  # type: ignore[method-assign]
+        service.index.search_entities = AsyncMock(  # type: ignore[method-assign]
+            return_value={
+                "results": [
+                    {
+                        "iri": "http://example.org/hasParent",
+                        "label": "hasParent",
+                        "entity_type": "property",
+                        "property_kind": "object",
+                        "deprecated": False,
+                    },
+                    {
+                        "iri": "http://example.org/age",
+                        "label": "age",
+                        "entity_type": "property",
+                        "property_kind": "data",
+                        "deprecated": False,
+                    },
+                    {
+                        "iri": "http://example.org/Person",
+                        "label": "Person",
+                        "entity_type": "class",
+                        "property_kind": None,
+                        "deprecated": False,
+                    },
+                ],
+                "total": 3,
+            }
+        )
+
+        response = await service.search_entities(PROJECT_ID, "x", branch=BRANCH)
+        kinds = {r.iri: r.property_kind for r in response.results}
+        assert kinds["http://example.org/hasParent"] == "object"
+        assert kinds["http://example.org/age"] == "data"
+        assert kinds["http://example.org/Person"] is None

--- a/tests/unit/test_ontology_index_service.py
+++ b/tests/unit/test_ontology_index_service.py
@@ -364,6 +364,46 @@ class TestSearchEntities:
         assert result["results"][0]["iri"] == "http://example.org/Person"
 
     @pytest.mark.asyncio
+    async def test_search_entities_property_kind_per_subtype(
+        self, service: OntologyIndexService, mock_db: AsyncMock
+    ) -> None:
+        """Each OWL property subtype maps to its expected property_kind value."""
+        cases = [
+            ("object_property", "object"),
+            ("datatype_property", "data"),
+            ("annotation_property", "annotation"),
+            ("class", None),
+            ("individual", None),
+        ]
+        for stored_type, expected_kind in cases:
+            mock_count_result = MagicMock()
+            mock_count_result.scalar.return_value = 1
+
+            mock_entity_row = MagicMock()
+            mock_entity_row.id = f"entity-{stored_type}"
+            mock_entity_row.iri = f"http://example.org/{stored_type}"
+            mock_entity_row.local_name = stored_type
+            mock_entity_row.entity_type = stored_type
+            mock_entity_row.deprecated = False
+
+            mock_entities_result = MagicMock()
+            mock_entities_result.all.return_value = [mock_entity_row]
+
+            mock_labels_result = MagicMock()
+            mock_labels_result.scalars.return_value.all.return_value = []
+
+            mock_db.execute.side_effect = [
+                mock_count_result,
+                mock_entities_result,
+                mock_labels_result,
+            ]
+
+            result = await service.search_entities(PROJECT_ID, BRANCH, stored_type)
+            assert result["results"][0]["property_kind"] == expected_kind, (
+                f"{stored_type} should map to property_kind={expected_kind!r}"
+            )
+
+    @pytest.mark.asyncio
     async def test_search_entities_no_matches(
         self, service: OntologyIndexService, mock_db: AsyncMock
     ) -> None:

--- a/tests/unit/test_ontology_service_extended.py
+++ b/tests/unit/test_ontology_service_extended.py
@@ -522,3 +522,58 @@ class TestSearchEntitiesExtended:
         """Limit restricts number of returned results."""
         result = await loaded_service.search_entities(PROJECT_ID, "*", limit=1)
         assert len(result.results) <= 1
+
+    @pytest.mark.asyncio
+    async def test_search_object_property_kind(self, loaded_service: OntologyService) -> None:
+        """ObjectProperty results carry property_kind='object' (issue #117)."""
+        result = await loaded_service.search_entities(
+            PROJECT_ID, "worksFor", entity_types=["property"]
+        )
+        matches = [r for r in result.results if r.iri.endswith("worksFor")]
+        assert matches, "expected the worksFor property to be in results"
+        assert matches[0].entity_type == "property"
+        assert matches[0].property_kind == "object"
+
+    @pytest.mark.asyncio
+    async def test_search_datatype_property_kind(self, loaded_service: OntologyService) -> None:
+        """DatatypeProperty results carry property_kind='data' (issue #117)."""
+        result = await loaded_service.search_entities(
+            PROJECT_ID, "hasName", entity_types=["property"]
+        )
+        matches = [r for r in result.results if r.iri.endswith("hasName")]
+        assert matches, "expected the hasName property to be in results"
+        assert matches[0].entity_type == "property"
+        assert matches[0].property_kind == "data"
+
+    @pytest.mark.asyncio
+    async def test_search_annotation_property_kind(self, ontology_service: OntologyService) -> None:
+        """AnnotationProperty results carry property_kind='annotation' (issue #117).
+
+        Uses a self-contained graph because the shared sample ontology has no
+        annotation properties and other tests assert on its exact contents.
+        """
+        from rdflib import RDF, Graph, Literal
+        from rdflib.namespace import OWL, RDFS
+
+        g = Graph()
+        ann = URIRef("http://example.org/ontology#status")
+        g.add((ann, RDF.type, OWL.AnnotationProperty))
+        g.add((ann, RDFS.label, Literal("status", lang="en")))
+        ontology_service.set_graph(PROJECT_ID, BRANCH, g)
+
+        result = await ontology_service.search_entities(
+            PROJECT_ID, "status", entity_types=["property"]
+        )
+        matches = [r for r in result.results if r.iri.endswith("status")]
+        assert matches, "expected the status annotation property to be in results"
+        assert matches[0].entity_type == "property"
+        assert matches[0].property_kind == "annotation"
+
+    @pytest.mark.asyncio
+    async def test_search_class_has_no_property_kind(self, loaded_service: OntologyService) -> None:
+        """Class results have property_kind=None (issue #117)."""
+        result = await loaded_service.search_entities(PROJECT_ID, "Person", entity_types=["class"])
+        matches = [r for r in result.results if r.iri.endswith("Person")]
+        assert matches
+        assert matches[0].entity_type == "class"
+        assert matches[0].property_kind is None


### PR DESCRIPTION
## Summary

\`search_entities()\` was already iterating \`OWL.ObjectProperty\`, \`OWL.DatatypeProperty\`, and \`OWL.AnnotationProperty\` separately, then collapsing all three into a generic \`entity_type=\"property\"\` — discarding the subtype the loop already knew. Web clients (notably the property tree at [ontokit-web#176](https://github.com/CatholicOS/ontokit-web/issues/176)) had been falling back to fragile IRI-substring heuristics like \`iri.includes(\"objectproperty\")\` to recover what we already had.

## Change

Adds an optional field to \`EntitySearchResult\`:

\`\`\`python
property_kind: Literal[\"object\", \"data\", \"annotation\"] | None = None
\`\`\`

Populated from the \`rdf:type\` the subject came from. \`None\` for non-property results (classes, individuals) and as a defensive fallback for properties whose \`rdf:type\` resolves to none of the three OWL subkinds.

**Non-breaking additive change**: existing consumers ignore the new field; new consumers gate property categorization on it.

Closes #117

## Unblocks

- [ontokit-web#176](https://github.com/CatholicOS/ontokit-web/issues/176) — Fix property classification in tree view and add Data Properties category

## Test plan
- [x] 4 new tests in \`TestSearchEntitiesExtended\` cover all three property subtypes (object / data / annotation) plus an assertion that classes get \`property_kind=None\`
- [x] All 1506 tests pass
- [x] mypy strict + ruff lint + ruff format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Entity search results now include a property type field that identifies whether properties are object, data, or annotation types. This enables clients to categorize properties directly without relying on IRI substring heuristics. Property type information is provided only for properties; class and individual search results are unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->