### PR TITLE
fix(ci): make Semgrep workflow handle SEMGREP_APP_TOKEN correctly

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -35,19 +35,28 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # `semgrep ci` is incompatible with explicit --config flags when
+      # SEMGREP_APP_TOKEN is set — semgrep-app expects the rules to come
+      # from the server-side AppSec policy. Worse, it exits 0 with a
+      # warning, so the misconfiguration silently produces a false-pass.
+      # When the token is set, defer to the server policy. When it isn't,
+      # fall back to explicit local rulesets so the scan still runs in
+      # forks / setups without the secret. `--no-suppress-errors` makes
+      # any future misconfiguration fail loudly.
       - name: Run Semgrep
         env:
-          # Optional: when set, `semgrep ci` posts findings to the Semgrep
-          # AppSec Platform. When unset, the scan runs in local-only mode
-          # and prints findings to the job log. Either path is fine.
           SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
         run: |
-          semgrep ci \
-            --config p/default \
-            --config p/owasp-top-ten \
-            --config p/python \
-            --config p/fastapi \
-            --config p/jwt
+          if [ -n "$SEMGREP_APP_TOKEN" ]; then
+            semgrep ci --no-suppress-errors
+          else
+            semgrep ci --no-suppress-errors \
+              --config p/default \
+              --config p/owasp-top-ten \
+              --config p/python \
+              --config p/fastapi \
+              --config p/jwt
+          fi
 
 # Enforcing mode: a failing scan blocks the PR. The baseline was triaged
 # in issue #124 (PR #126) — every false positive carries an inline


### PR DESCRIPTION
## Summary

Mirrors the same fix shipped in [ontokit-web#194](https://github.com/CatholicOS/ontokit-web/pull/194).

The existing workflow always passed `--config p/...` flags. With `SEMGREP_APP_TOKEN` set as a repo secret, `semgrep ci` rejects this combination and exits 0 with only a warning — producing a silent false-pass. This is why `ontokit-api` is stuck in **"Not scanning"** on semgrep.dev: the scans never reached the dashboard.

Two corrections:

1. Choose the invocation based on whether the token is set. With token → server-side AppSec policy (no `--config`). Without token → explicit local rulesets (so forks / setups without the secret still work).
2. Add `--no-suppress-errors` so future misconfiguration fails loudly instead of producing a false-positive green check.

After merge, `ontokit-api` should appear in semgrep.dev's "Scanning" project list.

Refs: [ontokit-web#192](https://github.com/CatholicOS/ontokit-web/issues/192) (issue tracking the original web work), [ontokit-web#194](https://github.com/CatholicOS/ontokit-web/pull/194) (web-side fix this mirrors)

## Test plan

- [ ] CI: `Semgrep / Static analysis` job runs and reports a real scan summary (rules > 0, targets > 0)
- [ ] After merge: project appears under semgrep.dev → Projects → Scanning

🤖 Generated with [Claude Code](https://claude.com/claude-code)