### PR TITLE
fix: prevent startup hang on unreachable MinIO/DB

### DIFF
--- a/ontokit/main.py
+++ b/ontokit/main.py
@@ -51,10 +51,15 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
     logger.info("Starting OntoKit API v%s (env=%s)", __version__, settings.app_env)
 
     # --- Database (required — fail fast on hang) ----------------------------
+    # asyncio.timeout() bounds the entire connect-and-execute block: a stuck
+    # TCP handshake in engine.connect() needs the same fail-fast behavior as
+    # a stuck query, otherwise startup can hang indefinitely on an unreachable
+    # database.
     _startup_print("Connecting to database...")
     try:
-        async with engine.connect() as conn:
-            await asyncio.wait_for(conn.execute(text("SELECT 1")), timeout=20.0)
+        async with asyncio.timeout(20.0):
+            async with engine.connect() as conn:
+                await conn.execute(text("SELECT 1"))
         _startup_print("Database connection verified")
         logger.info("Database connection verified")
     except TimeoutError:

--- a/ontokit/main.py
+++ b/ontokit/main.py
@@ -1,6 +1,8 @@
 """OntoKit API - Main FastAPI Application."""
 
+import asyncio
 import logging
+import sys
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
@@ -34,23 +36,38 @@ redis_pool: aioredis.Redis | None = None
 limiter = Limiter(key_func=get_remote_address, default_limits=["100/minute"])
 
 
+def _startup_print(message: str) -> None:
+    # Mirror lifespan progress to stderr so it surfaces in Railway/container
+    # deploy logs even when the logging pipeline isn't fully configured yet.
+    print(f"[ontokit] {message}", file=sys.stderr, flush=True)
+
+
 @asynccontextmanager
 async def lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
     """Application lifespan handler for startup/shutdown events."""
     global redis_pool  # noqa: PLW0603
 
+    _startup_print(f"Starting OntoKit API v{__version__} (env={settings.app_env})")
     logger.info("Starting OntoKit API v%s (env=%s)", __version__, settings.app_env)
 
-    # --- Database -----------------------------------------------------------
+    # --- Database (required — fail fast on hang) ----------------------------
+    _startup_print("Connecting to database...")
     try:
         async with engine.connect() as conn:
-            await conn.execute(text("SELECT 1"))
+            await asyncio.wait_for(conn.execute(text("SELECT 1")), timeout=20.0)
+        _startup_print("Database connection verified")
         logger.info("Database connection verified")
+    except TimeoutError:
+        _startup_print("Database connection timed out after 20s")
+        logger.exception("Database connection timed out")
+        raise
     except Exception:
+        _startup_print("Failed to connect to the database")
         logger.exception("Failed to connect to the database")
         raise
 
-    # --- Redis --------------------------------------------------------------
+    # --- Redis (optional) ---------------------------------------------------
+    _startup_print("Connecting to Redis...")
     try:
         pool = aioredis.from_url(  # type: ignore[no-untyped-call]
             str(settings.redis_url),
@@ -60,19 +77,31 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
         )
         await pool.ping()
         redis_pool = pool
+        _startup_print("Redis connection verified")
         logger.info("Redis connection verified")
     except Exception:
+        _startup_print("Failed to connect to Redis — continuing startup")
         logger.exception("Failed to connect to Redis — continuing startup")
         redis_pool = None
 
-    # --- MinIO / Object Storage ---------------------------------------------
+    # --- MinIO / Object Storage (optional) ----------------------------------
+    # MinIO's Python client is synchronous; StorageService now wraps it in
+    # asyncio.to_thread, but we still bound the call so a stuck MinIO can't
+    # delay startup beyond 15s.
+    _startup_print("Verifying MinIO bucket...")
     try:
         storage = StorageService()
-        await storage.ensure_bucket_exists()
+        await asyncio.wait_for(storage.ensure_bucket_exists(), timeout=15.0)
+        _startup_print(f"MinIO bucket '{settings.minio_bucket}' is ready")
         logger.info("MinIO bucket '%s' is ready", settings.minio_bucket)
