### PR TITLE
fix(security): move list_lint_runs nosem inside db.execute()

### DIFF
--- a/ontokit/api/routes/lint.py
+++ b/ontokit/api/routes/lint.py
@@ -258,8 +258,8 @@ async def list_lint_runs(
     # skip/limit are FastAPI Query params typed as int with ge=0 / ge=1,le=100
     # bounds — they cannot carry SQL. SQLAlchemy .offset()/.limit() bind their
     # arguments as parameters, so the resulting query is parameterized.
-    # nosemgrep: python.fastapi.db.generic-sql-fastapi.generic-sql-fastapi
     result = await db.execute(
+        # nosemgrep: python.fastapi.db.generic-sql-fastapi.generic-sql-fastapi
         select(LintRun)
         .where(LintRun.project_id == project_id)
         .order_by(LintRun.started_at.desc())


### PR DESCRIPTION
## Summary

Follow-up to PR #139. The Semgrep CI gate is still red on `dev` because one of the four suppressions didn't take effect: in `list_lint_runs`, the Pro engine matches the inner `select(...).offset(skip).limit(limit)` chain as the sink, not the outer `await db.execute(...)`. `# nosemgrep:` only suppresses the immediately following line, so a comment placed above the wrapping `db.execute(` was ignored.

This moves the comment inside the parens so it sits directly above `select(LintRun)` — matching the actual sink line — which brings it into line with the three other call sites that were suppressed correctly in PR #139.

Run that surfaced the remaining finding: https://github.com/CatholicOS/ontokit-api/actions/runs/25263320286/job/74074023761 (1 Blocking Code Finding remaining, down from 4).

## Test plan

- [x] `ruff check` / `ruff format --check` clean
- [x] `mypy` clean (pre-commit hook ran)
- [ ] Semgrep CI on this PR is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)