### PR TITLE
chore(packaging): add Python 3.13 to pyproject classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 


### PR DESCRIPTION
## Summary

The `pyproject.toml` `classifiers` list was stale. It advertised only Python 3.11 and 3.12 on PyPI even though the project has been on Python 3.13 for some time:

- `.python-version` = `3.13`
- `Dockerfile` and `Dockerfile.prod` use `python:3.13-slim`
- CI resolves Python 3.13

Since `requires-python = ">=3.11"` was already correct, installs were never affected — this was purely PyPI metadata drift. This PR adds `"Programming Language :: Python :: 3.13"` to the classifiers (in semver-ascending order) so PyPI metadata matches the actual supported runtime.

3.11 and 3.12 are kept in the classifiers list because `requires-python = ">=3.11"` still allows them; dropping 3.11 from the classifiers without bumping `requires-python` would be inconsistent. Whether 3.11 is still officially supported (and whether to bump `requires-python`) is a separate policy decision and is deferred.

## Test plan

- [ ] CI lint, typecheck, and build pass on this branch
- [x] Manual sanity check: `python -c "import tomllib; tomllib.load(open('pyproject.toml','rb'))"` — file still parses
- [x] Manual sanity check: `uv build --sdist` completes successfully with the updated metadata
- [x] Classifiers list is in semver-ascending order (3.11, 3.12, 3.13)

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)