### PR TITLE
docs: add SECURITY.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,10 +32,31 @@ mypy ontokit/
 ```
 
 ### Security Scanning
+
+CI runs `semgrep ci` (diff-aware against the PR baseline). For local one-shot
+scans you have two options depending on whether you've signed up for Semgrep
+Pro:
+
+**With Pro entitlement** — runs the same engine as CI, including taint
+analysis and the curated Pro rule pack. Mirrors what CI runs
+(`.github/workflows/semgrep.yml`); `.semgrepignore` excludes are honored
+automatically.
+
 ```bash
-# Mirror what CI runs (.github/workflows/semgrep.yml). Excludes from
-# .semgrepignore are honored automatically.
 semgrep --pro \
+  --config p/default \
+  --config p/owasp-top-ten \
+  --config p/python \
+  --config p/fastapi \
+  --config p/jwt
+```
+
+**Without Pro (community fallback)** — drop `--pro`. You get the same rule
+packs but only the OSS engine; some advanced cross-file taint findings won't
+surface. Useful for forks and external contributors.
+
+```bash
+semgrep \
   --config p/default \
   --config p/owasp-top-ten \
   --config p/python \

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,12 +37,22 @@ expanded.
 
 ## Security Tooling
 
-Both `ontokit-web` and `ontokit-api` are scanned on every PR and on every push
-to `main` / `dev` by **[Semgrep](https://semgrep.dev)** (Pro engine, server-
-side AppSec policy). The scan workflow lives at
+Both `ontokit-web` and `ontokit-api` are scanned on PRs targeting `dev` and on
+every push to `main` / `dev` by **[Semgrep](https://semgrep.dev)** (Pro
+engine, server-side AppSec policy). The scan workflow lives at
 `.github/workflows/semgrep.yml` and covers ~98,000 rules per scan.
 
 ### Enforcement modes
+
+The mode semantics described below (**Block / Comment / Monitor**) are
+applied by the Semgrep AppSec Platform when the workflow runs with
+`SEMGREP_APP_TOKEN` set — i.e., the primary CI path. When the token isn't
+available (typical for forks or contributors outside the org), `semgrep ci`
+falls back to the explicit `--config p/...` rulesets in the workflow file.
+In that fallback path, ERROR-severity findings still fail CI (so Block-mode
+rules effectively still block), but Comment-mode rules don't post inline PR
+comments — there's no semgrep-app[bot] integration without the token — and
+Monitor-mode collapses into the same CI-log surface as Comment-mode.
 
 The org-wide policy at
 <https://semgrep.dev/orgs/priest-johnromanodorazio-com/policies> applies the
