### PR TITLE
ci: use DEPENDABOT_APPROVE_TOKEN for rebase comments

### DIFF
--- a/.github/workflows/dependabot-rebase-on-push.yml
+++ b/.github/workflows/dependabot-rebase-on-push.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Request rebase on stale dependabot PRs
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.DEPENDABOT_APPROVE_TOKEN }}
           REPO: ${{ github.repository }}
         run: |
           mapfile -t prs < <(

--- a/.github/workflows/dependabot-rebase-on-push.yml
+++ b/.github/workflows/dependabot-rebase-on-push.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Request rebase on stale dependabot PRs
         env:
+          # PAT, not GITHUB_TOKEN: comments by github-actions[bot] don't
+          # trigger dependabot's @-command handler.
           GH_TOKEN: ${{ secrets.DEPENDABOT_APPROVE_TOKEN }}
           REPO: ${{ github.repository }}
         run: |


### PR DESCRIPTION
The default GITHUB_TOKEN cannot trigger @dependabot rebase commands
because comments it creates do not invoke dependabot. Switch to the
PAT used for approving dependabot PRs, which has the required scope.

https://claude.ai/code/session_01WBeZrUUBRf6GRUv4YKnNPv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal GitHub workflow configuration for automated dependency management handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CatholicOS/ontokit-api/pull/161?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->