### PR TITLE
chore(pre-commit): run mypy in the uv venv via a local hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,29 +6,21 @@ repos:
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
 
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.15.0
+  # Run mypy inside the uv-managed project venv (same command/scope as CI's
+  # `uv run mypy ontokit/`) instead of mirrors-mypy. mirrors-mypy builds a
+  # separate isolated env and reinstalls the full dependency set —
+  # sentence-transformers pulls torch — which made cold runs take 20+ min and
+  # forced a hand-maintained `additional_dependencies` list that drifts from
+  # pyproject.toml. The system hook reuses already-installed deps: no env
+  # build, no parallel list, single source of truth. Strictness and target
+  # Python come from [tool.mypy] in pyproject.toml. See issue #179.
+  - repo: local
     hooks:
       - id: mypy
-        args: [--strict, --python-version=3.11]
-        additional_dependencies:
-          - alembic>=1.14.0
-          - fastapi>=0.115.0
-          - pydantic>=2.10.0
-          - pydantic-settings>=2.6.0
-          - sqlalchemy>=2.0.0
-          - rdflib>=7.1.0
-          - redis>=5.2.0
-          - arq>=0.26.0
-          - httpx>=0.28.0
-          - pyjwt>=2.12.0
-          - pygit2>=1.13.0
-          - gitpython>=3.1.0
-          - minio>=7.2.0
-          - slowapi>=0.1.9
-          - numpy>=2.4.4,<2.5  # cap <2.5: numpy 2.5 stubs use PEP 695 `type`, which mypy rejects under --python-version=3.11
-          - pgvector>=0.3.0
-          - sentence-transformers>=3.0.0
-          - cryptography>=42.0.0
-          - pytest>=8.0.0
-          - pytest-asyncio>=0.24.0
+        name: mypy (strict)
+        entry: uv run mypy ontokit/
+        language: system
+        types: [python]
+        files: ^ontokit/
+        pass_filenames: false
+        require_serial: true


### PR DESCRIPTION
## What

Replaces the `mirrors-mypy` pre-commit hook with a `repo: local` / `language: system` hook that runs `uv run mypy ontokit/` — the same command and scope as CI (`release.yml`) — reusing the uv-managed project venv.

```yaml
- repo: local
  hooks:
    - id: mypy
      name: mypy (strict)
      entry: uv run mypy ontokit/
      language: system
      types: [python]
      files: ^ontokit/
      pass_filenames: false
      require_serial: true
```

## Why

`mirrors-mypy` built a **separate isolated env** and reinstalled the full dependency set into it — `sentence-transformers` pulls **torch** — so a cold run took **20+ min** on WSL (a routine `git commit` looked hung). It also required a hand-maintained `additional_dependencies` list that drifts from `pyproject.toml` (it already carried a bespoke `numpy<2.5` mypy pin).

This hook reuses the already-installed venv: no env build, no parallel dependency list, single source of truth. Strictness and target Python come from `[tool.mypy]` in `pyproject.toml`, matching CI exactly.

## Measured

| | mirrors-mypy | local hook |
|---|---|---|
| Cold | 20+ min (torch install) | ~1m44 (one-time mypy cache build) |
| Warm | n/a | **~0.8s** |

## Notes / decisions

- **Scope:** like CI, this checks `ontokit/` only — **not** `tests/`. The old hook type-checked all staged Python (incl. tests), which is what surfaced #179. If we want tests covered, that should be a deliberate change to *both* this hook and CI.
- Requires `uv` locally (already the project's standard setup).

Closes #179

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development tooling configuration for improved code quality checks during development.

---

**Note:** This release contains internal development infrastructure updates with no end-user facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->