@@ -72,7 +82,10 @@ them.
 - **Inline PR comments** from `semgrep-app[bot]` for Comment-mode findings
   (only when the GitHub App is installed on the org — see
   <https://github.com/apps/semgrep>). These are advisory and don't block
-  merge.
+  merge. **Forks and contributors without org access** won't see these
+  inline comments because the GitHub App can't post on their behalf —
+  findings still appear in the CI job log and the Block-mode CI gate still
+  applies, just without the inline-comment notification.
 - A link from the check's "Details" page to the matching dashboard view at
   semgrep.dev for triage history.
 
@@ -115,7 +128,7 @@ The following are **not** considered security vulnerabilities:
 
 ## Disclosure Coordination
 
-Once a fix is shipped, we'll publish a GitHub Security Advisory (with the
+Once a fix is available for release, we'll publish a GitHub Security Advisory (with the
 reporter credited unless they request anonymity) and request a CVE if the
 issue warrants one. Please don't disclose details publicly — including via
 social media, blog posts, or conference talks — until the advisory is

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,122 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in OntoKit, **please do not open a
+public GitHub issue**. We treat security reports privately so we can ship a
+fix before details become public.
+
+Two ways to report, in order of preference:
+
+1. **GitHub Security Advisory** (preferred) — open a private report at
+   <https://github.com/CatholicOS/ontokit-api/security/advisories/new> (or the
+   equivalent path on `ontokit-web` if the bug is frontend-side). This keeps
+   the report in GitHub's secure channel and gives us a structured place to
+   coordinate fixes, CVE assignment, and disclosure.
+
+2. **Email** — `priest@johnromanodorazio.com` if GitHub Advisories aren't
+   suitable (e.g., you can't sign in or the issue spans multiple
+   non-CatholicOS repos).
+
+We'll acknowledge receipt within **5 business days** and aim to provide an
+initial assessment within **10 business days**. Coordinated disclosure
+timelines are negotiated case-by-case based on severity.
+
+## Supported Versions
+
+OntoKit is pre-1.0. Security fixes are applied to:
+
+| Version          | Status                                |
+| ---------------- | ------------------------------------- |
+| `main`           | Latest tagged release                 |
+| `dev`            | In-progress next release              |
+| Older releases   | Not supported — please upgrade        |
+
+There is no LTS line yet. Once OntoKit reaches 1.0 this section will be
+expanded.
+
+## Security Tooling
+
+Both `ontokit-web` and `ontokit-api` are scanned on every PR and on every push
+to `main` / `dev` by **[Semgrep](https://semgrep.dev)** (Pro engine, server-
+side AppSec policy). The scan workflow lives at
+`.github/workflows/semgrep.yml` and covers ~98,000 rules per scan.
+
+### Enforcement modes
+
+The org-wide policy at
+<https://semgrep.dev/orgs/priest-johnromanodorazio-com/policies> applies the
+following modes to the rulesets we explicitly enable on top of Semgrep's Pro
+Rules baseline:
+
+| Ruleset            | Mode      | Why                                                                       |
+| ------------------ | --------- | ------------------------------------------------------------------------- |
+| `p/owasp-top-ten`  | **Block** | High-confidence, well-vetted findings; PRs cannot merge if these fire     |
+| `p/jwt`            | **Block** | Targeted JWT-handling pitfalls; we use Zitadel JWTs everywhere            |
+| `p/python`         | Comment   | Broad language pack; surfaces findings as PR comments without blocking    |
+| `p/fastapi`        | Comment   | Framework patterns                                                        |
+| `p/javascript`     | Comment   | (web repo) Same as language packs above                                   |
+| `p/typescript`     | Comment   | (web repo) Same                                                           |
+| `p/react`          | Comment   | (web repo) Framework patterns                                             |
+| `p/nextjs`         | Comment   | (web repo) Same                                                           |
+
+In addition, the Pro Rules baseline (~3,000 code rules) runs in **Monitor**
+mode — findings are visible in the dashboard but don't post PR comments or
+block merging. We promote individual rules to Comment or Block as we triage
+them.
+
+### What contributors see
+
+- A **CI check** named `Semgrep / Static analysis` on every PR. It fails when
+  a Block-mode finding lands in the diff.
+- **Inline PR comments** from `semgrep-app[bot]` for Comment-mode findings
+  (only when the GitHub App is installed on the org — see
+  <https://github.com/apps/semgrep>). These are advisory and don't block
+  merge.
+- A link from the check's "Details" page to the matching dashboard view at
+  semgrep.dev for triage history.
+
+### Suppressing false positives
+
+If a Semgrep finding is a confirmed false positive, suppress it inline with a
+justification:
+
+```python
+# nosemgrep: <rule-id>  Reason: <why it's safe in this context>
+foo()
+```
+
+The `Reason:` is required — bare `nosemgrep` comments without justification
+will be rejected at code review. The current baseline of legitimate
+suppressions was triaged in #124 (PR #126); follow that style for any new
+suppressions you add. For repository-wide exclusions (build output, test
+fixtures, generated migrations), edit `.semgrepignore`.
+
+### Local Semgrep recipe
+
+See `CLAUDE.md` for the equivalent `semgrep` invocation contributors can run
+locally before pushing. Both the Pro and the OSS-engine fallback are
+documented there.
+
+## Out of Scope
+
+The following are **not** considered security vulnerabilities:
+
+- Findings in code that lives under `tests/`, `alembic/versions/`, `docs/`,
+  or other paths excluded via `.semgrepignore`. Those locations are
+  intentionally permissive (test fixtures use insecure patterns deliberately;
+  generated migrations are autogenerated by Alembic).
+- Issues in unsupported third-party services we integrate with (Zitadel,
+  GitHub, Cloudflare, MinIO, Postgres, Redis). Report those upstream.
+- DoS via rate-limiting or unauthenticated endpoint flooding — we rely on
+  reverse-proxy / WAF layers for those, not application code.
+- Self-XSS or attacks that require an attacker to already control the
+  victim's browser session.
+
+## Disclosure Coordination
+
+Once a fix is shipped, we'll publish a GitHub Security Advisory (with the
+reporter credited unless they request anonymity) and request a CVE if the
+issue warrants one. Please don't disclose details publicly — including via
+social media, blog posts, or conference talks — until the advisory is
+published.


### PR DESCRIPTION
## Summary

API-side mirror of [ontokit-web#195](https://github.com/CatholicOS/ontokit-web/pull/195). Same vulnerability reporting / Semgrep policy / suppression-discipline / out-of-scope content; API-specific adjustments:

- Reporting URL points at `ontokit-api`'s advisories page
- Suppression syntax example shown only for Python
- Out-of-scope paths reference `tests/`, `alembic/versions/`, `docs/` (matching `.semgrepignore` here)
- Cross-references #124 / PR #126 so contributors follow the existing `nosemgrep` triage style

GitHub renders \`SECURITY.md\` in the repo's "Security" tab, giving both surfaces consistent policy visibility.

## Test plan

- [ ] After merge, https://github.com/CatholicOS/ontokit-api/security renders the policy
- [ ] The Security Advisory link in the doc resolves to the new-advisory form

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added security policy documentation outlining vulnerability reporting procedures, version support timelines, security scanning processes, and disclosure coordination guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->