### PR TITLE
fix(security): triage Semgrep baseline + flip CI gate to enforcing

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -19,9 +19,6 @@ jobs:
     # rule packs preloaded. Pinned to a major tag for reproducibility.
     container:
       image: semgrep/semgrep
-    # Advisory mode — see the comment block below the steps for why this
-    # is currently `true` and what needs to happen before flipping it.
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
 
@@ -39,20 +36,7 @@ jobs:
             --config p/fastapi \
             --config p/jwt
 
-# ──────────────────────────────────────────────────────────────────────────
-# Why continue-on-error: true (issue #114, "Baseline findings to address first")
-# ──────────────────────────────────────────────────────────────────────────
-# At workflow-introduction time the baseline scan reported 13 findings, of
-# which:
-#   * ~11 are false positives in the `tainted-fastapi-http-request-httpx`
-#     taint analyzer — it doesn't recognize urllib.parse.quote() (added in
-#     PR #116) as a sanitizer.
-#   * 2 are low-signal generic warnings (sqlalchemy.text() and a logger
-#     message whose text contains the word "token" while the actual logged
-#     value is a user id).
-#
-# Flipping this to fail-the-build is tracked in issue #124 — once those
-# findings are triaged (suppressed via `# nosemgrep:` comments where
-# verified, or fixed where real), set `continue-on-error: false` and
-# delete this comment block. Until then, this workflow runs as a
-# read-only signal so we don't block PRs on a noisy baseline.
+# Enforcing mode: a failing scan blocks the PR. The baseline was triaged
+# in issue #124 (PR #126) — every false positive carries an inline
+# `# nosemgrep:` comment with a justification at the call site. New
+# suppressions added later should follow the same form.

--- a/ontokit/api/routes/auth.py
+++ b/ontokit/api/routes/auth.py
@@ -91,6 +91,12 @@ async def refresh_token(refresh_token: str) -> TokenResponse:
     """Refresh an access token using a refresh token."""
     async with httpx.AsyncClient() as client:
         try:
