### PR TITLE
fix(compose): override worker healthcheck so it's not always unhealthy

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -317,6 +317,16 @@ services:
       - ./ontokit:/home/ontokit/app/ontokit:ro
       # Git repositories (shared with API)
       - git_repos:/data/repos
+    # The worker shares the api image, which bakes in a `curl localhost:8000`
+    # healthcheck. The worker has no HTTP server (it runs ARQ), so that check
+    # always fails. Override with a check that PID 1 is still the arq process —
+    # works without any extra binaries in the slim image.
+    healthcheck:
+      test: ["CMD-SHELL", "grep -q arq /proc/1/cmdline"]
+      interval: 30s
+      timeout: 5s
+      start_period: 10s
+      retries: 3
     networks:
       - ontokit
     depends_on:


### PR DESCRIPTION
## Summary

The worker container shares the api image, which bakes in a \`curl http://localhost:8000/health\` HEALTHCHECK. The api uses that to confirm uvicorn is serving, but the worker runs ARQ and never binds an HTTP port — so the check has been failing every 30s since the image was first built.

\`\`\`
$ docker inspect ontokit-worker --format '{{.State.Health.FailingStreak}}'
17
\`\`\`

## Impact

- \`docker compose ps\` permanently shows the worker as \`unhealthy\`, masking real worker problems behind a stuck-red light.
- Any service that does \`depends_on: { worker: { condition: service_healthy } }\` would deadlock waiting for it. None do today, but it'd be a foot-gun next time someone wires one up.

## Fix

Override the worker healthcheck in \`compose.yaml\`. PID 1 in the worker container is \`arq ontokit.worker.WorkerSettings\` directly (verified with \`cat /proc/1/cmdline\`), so checking that PID 1's cmdline still mentions \`arq\` is a reliable liveness probe — and works without adding curl / pgrep / redis-cli to the python:3.13-slim image.

\`\`\`yaml
healthcheck:
  test: [\"CMD-SHELL\", \"grep -q arq /proc/1/cmdline\"]
  interval: 30s
  timeout: 5s
  start_period: 10s
  retries: 3
\`\`\`

## Test plan
- [x] \`docker compose up -d --force-recreate worker\` → transitions to \`healthy\` within ~10s (previously stayed \`unhealthy\` indefinitely)
- [x] No code change; pre-commit hooks skip ruff/mypy

🤖 Generated with [Claude Code](https://claude.com/claude-code)