### PR TITLE
fix(ops): detect stuck gRPC channel in login healthcheck (closes #130)

### DIFF
--- a/.claude/commands/post-merge.md
+++ b/.claude/commands/post-merge.md
@@ -15,7 +15,9 @@ Steps to perform:
    - Only `alembic/` changed (new migrations) → `docker compose up -d --force-recreate api worker` (recreates containers so migrations run on startup)
    - None of the above changed → `docker compose restart api worker` (picks up volume-mounted code changes)
 
-5. **Verify**: Run `docker compose ps` to confirm all services are healthy.
+5. **Restart the login container if api/worker were recreated**: If step 4 ran the rebuild or force-recreate path (i.e., the api/worker containers were recreated rather than just restarted), also run `docker compose restart login`. Recreating api/worker can sever the `ontokit-zitadel-login` container's persistent gRPC channel to Zitadel without it auto-reconnecting — see issue #130. Skip this if step 4 only restarted (no recreation).
+
+6. **Verify**: Run `docker compose ps` to confirm all services are healthy.
 
 Important:
 - The "no infra changes → restart" branch relies on the `./ontokit:/home/ontokit/app/ontokit:ro` volume mount in `compose.yaml` (api + worker services). If that mount is ever removed, restart will silently keep running the old code baked into the image and you'll need `docker compose up -d --build api worker` instead. Before relying on the restart path, confirm the mount still exists with `grep -A 1 "Mount source code" compose.yaml`.

--- a/compose.yaml
+++ b/compose.yaml
@@ -196,12 +196,18 @@ services:
       NEXT_PUBLIC_BASE_PATH: /ui/v2/login
       ZITADEL_SERVICE_USER_TOKEN_FILE: /zitadel-data/login-client.pat
       EMAIL_VERIFICATION: true
+    # Probe the username form page rather than the login landing. The
+    # form is server-rendered using config the login app fetches from
+    # Zitadel via gRPC, so a stuck gRPC channel produces an error
+    # fallback that lacks the `username-text-input` test-id marker. The
+    # plain landing page returns 200 even with a dead gRPC channel — see
+    # issue #130 for the failure mode this guards against.
     healthcheck:
       test:
         - CMD
         - node
         - -e
-        - "const http = require('http'); const req = http.get('http://localhost:3000/ui/v2/login', (res) => { process.exit(res.statusCode === 200 ? 0 : 1); }); req.on('error', () => process.exit(1)); req.setTimeout(5000, () => { req.destroy(); process.exit(1); });"
+        - "fetch('http://localhost:3000/ui/v2/login/loginname', { signal: AbortSignal.timeout(5000) }).then(async r => { if (!r.ok) process.exit(1); const body = await r.text(); process.exit(body.includes('data-testid=\"username-text-input\"') ? 0 : 1); }).catch(() => process.exit(1));"
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## Summary

- The current healthcheck on \`ontokit-zitadel-login\` reports \`healthy\` even when the container's persistent gRPC channel to Zitadel is dead, because it only probes \`/ui/v2/login\` (which returns 200 regardless).
- Replace it with a probe of \`/ui/v2/login/loginname\` that verifies the username form actually renders. The form is server-rendered using gRPC-fetched config; a stuck channel produces an error fallback that omits the \`data-testid="username-text-input"\` marker.
- Update the \`/post-merge\` skill to restart the login container whenever api/worker are recreated — the rebuild path is what caused the original gRPC severance.

Closes #130.

## Why this approach (and what it doesn't solve)

We considered three options before settling on this one:

- **(A) Body-content check on the form page.** What this PR does. Catches the actual stuck-channel state because the form depends on gRPC-fetched config. Tradeoff: the check depends on a hardcoded upstream string (\`data-testid="username-text-input"\`); if zitadel-login renames it in a future image bump, the healthcheck flips to unhealthy until we update.
- **(B) Composite TCP probe of login HTTP + Zitadel \`/debug/ready\`.** Doesn't catch the stuck-channel state we hit (Zitadel was reachable, login HTTP returned 200; only the in-process gRPC client was wedged). Strictly weaker than what this PR ships.
- **(C) Skill-level: restart login alongside api/worker rebuilds.** Treats the most common cause (Docker network disruption from rebuilds) at the source. Cheap, no detection logic to maintain. Combined with (A) for residual cases.

This PR ships A + C. (B) is omitted.

## Verification

- \`docker compose config\` validates the new compose.yaml.
- Steady-state: \`force-recreate login\`, wait for healthcheck cycle → reports \`healthy\` (exit 0).
- Negative tests (run inside container):
  - Marker absent in body → script exits 1 ✓
  - Connection refused → script exits 1 ✓
- Unhealthy-detection latency: \`interval=30s × retries=3\` ≈ 90s from breakage to \`unhealthy\`. The acceptance criterion was "within ~1 minute" — 90s is a touch over but reasonable for a startup/network blip tolerance budget. Tunable later if it proves too lax.

## Acceptance criteria (from #130)

- [x] When the gRPC connection between \`login\` and \`zitadel\` is broken, \`docker compose ps\` reports the login container as unhealthy within ~1 minute (90s; see above).
- [x] When the connection recovers (or after \`docker compose restart login\`), the container returns to healthy.
- [x] Documented in compose.yaml (comment block above the new healthcheck explains what's being verified and links #130).

## Test plan

- [x] \`docker compose config\` validates
- [x] Steady-state: healthcheck reports healthy
- [x] Negative test (missing marker): script exits 1
- [x] Negative test (connection refused): script exits 1
- [ ] After merge + post-merge rebuild path runs, login container reaches healthy (you'll see this naturally on the next infra-changing merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated post-merge deployment workflow to conditionally restart the login service when Docker containers are recreated, preserving persistent authentication connections
  * Enhanced login service health checks by validating form element rendering and enforcing strict connection timeouts for more reliable verification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->