### PR TITLE
ci: add pyright (soft-gated) + fix the type issues it found (#134)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       - run: uv sync --group dev
       - run: uv run pyright ontokit/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,9 +19,9 @@ jobs:
       - run: uv run ruff format --check ontokit/
       - run: uv run mypy ontokit/
 
-  # Advisory only: pyright complements mypy but does NOT gate merges yet.
-  # continue-on-error surfaces its diagnostics in the logs without failing
-  # CI. Re-evaluate making it gating after a trial period (see issue #134).
+  # Soft gate: this job goes red on any pyright error (clear signal), but it is
+  # deliberately NOT in the dev ruleset's required checks, so it never hard-blocks
+  # merges. mypy remains the authoritative gate. See issue #134.
   pyright:
     runs-on: ubuntu-latest
     permissions:
@@ -31,7 +31,6 @@ jobs:
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       - run: uv sync --group dev
       - run: uv run pyright ontokit/
-        continue-on-error: true
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,20 @@ jobs:
       - run: uv run ruff format --check ontokit/
       - run: uv run mypy ontokit/
 
+  # Advisory only: pyright complements mypy but does NOT gate merges yet.
+  # continue-on-error surfaces its diagnostics in the logs without failing
+  # CI. Re-evaluate making it gating after a trial period (see issue #134).
+  pyright:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      - run: uv sync --group dev
+      - run: uv run pyright ontokit/
+        continue-on-error: true
+
   test:
     runs-on: ubuntu-latest
     permissions:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,11 +34,13 @@ uv run pyright ontokit/   # advisory — non-gating CI job + IDE
 
 **mypy is authoritative**: strict mode with the `pydantic.mypy` plugin, run in
 pre-commit and the `lint` CI job — it is the only type checker that gates merges.
-**pyright is advisory**: a `continue-on-error` CI job (issue #134) and the default
-IDE checker. It catches issues mypy misses (possibly-unbound vars, narrowing) but
-lacks mypy's plugin coverage (Pydantic field typing), so when they disagree, mypy
-wins until pyright is promoted to gating. Pyright only recognizes keyword
-defaults — prefer `Field(default=None)` over `Field(None)` in Pydantic schemas.
+**pyright is advisory (soft-gated)**: a CI job that goes red on any error but is
+**not** in the branch ruleset's required checks, so it surfaces problems without
+hard-blocking merges (issue #134); it is also the default IDE checker. It catches
+issues mypy misses (possibly-unbound vars, narrowing) but lacks mypy's plugin
+coverage (Pydantic field typing), so when they disagree, mypy wins. Pyright only
+recognizes keyword defaults — prefer `Field(default=None)` over `Field(None)` in
+Pydantic schemas. Keep the `ontokit/` pyright run clean (0 errors).
 
 ### Security Scanning
 
@@ -166,7 +168,8 @@ From pyproject.toml:
 - Line length: 100 characters
 - Ruff rules: E, W, F, I, B, C4, UP, ARG, SIM
 - MyPy: Strict mode enabled, Python 3.11 target — authoritative, gates CI
-- Pyright: standard mode, advisory only (non-gating CI + IDE); see Type Checking
+- Pyright: standard mode, advisory soft-gate (CI job red on error, non-blocking);
+  keep `ontokit/` at 0 errors. See Type Checking.
 
 ## Scripts
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,8 +28,17 @@ ruff format ontokit/          # Format code
 
 ### Type Checking
 ```bash
-mypy ontokit/
+mypy ontokit/             # authoritative — gates CI & pre-commit
+uv run pyright ontokit/   # advisory — non-gating CI job + IDE
 ```
+
+**mypy is authoritative**: strict mode with the `pydantic.mypy` plugin, run in
+pre-commit and the `lint` CI job — it is the only type checker that gates merges.
+**pyright is advisory**: a `continue-on-error` CI job (issue #134) and the default
+IDE checker. It catches issues mypy misses (possibly-unbound vars, narrowing) but
+lacks mypy's plugin coverage (Pydantic field typing), so when they disagree, mypy
+wins until pyright is promoted to gating. Pyright only recognizes keyword
+defaults — prefer `Field(default=None)` over `Field(None)` in Pydantic schemas.
 
 ### Security Scanning
 
@@ -156,7 +165,8 @@ Environment variables are configured in `.env` (see `.env.example`). Key section
 From pyproject.toml:
 - Line length: 100 characters
 - Ruff rules: E, W, F, I, B, C4, UP, ARG, SIM
-- MyPy: Strict mode enabled, Python 3.11 target
+- MyPy: Strict mode enabled, Python 3.11 target — authoritative, gates CI
+- Pyright: standard mode, advisory only (non-gating CI + IDE); see Type Checking
 
 ## Scripts
 

--- a/ontokit/git/bare_repository.py
+++ b/ontokit/git/bare_repository.py
@@ -704,9 +704,9 @@ class BareOntologyRepository:
             # Merge conflicts
             conflict_paths = list(
                 {
-                    entry[0].path if entry[0] else entry[1].path if entry[1] else entry[2].path
+                    str(index_entry.path)
                     for entry in merge_index.conflicts
-                    if any(entry)
+                    if (index_entry := entry[0] or entry[1] or entry[2]) is not None
                 }
             )
             return MergeResult(

--- a/ontokit/services/embedding_providers/local_provider.py
+++ b/ontokit/services/embedding_providers/local_provider.py
@@ -30,7 +30,12 @@ class LocalEmbeddingProvider(EmbeddingProvider):
     def dimensions(self) -> int:
         if self._dims is None:
             model = _get_model(self._model_name)
-            self._dims = model.get_sentence_embedding_dimension()  # type: ignore[attr-defined]
+            dims = model.get_sentence_embedding_dimension()  # type: ignore[attr-defined]
+            if dims is None:
+                raise RuntimeError(
+                    f"Model '{self._model_name}' did not report an embedding dimension"
+                )
+            self._dims = int(dims)
         return self._dims
 
     @property

--- a/ontokit/services/project_service.py
+++ b/ontokit/services/project_service.py
@@ -35,6 +35,7 @@ from ontokit.schemas.project import (
     TransferOwnership,
 )
 from ontokit.services.ontology_extractor import (
+    NormalizationReport,
     OntologyMetadataExtractor,
     OntologyMetadataUpdater,
     OntologyParseError,
@@ -125,6 +126,7 @@ class ProjectService:
         # Skip canonical bnode IDs on import for speed - can be applied later via
         # the normalization feature if desired
         normalization_report_json: str | None = None
+        normalization_report: NormalizationReport | None = None
         try:
             normalized_content, normalization_report = extractor.normalize_to_turtle(
                 file_content, filename, use_canonical=False
@@ -208,12 +210,12 @@ class ProjectService:
             logger.warning(f"Failed to initialize git repository for project {db_project.id}: {e}")
 
         # Record normalization run for history tracking
-        if normalization_report_json is not None:
+        if normalization_report is not None:
             run = NormalizationRun(
                 project_id=db_project.id,
                 triggered_by=owner.id,
                 trigger_type="import",
-                report_json=normalization_report_json,
+                report_json=json.dumps(normalization_report.to_dict()),
                 original_format=normalization_report.original_format,
                 original_size_bytes=normalization_report.original_size_bytes,
                 normalized_size_bytes=normalization_report.normalized_size_bytes,
@@ -290,6 +292,7 @@ class ProjectService:
 
         # Normalize to Turtle
         normalization_report_json: str | None = None
+        normalization_report: NormalizationReport | None = None
         try:
             normalized_content, normalization_report = extractor.normalize_to_turtle(
                 file_content, filename, use_canonical=False
@@ -414,12 +417,12 @@ class ProjectService:
                 )
 
         # Record normalization run for history tracking
-        if normalization_report_json is not None:
+        if normalization_report is not None:
             run = NormalizationRun(
                 project_id=db_project.id,
                 triggered_by=owner.id,
                 trigger_type="import",
-                report_json=normalization_report_json,
+                report_json=json.dumps(normalization_report.to_dict()),
                 original_format=normalization_report.original_format,
                 original_size_bytes=normalization_report.original_size_bytes,
                 normalized_size_bytes=normalization_report.normalized_size_bytes,
@@ -457,11 +460,17 @@ class ProjectService:
         opts = [selectinload(Project.members), selectinload(Project.github_integration)]
         query = select(Project).options(*opts)
 
+        # Subquery of project IDs the user is a member of. For anonymous users
+        # the predicate matches nothing and is never used in the branches below,
+        # but computing it unconditionally keeps it always bound.
+        subquery = select(ProjectMember.project_id).where(
+            ProjectMember.user_id == (user.id if user is not None else None)
+        )
+
         # Build access-control clause (all projects the user can see)
         if user is None:
             access_clause = Project.is_public == True  # noqa: E712
         else:
-            subquery = select(ProjectMember.project_id).where(ProjectMember.user_id == user.id)
             access_clause = or_(
                 Project.is_public == True,  # noqa: E712
                 Project.id.in_(subquery),

--- a/ontokit/services/search.py
+++ b/ontokit/services/search.py
@@ -218,7 +218,7 @@ class SearchService:
         }
         try:
             parsed = parseQuery(query_text)
-            query_type = _SPARQL_TYPE_MAP.get(parsed[1].name, "SELECT")
+            query_type = _SPARQL_TYPE_MAP.get(getattr(parsed[1], "name", ""), "SELECT")
         except Exception as exc:
             logger.warning("SPARQL query parse failed: %s", exc)
             raise ValueError(f"Invalid SPARQL query: {exc}") from exc

--- a/ontokit/worker.py
+++ b/ontokit/worker.py
@@ -1042,8 +1042,10 @@ async def run_remote_check_task(
 
     project_uuid = UUID(project_id)
 
+    # Imported before the try so they stay bound in the except handler below.
+    from ontokit.models.remote_sync import RemoteSyncConfig, SyncEvent
+
     try:
-        from ontokit.models.remote_sync import RemoteSyncConfig, SyncEvent
         from ontokit.services.github_service import get_github_service
 
         # Get sync config

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ dev = [
     "ruff>=0.15.18",
     "mypy>=2.1.0",
     "pre-commit>=4.6.0",
+    "pyright>=1.1.410",
 ]
 
 [project.urls]
@@ -103,6 +104,19 @@ known-first-party = ["ontokit"]
 venvPath = "."
 venv = ".venv"
 pythonVersion = "3.11"
+# Pyright is an advisory (non-gating) checker; mypy (strict, with the pydantic
+# plugin) remains the authoritative gate. Keep pyright at "standard" rather than
+# "strict" — strict-on-strict is redundant noise. The opinionated rules
+# (reportImplicitOverride, reportMissingTypeStubs, reportPrivateUsage) stay at
+# their standard-mode defaults (off). See issue #134.
+typeCheckingMode = "standard"
+include = ["ontokit", "tests"]
+
+# Test fixtures intentionally carry unused symbols (fixture-symmetry params like
+# mock_db, placeholder _args/_kwargs), so don't flag unused variables in tests.
+[[tool.pyright.executionEnvironments]]
+root = "tests"
+reportUnusedVariable = false
 
 [tool.mypy]
 python_version = "3.11"

--- a/tests/unit/test_local_provider.py
+++ b/tests/unit/test_local_provider.py
@@ -1,0 +1,45 @@
+"""Unit tests for LocalEmbeddingProvider.dimensions."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ontokit.services.embedding_providers.local_provider import LocalEmbeddingProvider
+
+
+@patch("ontokit.services.embedding_providers.local_provider._get_model")
+def test_dimensions_returns_model_dimension(mock_get_model: MagicMock) -> None:
+    """dimensions reports the model's embedding dimension."""
+    model = MagicMock()
+    model.get_sentence_embedding_dimension.return_value = 384
+    mock_get_model.return_value = model
+
+    provider = LocalEmbeddingProvider("some-model")
+    assert provider.dimensions == 384
+
+
+@patch("ontokit.services.embedding_providers.local_provider._get_model")
+def test_dimensions_is_cached(mock_get_model: MagicMock) -> None:
+    """dimensions is computed once and cached on subsequent access."""
+    model = MagicMock()
+    model.get_sentence_embedding_dimension.return_value = 384
+    mock_get_model.return_value = model
+
+    provider = LocalEmbeddingProvider("some-model")
+    assert provider.dimensions == 384
+    assert provider.dimensions == 384
+    mock_get_model.assert_called_once()
+
+
+@patch("ontokit.services.embedding_providers.local_provider._get_model")
+def test_dimensions_raises_when_model_reports_none(mock_get_model: MagicMock) -> None:
+    """A model that reports no embedding dimension raises rather than returning None."""
+    model = MagicMock()
+    model.get_sentence_embedding_dimension.return_value = None
+    mock_get_model.return_value = model
+
+    provider = LocalEmbeddingProvider("some-model")
+    with pytest.raises(RuntimeError, match="did not report an embedding dimension"):
+        _ = provider.dimensions

--- a/tests/unit/test_project_service.py
+++ b/tests/unit/test_project_service.py
@@ -12,6 +12,7 @@ from fastapi import HTTPException
 
 from ontokit.core.auth import CurrentUser
 from ontokit.schemas.project import MemberCreate, ProjectCreate, ProjectUpdate, TransferOwnership
+from ontokit.services.ontology_extractor import OntologyMetadataExtractor, OntologyParseError
 from ontokit.services.project_service import ProjectService, get_project_service
 
 PROJECT_ID = uuid.UUID("12345678-1234-5678-1234-567812345678")
@@ -987,6 +988,37 @@ class TestCreateFromImport:
         mock_db.commit.assert_awaited()
 
     @pytest.mark.asyncio
+    async def test_import_normalization_failure_skips_run(
+        self, service: ProjectService, mock_db: AsyncMock
+    ) -> None:
+        """If normalization fails after metadata extraction, import still
+        succeeds and no NormalizationRun is recorded."""
+        owner = _make_user()
+        storage = AsyncMock()
+        storage.upload_file = AsyncMock(return_value="projects/xyz/ontology.ttl")
+        turtle_content = (
+            b"@prefix owl: <http://www.w3.org/2002/07/owl#> .\n<http://ex.org/ont> a owl:Ontology ."
+        )
+        mock_db.refresh.side_effect = _make_simulate_refresh(owner.id, extended=True)
+
+        with patch.object(
+            OntologyMetadataExtractor,
+            "normalize_to_turtle",
+            side_effect=OntologyParseError("normalization boom"),
+        ):
+            result = await service.create_from_import(
+                file_content=turtle_content,
+                filename="test.ttl",
+                is_public=True,
+                owner=owner,
+                storage=storage,
+            )
+
+        assert result.name is not None
+        added = [type(c.args[0]).__name__ for c in mock_db.add.call_args_list]
+        assert "NormalizationRun" not in added
+
+    @pytest.mark.asyncio
     async def test_import_unsupported_format(
         self,
         service: ProjectService,
@@ -1116,6 +1148,43 @@ class TestCreateFromGithub:
         # 3 adds: project, owner member, github integration
         # 4 adds: project, owner member, github integration, normalization run
         assert mock_db.add.call_count == 4
+
+    @pytest.mark.asyncio
+    async def test_github_import_normalization_failure_skips_run(
+        self, service: ProjectService, mock_db: AsyncMock, mock_git_service: MagicMock
+    ) -> None:
+        """If normalization fails, GitHub import still succeeds without a
+        NormalizationRun (project, owner member, github integration only)."""
+        owner = _make_user()
+        storage = AsyncMock()
+        storage.upload_file = AsyncMock(return_value="projects/xyz/ontology.ttl")
+        mock_git_service.clone_from_github = MagicMock()
+        mock_git_service.commit_changes = MagicMock(return_value=MagicMock(hash="def456"))
+        turtle_content = (
+            b"@prefix owl: <http://www.w3.org/2002/07/owl#> .\n<http://ex.org/ont> a owl:Ontology ."
+        )
+        mock_db.refresh.side_effect = _make_simulate_refresh(owner.id, extended=True)
+
+        with patch.object(
+            OntologyMetadataExtractor,
+            "normalize_to_turtle",
+            side_effect=OntologyParseError("normalization boom"),
+        ):
+            result = await service.create_from_github(
+                file_content=turtle_content,
+                filename="ontology.ttl",
+                repo_owner="testorg",
+                repo_name="testrepo",
+                ontology_file_path="src/ontology.ttl",
+                default_branch="main",
+                is_public=True,
+                owner=owner,
+                storage=storage,
+                github_token="test-token",
+            )
+
+        assert result.name is not None
+        assert mock_db.add.call_count == 3
 
     @pytest.mark.asyncio
     async def test_github_import_clone_failure_falls_back(

--- a/uv.lock
+++ b/uv.lock
@@ -1631,6 +1631,7 @@ dev = [
     { name = "httpx" },
     { name = "mypy" },
     { name = "pre-commit" },
+    { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -1670,6 +1671,7 @@ dev = [
     { name = "httpx", specifier = ">=0.28.0" },
     { name = "mypy", specifier = ">=2.1.0" },
     { name = "pre-commit", specifier = ">=4.6.0" },
+    { name = "pyright", specifier = ">=1.1.410" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "pytest-asyncio", specifier = ">=1.4.0" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
@@ -2077,6 +2079,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "pyright"
+version = "1.1.410"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/10/53/e4d8ea1391bd4355231be6f91bf239479aa0014260ed3fb5526eeb12a1f2/pyright-1.1.410.tar.gz", hash = "sha256:07a073b8ba6749826773c1269773efa11b93440d9a6aa60419d9a3172d6dc488", size = 4062013, upload-time = "2026-06-01T17:35:48.894Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/33/288b5868fa00846dacf249633719d747893e54aebd196b9968ac1878a5d3/pyright-1.1.410-py3-none-any.whl", hash = "sha256:5e961bed37cacf96b3f7cd7b1da39b350a9239aa2e69138d0e88f728cfaf296c", size = 6082448, upload-time = "2026-06-01T17:35:46.387Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #134 (Phase 1).

## What

Introduces **pyright as a complement to mypy, non-gating**, per the issue's Phase 1 plan.

- `pyright>=1.1.410` added to `[dependency-groups].dev`.
- New `pyright` CI job in `release.yml`: `uv run pyright ontokit/` with `continue-on-error: true` — runs in parallel with `lint`, surfaces diagnostics in logs, **never blocks merges**.
- `[tool.pyright]` tuned:
  - `typeCheckingMode = "standard"` (strict pyright + strict mypy is redundant noise).
  - `include = ["ontokit", "tests"]`.
  - `reportUnusedVariable = false` for `tests/` (fixture-symmetry params like `mock_db`, placeholder `_args`/`_kwargs`) — the exact noise the issue called out. Verified suppressed.
  - Opinionated rules (`reportImplicitOverride`, `reportMissingTypeStubs`, `reportPrivateUsage`) left at standard defaults (off).
- **Authority documented** in CLAUDE.md/AGENTS.md: mypy is authoritative (gating, pydantic plugin); pyright is advisory.

## Acceptance criteria

- [x] `pyright` in `[dependency-groups].dev`
- [x] CI runs `uv run pyright ontokit/` with `continue-on-error: true`
- [x] `[tool.pyright]` tuned to suppress fixture-symmetry/placeholder noise
- [x] Decision documented on which checker is authoritative

## First-run signal (seeds Phase 2)

25 errors on `ontokit/`, **0 unused-var noise** (that noise is test-only; CI checks `ontokit/`). Breakdown:

| Rule | Count | Notes |
|------|------:|-------|
| reportPossiblyUnboundVariable | 19 | 14 in `project_service.py` are a **confirmed false positive** — `normalization_report` is bound iff `normalization_report_json is not None` (the line-211 guard), but pyright tracks the two vars independently. Remaining 5 (`worker.py` conditional imports, `subquery`) need a look. |
| reportArgumentType | 2 | `bare_repository.py`, `search.py` |
| reportReturnType / reportOptionalMemberAccess / reportCallIssue / reportAttributeAccessIssue | 1 each | `local_provider.py`, `bare_repository.py`, `search.py` |

These are **left unfixed by design** — Phase 1 only adds the tooling. Phase 2 (follow-up) evaluates whether to fix, keep advisory, or promote to gating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a standalone Pyright job to the CI workflow as an advisory “soft gate” alongside existing checks.

* **Bug Fixes**
  * Improved handling when embedding models report missing dimensions.
  * Safer SPARQL operation-type detection.
  * More robust project normalization/report recording and access filtering.
  * More reliable merge-conflict path selection.

* **Tests**
  * Added unit tests for embedding dimension caching/validation and ontology import normalization failure handling.

* **Documentation**
  * Expanded type-checking guidance to cover Pyright usage alongside mypy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->