+            # URL is settings.zitadel_issuer + a literal path; the user-supplied
+            # refresh_token flows into the request *body*, not the URL. The taint
+            # analyzer can't distinguish URL sinks from body params, so it also
+            # flags the response.json() fields that get echoed back into
+            # TokenResponse below — none of those are URL sinks either.
+            # nosemgrep: python.fastapi.net.tainted-fastapi-http-request-httpx.tainted-fastapi-http-request-httpx
             resp = await client.post(
                 f"{settings.zitadel_issuer}/oauth/v2/token",
                 data={
@@ -105,7 +111,9 @@ async def refresh_token(refresh_token: str) -> TokenResponse:
                 access_token=data["access_token"],
                 token_type=data["token_type"],
                 expires_in=data["expires_in"],
+                # nosemgrep: python.fastapi.net.tainted-fastapi-http-request-httpx.tainted-fastapi-http-request-httpx
                 refresh_token=data.get("refresh_token"),
+                # nosemgrep: python.fastapi.net.tainted-fastapi-http-request-httpx.tainted-fastapi-http-request-httpx
                 id_token=data.get("id_token"),
             )
         except httpx.HTTPStatusError as e:

--- a/ontokit/api/routes/projects.py
+++ b/ontokit/api/routes/projects.py
@@ -289,6 +289,10 @@ async def create_project_from_github(
     default_branch = data.default_branch
     if not default_branch:
         repo_info = await github.get_repo_info(pat, data.repo_owner, data.repo_name)
+        # Taint flow tracking, not a real sink — get_repo_info() URL-encodes
+        # owner/repo via _enc() (PR #116). The branch we extract here is then
+        # passed to get_file_content() which also encodes it.
+        # nosemgrep: python.fastapi.net.tainted-fastapi-http-request-httpx.tainted-fastapi-http-request-httpx
         default_branch = repo_info.get("default_branch") or "main"
 
     # Download the ontology file from GitHub

--- a/ontokit/core/auth.py
+++ b/ontokit/core/auth.py
@@ -230,6 +230,9 @@ async def fetch_userinfo(access_token: str) -> dict[str, Any] | None:
 
     try:
         async with httpx.AsyncClient() as client:
+            # base_url comes from settings (zitadel_internal_url or _issuer);
+            # the path is a literal. No user-controlled URL composition here.
+            # nosemgrep: python.fastapi.net.tainted-fastapi-http-request-httpx.tainted-fastapi-http-request-httpx
             response = await client.get(
                 f"{base_url}/oidc/v1/userinfo",
                 headers=headers,

--- a/ontokit/services/duplicate_detection_service.py
+++ b/ontokit/services/duplicate_detection_service.py
@@ -47,7 +47,11 @@ async def find_duplicates_sql(
     similar labels belonging to *other* entities of the same type.  This
     avoids parsing the ontology file and runs in seconds rather than minutes.
     """
-    # Set the similarity threshold for this transaction
+    # Set the similarity threshold for this transaction. Postgres SET does not
+    # accept bind parameters (it's a session-config statement, not a query),
+    # so the value is interpolated — but only after a float() cast that
+    # guarantees no SQL-injectable characters can survive.
+    # nosemgrep: python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text
     await db.execute(text(f"SET LOCAL pg_trgm.similarity_threshold = {float(threshold)}"))
 
     # Step 1: Get one rdfs:label per entity for this project/branch

--- a/ontokit/services/github_service.py
+++ b/ontokit/services/github_service.py
@@ -90,6 +90,12 @@ class GitHubService:
             JSON response data
         """
         async with httpx.AsyncClient() as client:
+            # endpoint is built by callers using _enc() (see PR #116) so every
+            # user-controlled segment is URL-encoded before reaching this sink.
+            # The taint analyzer doesn't recognize urllib.parse.quote() as a
+            # sanitizer; the same justification covers the other client.* call
+            # sites in this module.
+            # nosemgrep: python.fastapi.net.tainted-fastapi-http-request-httpx.tainted-fastapi-http-request-httpx
             response = await client.request(
                 method=method,
                 url=f"{self.GITHUB_API_BASE}{endpoint}",
@@ -201,11 +207,18 @@ class GitHubService:
             f"/repos/{_enc(owner)}/{_enc(repo)}/git/trees/{_enc(resolved_ref)}?recursive=1",
             token,
         )
+        # The dict accesses below are not HTTP sinks — they extract fields
+        # from the GitHub API response into a local list. Semgrep's taint
+        # tracker flags each access in the flow path, but none of these
+        # values flow back into a request URL.
         files: list[dict[str, Any]] = []
         if isinstance(data, dict):
+            # nosemgrep: python.fastapi.net.tainted-fastapi-http-request-httpx.tainted-fastapi-http-request-httpx
             for item in data.get("tree", []):
+                # nosemgrep: python.fastapi.net.tainted-fastapi-http-request-httpx.tainted-fastapi-http-request-httpx
                 if item.get("type") != "blob":
                     continue
+                # nosemgrep: python.fastapi.net.tainted-fastapi-http-request-httpx.tainted-fastapi-http-request-httpx
                 path = item.get("path", "")
                 ext = ("." + path.rsplit(".", 1)[-1]).lower() if "." in path else ""
                 if ext in self.ONTOLOGY_EXTENSIONS:
@@ -213,6 +226,7 @@ class GitHubService:
                         {
                             "path": path,
                             "name": path.rsplit("/", 1)[-1],
+                            # nosemgrep: python.fastapi.net.tainted-fastapi-http-request-httpx.tainted-fastapi-http-request-httpx
                             "size": item.get("size", 0),
                         }
                     )
@@ -242,6 +256,9 @@ class GitHubService:
         if ref:
             endpoint += f"?ref={_enc(ref)}"
         async with httpx.AsyncClient() as client:
+            # endpoint is composed entirely of _enc()-encoded segments above;
+            # see the central _request() method for the full justification.
+            # nosemgrep: python.fastapi.net.tainted-fastapi-http-request-httpx.tainted-fastapi-http-request-httpx
             response = await client.get(
                 f"{self.GITHUB_API_BASE}{endpoint}",
                 headers={

--- a/ontokit/services/pull_request_service.py
+++ b/ontokit/services/pull_request_service.py
@@ -1721,8 +1721,13 @@ class PullRequestService:
         try:
             token = decrypt_token(token_row.encrypted_token)
         except Exception:
+            # The interpolated value is a user_id (int), not a credential. The
+            # message string mentions "credential" only as part of the
+            # human-readable failure context.
+            # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
             logger.warning(
-                "Failed to decrypt GitHub token for user %s", integration.connected_by_user_id
+                "Failed to decrypt GitHub credential for user %s",
+                integration.connected_by_user_id,
             )
             return None
         return integration, token

--- a/ontokit/services/pull_request_service.py
+++ b/ontokit/services/pull_request_service.py
@@ -1721,9 +1721,9 @@ class PullRequestService:
         try:
             token = decrypt_token(token_row.encrypted_token)
         except Exception:
-            # The interpolated value is a user_id (int), not a credential. The
-            # message string mentions "credential" only as part of the
-            # human-readable failure context.
+            # The interpolated value is a user_id (str | None), not a
+            # credential. The message string mentions "credential" only as
+            # part of the human-readable failure context.
             # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
             logger.warning(
                 "Failed to decrypt GitHub credential for user %s",


### PR DESCRIPTION
## Summary

Closes #124. Baseline scan now reports **0 findings**, so the Semgrep workflow can stop running in advisory mode.

## Per-finding triage

| Count | Rule | Decision |
|---|---|---|
| 11× | \`tainted-fastapi-http-request-httpx\` | False positive. Taint analyzer doesn't recognize \`urllib.parse.quote()\` (PR #116) as a sanitizer; URL composition is from settings + literals (auth.py, core/auth.py) or pre-encoded segments (github_service.py, projects.py). Suppressed inline. |
| 1× | \`avoid-sqlalchemy-text\` | False positive. Postgres \`SET LOCAL\` doesn't accept bind params; \`float()\` cast removes injection risk before interpolation. Suppressed inline. |
| 1× | \`python-logger-credential-disclosure\` | False positive. Format-string contains the word \"credential\" but the interpolated value is a user_id (int). Suppressed inline. |

## Suppression style

Each \`# nosemgrep:\` comment is placed on the line **above** the flagged statement, not inline at end-of-line. The first attempt used trailing-comment placement and ruff's auto-formatter split the long lines, leaving the suppression on a different line than the flagged statement and silently breaking the gate. Above-the-line placement is robust to ruff format and survives any future line-length changes.

## Workflow change

\`\`\`diff
-    continue-on-error: true
\`\`\`

Replaced the multi-paragraph explanatory comment block at the bottom of the workflow with a one-line pointer to #124. The next Semgrep CI run will **fail the build** on any new finding — including this PR's run, which should pass since the baseline is clean.

## Test plan
- [x] \`semgrep --pro --config p/default --config p/owasp-top-ten --config p/python --config p/fastapi --config p/jwt\` reports **0 findings** locally.
- [x] All 1515 tests pass.
- [x] mypy strict + ruff lint + ruff format clean (and stable across runs — no oscillation).
- [ ] After merge: confirm the workflow runs on the next PR with \`continue-on-error: false\` and passes (or correctly fails when an offending change lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced code security scanning with stricter Semgrep configuration to block pull requests on scan failures.
  * Added inline documentation and security annotations throughout the codebase to clarify data handling and validate safe practices.
  * Updated logging terminology for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->