### PR TITLE
docs(skill): note the volume-mount assumption in post-merge

### DIFF
--- a/.claude/commands/post-merge.md
+++ b/.claude/commands/post-merge.md
@@ -18,6 +18,7 @@ Steps to perform:
 5. **Verify**: Run `docker compose ps` to confirm all services are healthy.
 
 Important:
+- The "no infra changes → restart" branch relies on the `./ontokit:/home/ontokit/app/ontokit:ro` volume mount in `compose.yaml` (api + worker services). If that mount is ever removed, restart will silently keep running the old code baked into the image and you'll need `docker compose up -d --build api worker` instead. Before relying on the restart path, confirm the mount still exists with `grep -A 1 "Mount source code" compose.yaml`.
 - The entrypoint.sh uses a marker file `/tmp/.migrations_done` to skip repeated migrations. This marker lives inside the container filesystem, so `docker compose restart` preserves it and migrations will NOT re-run. Only container recreation (`--build` or `--force-recreate`) clears the marker.
 - Always confirm before deleting a branch if it looks like it might have unmerged changes.
 - Run all commands from the repository root (use `git rev-parse --show-toplevel` to find it).


### PR DESCRIPTION
## Summary

Tiny docs-only tweak to \`.claude/commands/post-merge.md\`. The \"no infra changes → \`docker compose restart api worker\`\" branch silently relies on the \`./ontokit:/home/ontokit/app/ontokit:ro\` mount in \`compose.yaml\`. If that mount is ever removed (e.g. switching to a fully baked production image for local dev), restart will keep running the stale code from the image and the merged PR appears not to take effect.

Adds one Important note documenting the assumption + the one-line grep to verify the mount before relying on the restart path.

## Origin

Surfaced during the post-merge run for #119: I initially thought the mount was missing (a 5-line grep cut off before reaching the volumes section), almost reported a false issue, then realized the mount IS there. The skill is correct as written for this repo, but the assumption was implicit. This makes it explicit so the next person doesn't make the same mistake.

## Test plan
- [x] No code change; pre-commit hooks skip ruff/mypy

🤖 Generated with [Claude Code](https://claude.com/claude-code)