### PR TITLE
ci(deps): add 30-min cron to rebase stale Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-rebase-on-push.yml
+++ b/.github/workflows/dependabot-rebase-on-push.yml
@@ -1,8 +1,17 @@
-name: Rebase Dependabot PRs on dev push
+name: Rebase stale Dependabot PRs
 
+# Push trigger: catches the common case where dev advances under
+# already-open dependabot PRs.
+# Schedule trigger: catches the race where a fresh dependabot PR is
+# opened against a stale base SHA (e.g., dev got a merge during the
+# few-minute window dependabot took to open the PR). Self-heals
+# within 30 min, no manual `@dependabot rebase` required.
 on:
   push:
     branches: [dev]
+  schedule:
+    - cron: "*/30 * * * *"
+  workflow_dispatch:
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
## Summary
Add a `*/30 * * * *` schedule trigger (and `workflow_dispatch`) to the `Rebase stale Dependabot PRs` workflow.

## Why
The existing push-triggered workflow only fires when something pushes to `dev` — so it catches dependabot PRs that are *already open* at the moment dev advances. A PR opened **after** the merge, against a base SHA that's already stale, slips past it. That's exactly what happened with #151: opened 3.5 min after #148's merge, BEHIND from t=0, required a manual \`@dependabot rebase\` to unstick.

The 30-min cron is a belt-and-suspenders catch-all: regardless of how a dependabot PR landed in the BEHIND state, it gets rebased within at most 30 min.

## Test plan
- [ ] After merge, manually run via `workflow_dispatch` with no BEHIND PRs and confirm the loop is a no-op (exits 0, no comments posted).
- [ ] Wait for the next dependabot PR that lands BEHIND (or simulate by closing/reopening one) and confirm a `@dependabot rebase` comment is posted within 30 min without manual action.
- [ ] Confirm push trigger still works on the next merge to dev (overlap with cron is fine — duplicate `@dependabot rebase` comments are harmless, dependabot just rebases again).

🤖 Generated with [Claude Code](https://claude.com/claude-code)