### PR TITLE
fix(worker): use json.dumps for redis.publish payloads

### DIFF
--- a/ontokit/worker.py
+++ b/ontokit/worker.py
@@ -202,7 +202,13 @@ async def run_lint_task(
         # Notify via pubsub that lint has started
         await redis.publish(
             LINT_UPDATES_CHANNEL,
-            f'{{"type": "lint_started", "project_id": "{project_id}", "run_id": "{run_id}"}}',
+            json.dumps(
+                {
+                    "type": "lint_started",
+                    "project_id": project_id,
+                    "run_id": str(run_id),
+                }
+            ),
         )
 
         # Load ontology from storage
@@ -246,8 +252,14 @@ async def run_lint_task(
         # Notify via pubsub that lint is complete
         await redis.publish(
             LINT_UPDATES_CHANNEL,
-            f'{{"type": "lint_complete", "project_id": "{project_id}", '
-            f'"run_id": "{run_id}", "issues_found": {len(lint_results)}}}',
+            json.dumps(
+                {
+                    "type": "lint_complete",
+                    "project_id": project_id,
+                    "run_id": str(run_id),
+                    "issues_found": len(lint_results),
+                }
+            ),
         )
 
         return {
@@ -269,8 +281,14 @@ async def run_lint_task(
             # Notify via pubsub that lint failed
             await redis.publish(
                 LINT_UPDATES_CHANNEL,
-                f'{{"type": "lint_failed", "project_id": "{project_id}", '
-                f'"run_id": "{run.id}", "error": "{str(e)}"}}',
+                json.dumps(
+                    {
+                        "type": "lint_failed",
+                        "project_id": project_id,
+                        "run_id": str(run.id),
+                        "error": str(e),
+                    }
+                ),
             )
 
         raise
@@ -316,8 +334,13 @@ async def check_normalization_status_task(
         # Publish status update via Redis
         await redis.publish(
             NORMALIZATION_UPDATES_CHANNEL,
-            f'{{"type": "normalization_status", "project_id": "{project_id}", '
-            f'"needs_normalization": {str(status["needs_normalization"]).lower()}}}',
+            json.dumps(
+                {
+                    "type": "normalization_status",
+                    "project_id": project_id,
+                    "needs_normalization": status["needs_normalization"],
+                }
+            ),
         )
 
         logger.info(
@@ -376,8 +399,13 @@ async def run_normalization_task(
         # Notify start
         await redis.publish(
             NORMALIZATION_UPDATES_CHANNEL,
-            f'{{"type": "normalization_started", "project_id": "{project_id}", '
-            f'"dry_run": {str(dry_run).lower()}}}',
+            json.dumps(
+                {
+                    "type": "normalization_started",
+                    "project_id": project_id,
+                    "dry_run": dry_run,
+                }
+            ),
         )
 
         # Get project
@@ -418,9 +446,15 @@ async def run_normalization_task(
         # Notify completion
         await redis.publish(
             NORMALIZATION_UPDATES_CHANNEL,
-            f'{{"type": "normalization_complete", "project_id": "{project_id}", '
-            f'"run_id": "{run.id}", "dry_run": {str(dry_run).lower()}, '
-            f'"commit_hash": "{run.commit_hash or ""}"}}',
+            json.dumps(
+                {
+                    "type": "normalization_complete",
+                    "project_id": project_id,
+                    "run_id": str(run.id),
+                    "dry_run": dry_run,
+                    "commit_hash": run.commit_hash or "",
+                }
+            ),
         )
 
         return {
@@ -437,8 +471,13 @@ async def run_normalization_task(
         # Notify failure
         await redis.publish(
             NORMALIZATION_UPDATES_CHANNEL,
-            f'{{"type": "normalization_failed", "project_id": "{project_id}", '
-            f'"error": "{str(e)}"}}',
+            json.dumps(
+                {
+                    "type": "normalization_failed",
+                    "project_id": project_id,
+                    "error": str(e),
+                }
+            ),
         )
 
         return {
@@ -477,8 +516,13 @@ async def check_all_projects_normalization(ctx: dict[str, Any]) -> dict[str, Any
                     # Publish status update
                     await redis.publish(
                         NORMALIZATION_UPDATES_CHANNEL,
-                        f'{{"type": "normalization_status", "project_id": "{project.id}", '
-                        f'"needs_normalization": true}}',
+                        json.dumps(
+                            {
+                                "type": "normalization_status",
+                                "project_id": str(project.id),
+                                "needs_normalization": True,
+                            }
+                        ),
                     )
             except Exception as e:
                 logger.warning(f"Failed to check normalization for project {project.id}: {e}")
@@ -699,7 +743,12 @@ async def run_remote_check_task(
         # Notify start
         await redis.publish(
             REMOTE_SYNC_UPDATES_CHANNEL,
-            f'{{"type": "remote_check_started", "project_id": "{project_id}"}}',
+            json.dumps(
+                {
+                    "type": "remote_check_started",
+                    "project_id": project_id,
+                }
+            ),
         )
 
         # Get a GitHub token — try the project's connected user first
@@ -789,8 +838,13 @@ async def run_remote_check_task(
         # Notify completion
         await redis.publish(
             REMOTE_SYNC_UPDATES_CHANNEL,
-            f'{{"type": "remote_check_complete", "project_id": "{project_id}", '
-            f'"has_changes": {str(has_changes).lower()}}}',
+            json.dumps(
+                {
+                    "type": "remote_check_complete",
+                    "project_id": project_id,
+                    "has_changes": has_changes,
+                }
+            ),
         )
 
         return {
@@ -826,7 +880,13 @@ async def run_remote_check_task(
         # Notify failure
         await redis.publish(
             REMOTE_SYNC_UPDATES_CHANNEL,
-            f'{{"type": "remote_check_failed", "project_id": "{project_id}", "error": "{str(e)}"}}',
+            json.dumps(
+                {
+                    "type": "remote_check_failed",
+                    "project_id": project_id,
+                    "error": str(e),
+                }
+            ),
         )
 
         raise


### PR DESCRIPTION
## Summary

`ontokit/worker.py` previously built Redis pubsub payloads via f-string-formatted JSON. This was fragile, and outright **buggy** in three places — `lint_failed`, `normalization_failed`, and `remote_check_failed` interpolated `str(e)` directly into the JSON string, so any exception message containing a `"`, `\`, or newline produced invalid JSON for subscribers calling `json.loads(payload)`.

This PR replaces every f-string JSON payload with `json.dumps({...})`. `json` was already imported at the top of the file.

## Sites changed (11 total)

- `lint_started`, `lint_complete`, `lint_failed`
- `normalization_status` (status check task), `normalization_started`, `normalization_complete`, `normalization_failed`, `normalization_status` (per-project loop in `check_all_projects_normalization` cron)
- `remote_check_started`, `remote_check_complete`, `remote_check_failed`

## Schema unchanged — subscribers unaffected

- Same `type` values, same field names, same ordering.
- UUIDs are stringified the same way as before (`str(run.id)` etc.).
- Booleans are now passed as actual Python bools — `json.dumps` emits `true`/`false`, replacing the prior `str(x).lower()` workaround. The wire format is identical.
- Integer fields (e.g. `issues_found`) remain ints.

## Test plan

- [x] `ruff check ontokit/worker.py` — passes
- [x] `ruff format ontokit/worker.py` — no changes
- [x] `mypy ontokit/worker.py` (strict) — passes
- [x] `pytest tests/unit/test_worker.py -v` — all 51 worker tests pass (worker.py coverage 99%)
- [x] Pre-commit hooks (ruff, ruff format, mypy) all pass on commit
- [x] Manually round-trip-verified all 11 payload schemas through `json.dumps` → `json.loads` with adversarial error strings (containing `"`, `\n`, `\\`)

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal message handling and data serialization to ensure consistent formatting across system event publications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->