### PR TITLE
chore(deps): group dependabot updates and auto-rebase stale PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,20 @@ updates:
     schedule:
       interval: "weekly"
     rebase-strategy: "auto"
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     rebase-strategy: "auto"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,6 @@ updates:
       github-actions:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/dependabot-rebase-on-push.yml
+++ b/.github/workflows/dependabot-rebase-on-push.yml
@@ -1,0 +1,30 @@
+name: Rebase Dependabot PRs on dev push
+
+on:
+  push:
+    branches: [dev]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  rebase:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Request rebase on stale dependabot PRs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          mapfile -t prs < <(
+            gh pr list --repo "$REPO" \
+              --author 'app/dependabot' \
+              --base dev \
+              --state open \
+              --json number,mergeStateStatus \
+              --jq '.[] | select(.mergeStateStatus == "BEHIND") | .number'
+          )
+          for pr in "${prs[@]}"; do
+            echo "Requesting rebase of PR #$pr"
+            gh pr comment "$pr" --repo "$REPO" --body "@dependabot rebase"
+          done

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -1,0 +1,43 @@
+name: OSV-Scanner
+
+on:
+  pull_request:
+    branches: [dev]
+  push:
+    branches: [dev, main]
+  # Weekly drift check: a previously-clean lockfile can grow new findings
+  # when fresh advisories land in the OSV database. Monday 06:00 UTC =
+  # quiet time across most timezones; results are ready at the start of
+  # the EU work week. Mirrors the cadence of semgrep.yml.
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  # Required to upload SARIF to the Code Scanning tab.
+  # See: https://github.com/github/codeql-action/issues/2117
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  # Diff-aware scan on PRs: only flags vulnerabilities the PR introduces.
+  # Pre-existing findings stay visible in the scheduled run but won't
+  # block unrelated PRs.
+  scan-pr:
+    if: ${{ github.event_name == 'pull_request' }}
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@3d5827dbebf8a3f7ba681e730a8a1b116e8ebddd # v2.3.5
+    with:
+      scan-args: |-
+        -r
+        ./
+
+  # Full scan on push / schedule / manual dispatch. Uploads SARIF so
+  # findings show up in the Security tab.
+  scan-full:
+    if: ${{ github.event_name != 'pull_request' }}
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@3d5827dbebf8a3f7ba681e730a8a1b116e8ebddd # v2.3.5
+    with:
+      scan-args: |-
+        -r
+        ./

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -21,11 +21,13 @@ permissions:
   security-events: write
 
 jobs:
-  # Diff-aware scan on PRs: only flags vulnerabilities the PR introduces.
-  # Pre-existing findings stay visible in the scheduled run but won't
-  # block unrelated PRs.
+  # Diff-aware scan on Dependabot PRs only — Semgrep Supply Chain (run via
+  # `semgrep ci` in semgrep.yml) already covers human-authored PRs, but is
+  # skipped on Dependabot since SEMGREP_APP_TOKEN is unreadable from the
+  # Dependabot secret scope. OSV-Scanner closes that gap.
+  # Pre-existing findings stay visible in the scheduled `scan-full` run.
   scan-pr:
-    if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ github.event_name == 'pull_request' && github.actor == 'dependabot[bot]' }}
     uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@3d5827dbebf8a3f7ba681e730a8a1b116e8ebddd # v2.3.5
     with:
       scan-args: |-


### PR DESCRIPTION
## Summary
- Group dependabot's weekly minor/patch python bumps into one PR (and github-actions bumps into one PR) via `groups:` in `.github/dependabot.yml`. Major bumps stay as individual PRs so they still get manual review.
- Add `.github/workflows/dependabot-rebase-on-push.yml`: on every push to `dev`, post `@dependabot rebase` on any open dependabot PR whose `mergeStateStatus` is `BEHIND`.

## Why
The `dev` branch ruleset uses `strict_required_status_checks_policy: true` ("require branches to be up to date before merging"). When dependabot opens N PRs that all touch `uv.lock`, the first one merges, advances `dev`, and the rest go `BEHIND`. Auto-merge with rebase doesn't update-from-base on its own, so the cascade stalls — exactly what happened to PRs #142–#146.

Grouping shrinks N→1 in the common case; the rebase-on-push workflow handles the residual cases (multi-ecosystem weeks, manual feature merges landing while a dependabot PR is open).

## Test plan
- [ ] Once merged, push a small commit to `dev` and confirm the new workflow runs and (if any dependabot PR is still `BEHIND`) posts `@dependabot rebase` on it.
- [ ] Verify next weekly dependabot run produces a single grouped python PR rather than one per package.
- [ ] Confirm PRs #144, #145, #146 (and #142 once its conflict resolves) merge automatically without further manual rebase commands after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Dependabot configuration with organized Python dependency groups and restricted update types (minor and patch releases only) to improve stability and control over dependency changes.
  * Introduced automated workflow that automatically rebases Dependabot pull requests whenever changes are pushed to the development branch, ensuring dependency updates remain current and mergeable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->