+    except TimeoutError:
+        _startup_print("MinIO bucket check timed out after 15s — continuing startup")
+        logger.exception("MinIO bucket check timed out — continuing startup")
     except Exception:
+        _startup_print("Failed to initialise MinIO storage — continuing startup")
         logger.exception("Failed to initialise MinIO storage — continuing startup")
 
+    _startup_print("Startup complete")
     logger.info("Startup complete")
 
     yield

--- a/ontokit/services/storage.py
+++ b/ontokit/services/storage.py
@@ -1,5 +1,6 @@
 """Storage service for MinIO object storage integration."""
 
+import asyncio
 from io import BytesIO
 
 from minio import Minio
@@ -29,8 +30,11 @@ class StorageService:
     async def ensure_bucket_exists(self) -> None:
         """Ensure the bucket exists, creating it if necessary."""
         try:
-            if not self.client.bucket_exists(self.bucket):
-                self.client.make_bucket(self.bucket)
+            # MinIO's Python client is synchronous (urllib3); run in a thread
+            # so it never blocks the asyncio event loop.
+            exists = await asyncio.to_thread(self.client.bucket_exists, self.bucket)
+            if not exists:
+                await asyncio.to_thread(self.client.make_bucket, self.bucket)
         except S3Error as e:
             raise StorageError(f"Failed to ensure bucket exists: {e}") from e
 
@@ -51,7 +55,8 @@ class StorageService:
         """
         try:
             await self.ensure_bucket_exists()
-            self.client.put_object(
+            await asyncio.to_thread(
+                self.client.put_object,
                 bucket_name=self.bucket,
                 object_name=object_name,
                 data=BytesIO(data),
@@ -76,12 +81,13 @@ class StorageService:
             StorageError: If the download fails
         """
         try:
