### PR TITLE
fix(security): triage 4 Semgrep SQL-injection FPs in lint.py

### DIFF
--- a/ontokit/api/routes/lint.py
+++ b/ontokit/api/routes/lint.py
@@ -255,6 +255,10 @@ async def list_lint_runs(
     total = count_result.scalar() or 0
 
     # Get runs
+    # skip/limit are FastAPI Query params typed as int with ge=0 / ge=1,le=100
+    # bounds — they cannot carry SQL. SQLAlchemy .offset()/.limit() bind their
+    # arguments as parameters, so the resulting query is parameterized.
+    # nosemgrep: python.fastapi.db.generic-sql-fastapi.generic-sql-fastapi
     result = await db.execute(
         select(LintRun)
         .where(LintRun.project_id == project_id)
@@ -420,6 +424,11 @@ async def get_lint_issues(
         .limit(limit)
     )
 
+    # skip/limit are FastAPI Query params typed as int with ge=0 / ge=1,le=500
+    # bounds, and the issue_type/rule_id/subject_iri filters reach the query
+    # through SQLAlchemy .where() comparisons that bind as parameters. None of
+    # the user-controlled values are interpolated into SQL text.
+    # nosemgrep: python.fastapi.db.generic-sql-fastapi.generic-sql-fastapi
     result = await db.execute(query)
     issues = result.scalars().all()
 
@@ -588,6 +597,12 @@ async def update_lint_config(
     # Upsert to handle concurrent first-time PUTs safely; RETURNING gives
     # us the persisted row in the same round trip. Wrapping in select(...).from_statement(...)
     # with populate_existing materializes the returned row as an ORM instance.
+    #
+    # body.lint_level / body.enabled_rules are validated by the Pydantic
+    # LintConfigUpdate schema, and pg_insert(...).values(...) plus
+    # on_conflict_do_update(set_=...) bind them as INSERT/UPDATE parameters.
+    # from_statement() below receives a SQLAlchemy Core Insert (not text()),
+    # so the resulting execute() runs a parameterized statement.
     insert_stmt = (
         pg_insert(ProjectLintConfig)
         .values(
@@ -607,9 +622,11 @@ async def update_lint_config(
     )
     orm_stmt = (
         select(ProjectLintConfig)
+        # nosemgrep: python.fastapi.db.sqlalchemy-fastapi.sqlalchemy-fastapi
         .from_statement(insert_stmt)
         .execution_options(populate_existing=True)
     )
+    # nosemgrep: python.fastapi.db.generic-sql-fastapi.generic-sql-fastapi
     result = await db.execute(orm_stmt)
     config = result.scalar_one()
     await db.commit()


### PR DESCRIPTION
## Summary

The Semgrep CI gate has been red on `dev` since 2026-04-28 (5 consecutive merges) due to four false-positive findings on `ontokit/api/routes/lint.py`. The Pro taint engine follows validated FastAPI request inputs into SQLAlchemy core constructs and flags them as SQL-injection sinks, even though every flagged sink uses bound parameters.

This PR adds inline `# nosemgrep:` suppressions with per-site justifications, following the baseline pattern established in PR #126.

### Why these are false positives

| Site | Flagged sink | Why safe |
|------|--------------|----------|
| `list_lint_runs` (line 258) | `.offset(skip).limit(limit)` | `skip`/`limit` are FastAPI `Query(..., ge=0)` / `Query(..., ge=1, le=100)` — validated `int`. SQLAlchemy `.offset()`/`.limit()` bind their arguments as parameters. |
| `get_lint_issues` (line 427) | `db.execute(query)` | Same chain — `query = select(LintIssue).where(...).offset(skip).limit(limit)` with validated ints and `.where()` parameter binding. |
| `update_lint_config` (line 619) | `.from_statement(insert_stmt)` | `body: LintConfigUpdate` is a Pydantic model; `pg_insert(...).values(...)` and `.on_conflict_do_update(set_=...)` produce parameterized INSERT/UPDATE. `from_statement()` here receives a SQLAlchemy Core `Insert`, not a `text()`. |
| `update_lint_config` (line 622) | `db.execute(orm_stmt)` | Same chain; second sink. |

Locally without `--pro` neither rule fires (cross-function taint is Pro-engine only), so this only surfaces in CI against the server policy.

## Test plan

- [x] `ruff check` / `ruff format --check` clean on the modified file
- [x] `mypy` clean (pre-commit hook ran)
- [x] `pytest -k lint` — 147 passed
- [ ] Semgrep CI on this PR is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Internal documentation and code quality improvements to the lint API. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->