-            response = self.client.get_object(
+            response = await asyncio.to_thread(
+                self.client.get_object,
                 bucket_name=self.bucket,
                 object_name=object_name,
             )
             try:
-                return response.read()
+                return await asyncio.to_thread(response.read)
             finally:
                 response.close()
                 response.release_conn()
@@ -99,7 +105,8 @@ class StorageService:
             StorageError: If the deletion fails
         """
         try:
-            self.client.remove_object(
+            await asyncio.to_thread(
+                self.client.remove_object,
                 bucket_name=self.bucket,
                 object_name=object_name,
             )
@@ -117,7 +124,8 @@ class StorageService:
             True if the file exists, False otherwise
         """
         try:
-            self.client.stat_object(
+            await asyncio.to_thread(
+                self.client.stat_object,
                 bucket_name=self.bucket,
                 object_name=object_name,
             )

--- a/ontokit/services/storage.py
+++ b/ontokit/services/storage.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from io import BytesIO
+from typing import Any
 
 from minio import Minio
 from minio.error import S3Error
@@ -13,6 +14,17 @@ class StorageError(Exception):
     """Exception raised for storage operation errors."""
 
     pass
+
+
+def _read_and_release(response: Any) -> bytes:
+    # urllib3's release_conn() can do socket I/O; combine with read() so the
+    # whole response lifecycle stays off the event loop.
+    try:
+        data: bytes = response.read()
+        return data
+    finally:
+        response.close()
+        response.release_conn()
 
 
 class StorageService:
@@ -86,11 +98,7 @@ class StorageService:
                 bucket_name=self.bucket,
                 object_name=object_name,
             )
-            try:
-                return await asyncio.to_thread(response.read)
-            finally:
-                response.close()
-                response.release_conn()
+            return await asyncio.to_thread(_read_and_release, response)
         except S3Error as e:
             raise StorageError(f"Failed to download file: {e}") from e
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -2,15 +2,17 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
-from unittest.mock import Mock
+from typing import Any
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 from fastapi.testclient import TestClient
 
 from ontokit.core.config import settings
 from ontokit.core.exceptions import ConflictError, ForbiddenError, NotFoundError, ValidationError
-from ontokit.main import app, unhandled_exception_handler
+from ontokit.main import app, lifespan, unhandled_exception_handler
 
 
 @pytest.fixture
@@ -165,3 +167,141 @@ class TestUnhandledExceptionHandler:
 
         with pytest.raises(RuntimeError, match="kaboom"):
             await unhandled_exception_handler(Mock(), RuntimeError("kaboom"))
+
+
+class TestLifespan:
+    """Tests for the application lifespan (startup + shutdown).
+
+    These exercise the timeout / fail-fast paths added by PR #138 so that an
+    unreachable database fails startup quickly and an unreachable Redis or
+    MinIO degrades gracefully without blocking startup.
+    """
+
+    @pytest.fixture
+    def patched_lifespan(self, monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+        """Patch every external dependency the lifespan touches.
+
+        Returns the mocks so individual tests can override behavior (e.g. raise
+        TimeoutError) and assert on calls.
+        """
+        # Reset module-level redis_pool so leftover state from a previous test
+        # doesn't affect shutdown branches.
+        import ontokit.main as main_module
+
+        monkeypatch.setattr(main_module, "redis_pool", None)
+
+        mock_conn = AsyncMock()
+        mock_conn.execute = AsyncMock()
+
+        connect_cm = AsyncMock()
+        connect_cm.__aenter__.return_value = mock_conn
+        connect_cm.__aexit__.return_value = None
+
+        mock_engine = Mock()
+        mock_engine.connect = Mock(return_value=connect_cm)
+        mock_engine.dispose = AsyncMock()
+        monkeypatch.setattr(main_module, "engine", mock_engine)
+
+        redis_pool_mock = AsyncMock()
+        redis_pool_mock.ping = AsyncMock()
+        redis_pool_mock.close = AsyncMock()
+        from_url = Mock(return_value=redis_pool_mock)
+        # Patch via string path so mypy strict mode doesn't object to
+        # `main_module.aioredis` (the alias isn't explicitly re-exported).
+        monkeypatch.setattr("ontokit.main.aioredis.from_url", from_url)
+
+        storage_instance = Mock()
+        storage_instance.ensure_bucket_exists = AsyncMock()
+        storage_cls = Mock(return_value=storage_instance)
+        monkeypatch.setattr(main_module, "StorageService", storage_cls)
+
+        close_arq = AsyncMock()
+        monkeypatch.setattr("ontokit.api.utils.redis.close_arq_pool", close_arq)
+
+        return {
+            "engine": mock_engine,
+            "conn": mock_conn,
+            "redis_pool": redis_pool_mock,
+            "redis_from_url": from_url,
+            "storage": storage_instance,
+            "close_arq": close_arq,
+        }
+
+    @pytest.mark.asyncio
+    async def test_happy_path_runs_startup_and_shutdown(
+        self, patched_lifespan: dict[str, Any]
+    ) -> None:
+        """When every backend is healthy, startup verifies all of them and
+        shutdown disposes the engine and closes the Redis + ARQ pools."""
+        async with lifespan(Mock()):
+            patched_lifespan["conn"].execute.assert_awaited_once()
+            patched_lifespan["redis_pool"].ping.assert_awaited_once()
+            patched_lifespan["storage"].ensure_bucket_exists.assert_awaited_once()
+
+        patched_lifespan["redis_pool"].close.assert_awaited_once()
+        patched_lifespan["close_arq"].assert_awaited_once()
+        patched_lifespan["engine"].dispose.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_database_timeout_aborts_startup(self, patched_lifespan: dict[str, Any]) -> None:
+        """A stuck DB connect must abort startup — we re-raise TimeoutError so
+        the container exits and is restarted by the orchestrator."""
+        patched_lifespan["conn"].execute.side_effect = asyncio.TimeoutError
+
+        with pytest.raises(asyncio.TimeoutError):
+            async with lifespan(Mock()):
+                pytest.fail("lifespan should not have yielded after DB timeout")
+
+    @pytest.mark.asyncio
+    async def test_database_failure_aborts_startup(self, patched_lifespan: dict[str, Any]) -> None:
+        """A non-timeout DB error (auth failure, bad config) also aborts."""
+        patched_lifespan["conn"].execute.side_effect = RuntimeError("connection refused")
+
+        with pytest.raises(RuntimeError, match="connection refused"):
+            async with lifespan(Mock()):
+                pytest.fail("lifespan should not have yielded after DB failure")
+
+    @pytest.mark.asyncio
+    async def test_redis_failure_continues_startup(self, patched_lifespan: dict[str, Any]) -> None:
+        """Redis is optional — its failure must not block startup, and the
+        module-level redis_pool must be left as None so feature code can
+        detect the degraded state."""
+        import ontokit.main as main_module
+
+        patched_lifespan["redis_pool"].ping.side_effect = RuntimeError("redis down")
+
+        async with lifespan(Mock()):
+            assert main_module.redis_pool is None
+
+    @pytest.mark.asyncio
+    async def test_minio_timeout_continues_startup(self, patched_lifespan: dict[str, Any]) -> None:
+        """MinIO is optional — a timeout must be swallowed so the API still
+        comes up serving non-storage endpoints."""
+        patched_lifespan["storage"].ensure_bucket_exists.side_effect = asyncio.TimeoutError
+
+        async with lifespan(Mock()):
+            patched_lifespan["storage"].ensure_bucket_exists.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_minio_failure_continues_startup(self, patched_lifespan: dict[str, Any]) -> None:
+        """Same for non-timeout MinIO errors (auth, missing bucket, etc.)."""
+        patched_lifespan["storage"].ensure_bucket_exists.side_effect = RuntimeError("nope")
+
+        async with lifespan(Mock()):
+            patched_lifespan["storage"].ensure_bucket_exists.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_shutdown_swallows_cleanup_errors(self, patched_lifespan: dict[str, Any]) -> None:
+        """Shutdown must complete even if individual cleanup steps raise —
+        otherwise a flaky Redis can mask other shutdown work."""
+        patched_lifespan["redis_pool"].close.side_effect = RuntimeError("close failed")
+        patched_lifespan["close_arq"].side_effect = RuntimeError("arq close failed")
+        patched_lifespan["engine"].dispose.side_effect = RuntimeError("dispose failed")
+
+        # No exception should escape the lifespan exit.
+        async with lifespan(Mock()):
+            pass
+
+        patched_lifespan["redis_pool"].close.assert_awaited_once()
+        patched_lifespan["close_arq"].assert_awaited_once()
+        patched_lifespan["engine"].dispose.assert_awaited_once()


### PR DESCRIPTION
## Summary

`StorageService` methods are declared `async` but call the synchronous MinIO Python client (`urllib3`) directly, blocking the event loop until the request returns. When MinIO is unreachable from a Railway container, lifespan startup hangs indefinitely with no log output.

## Changes

- **`ontokit/services/storage.py`** — wrap every MinIO client call in `asyncio.to_thread` so async callers (lifespan, routes, workers) never block the event loop.
- **`ontokit/main.py`** lifespan:
  - Bound the database connect with `asyncio.wait_for(20s)` so a stuck DB fails fast instead of hanging the boot.
  - Bound the MinIO bucket check with `asyncio.wait_for(15s)`; MinIO is optional, so a timeout warns and continues startup.
  - Mirror lifespan progress to stderr so Railway/container deploy logs show startup steps even before the logging pipeline is configured.

## Test plan

- [x] Existing tests pass: `pytest tests/` → 1329 passed
- [x] `ruff check ontokit/` clean
- [x] `mypy ontokit/` clean
- [ ] Verify on Railway: app starts cleanly with reachable services
- [ ] Verify on Railway: app boot fails fast (≤20s) with unreachable DB instead of hanging
- [ ] Verify on Railway: app boot continues (with warning) when MinIO is unreachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Database connectivity verification now enforces timeout protection with clearer feedback messages
  * Object storage initialization is non-blocking; startup continues even on unavailability
  * Redis connection failures no longer prevent application startup; treated as optional service
  * Enhanced startup progress messaging for improved visibility into initialization status

<!-- end of auto-generated comment: release notes by coderabbit.ai -->